### PR TITLE
[Fix] fcm 알림 전송 예외 오류 해결

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/util/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fcm/repository/FcmTokenRepository.java
@@ -10,6 +10,8 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
     boolean existsByToken(String token);
 
+    boolean existsByTokenAndUserId(String token, Long userId);
+
     Optional<FcmToken> findByToken(String token);
 
     List<FcmToken> findAllByUserId(Long userId);


### PR DESCRIPTION
## ✔️ 연관 이슈

## 📝 작업 내용

- 하나의 기기에서 여러 계정의 알림이 올 수 있도록 개선
- 알림 전송에 실패할 경우, 나머지 알림도 보내지지 않는 문제 해결

### 스크린샷 (선택)
