### PR TITLE
[Feat] 관리자 페이지 지표 추가 및 성능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ monitoring/README.md
 
 ### macOS
 .DS_Store
+
+### Local agent guidance
+/AGENTS.md

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -71,6 +72,7 @@ public class AdminAnalysisController {
         long periodActiveUserCount = dailyActiveUsers.values().stream()
                 .mapToLong(Long::longValue)
                 .sum();
+        long periodUniqueVisitorCount = missionLogService.countUniqueVisitors(selectedStartDate, selectedEndDate);
         long periodPracticeNoteCount = dailyPracticeNotes.values().stream()
                 .mapToLong(Long::longValue)
                 .sum();
@@ -78,11 +80,10 @@ public class AdminAnalysisController {
                 .mapToLong(Long::longValue)
                 .sum();
 
-        // 하루 평균 방문자 수 (선택 기간)
-        double averageDailyVisitors = dailyActiveUsers.values().stream()
-                .mapToLong(Long::longValue)
-                .average()
-                .orElse(0.0);
+        long selectedDays = ChronoUnit.DAYS.between(selectedStartDate, selectedEndDate) + 1;
+        double averageDailyVisitors = selectedDays > 0
+                ? (double) periodActiveUserCount / selectedDays
+                : 0.0;
 
         model.addAttribute("allUserCount", allUserCount);
         model.addAttribute("allProblemCount", allProblemCount);
@@ -96,6 +97,7 @@ public class AdminAnalysisController {
         model.addAttribute("recentNewUsersCount", recentNewUsersCount);
         model.addAttribute("periodVisitCount", periodVisitCount);
         model.addAttribute("periodActiveUserCount", periodActiveUserCount);
+        model.addAttribute("periodUniqueVisitorCount", periodUniqueVisitorCount);
         model.addAttribute("periodPracticeNoteCount", periodPracticeNoteCount);
         model.addAttribute("periodPracticeLogCount", periodPracticeLogCount);
         model.addAttribute("averageDailyVisitors", averageDailyVisitors);

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.admin.controller;
 
 import com.aisip.OnO.backend.mission.service.MissionLogService;
 import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
+import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
 import com.aisip.OnO.backend.problem.service.ProblemService;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.entity.User;
@@ -44,6 +45,8 @@ public class AdminAnalysisController {
         long allProblemCount = problemService.countAllProblems();
         long allPracticeNoteCount = practiceNoteService.countAllPracticeNotes();
         long allPracticeLogCount = missionLogService.countNotePracticeLogs();
+        long allProblemAnalysisCount = problemService.countAllProblemAnalyses();
+        Map<AnalysisStatus, Long> allAnalysisStatusCounts = problemService.countProblemAnalysesByStatus();
 
         LocalDate today = LocalDate.now();
         LocalDate selectedStartDate = startDate != null ? startDate : today.minusDays(29);
@@ -61,6 +64,8 @@ public class AdminAnalysisController {
         Map<LocalDate, Long> dailyNewUsers = userService.getDailyNewUsersCount(selectedStartDate, selectedEndDate);
         Map<LocalDate, Long> dailyPracticeNotes = practiceNoteService.getDailyPracticeNotesCount(selectedStartDate, selectedEndDate);
         Map<LocalDate, Long> dailyPracticeLogs = missionLogService.getDailyNotePracticeLogsCount(selectedStartDate, selectedEndDate);
+        Map<LocalDate, Long> dailyProblems = problemService.getDailyProblemsCount(selectedStartDate, selectedEndDate);
+        Map<AnalysisStatus, Long> periodAnalysisStatusCounts = problemService.countProblemAnalysesByStatus(selectedStartDate, selectedEndDate);
 
         // 선택 기간 신규 가입자 총합
         long recentNewUsersCount = dailyNewUsers.values().stream()
@@ -79,6 +84,18 @@ public class AdminAnalysisController {
         long periodPracticeLogCount = dailyPracticeLogs.values().stream()
                 .mapToLong(Long::longValue)
                 .sum();
+        long periodProblemCount = dailyProblems.values().stream()
+                .mapToLong(Long::longValue)
+                .sum();
+        long periodCompletedAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.COMPLETED, 0L);
+        long periodFailedAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.FAILED, 0L);
+        long periodProcessingAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.PROCESSING, 0L);
+        long periodNotStartedAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.NOT_STARTED, 0L);
+        long periodNoImageAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.NO_IMAGE, 0L);
+        long periodFinishedAnalysisCount = periodCompletedAnalysisCount + periodFailedAnalysisCount;
+        double periodAnalysisFailureRate = periodFinishedAnalysisCount == 0
+                ? 0.0
+                : (double) periodFailedAnalysisCount * 100 / periodFinishedAnalysisCount;
 
         long selectedDays = ChronoUnit.DAYS.between(selectedStartDate, selectedEndDate) + 1;
         double averageDailyVisitors = selectedDays > 0
@@ -89,17 +106,31 @@ public class AdminAnalysisController {
         model.addAttribute("allProblemCount", allProblemCount);
         model.addAttribute("allPracticeNoteCount", allPracticeNoteCount);
         model.addAttribute("allPracticeLogCount", allPracticeLogCount);
+        model.addAttribute("allProblemAnalysisCount", allProblemAnalysisCount);
+        model.addAttribute("allCompletedAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.COMPLETED, 0L));
+        model.addAttribute("allFailedAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.FAILED, 0L));
+        model.addAttribute("allProcessingAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.PROCESSING, 0L));
+        model.addAttribute("allNotStartedAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.NOT_STARTED, 0L));
+        model.addAttribute("allNoImageAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.NO_IMAGE, 0L));
         model.addAttribute("dailyActiveUsers", dailyActiveUsers);
         model.addAttribute("dailyVisits", dailyVisits);
         model.addAttribute("dailyNewUsers", dailyNewUsers);
         model.addAttribute("dailyPracticeNotes", dailyPracticeNotes);
         model.addAttribute("dailyPracticeLogs", dailyPracticeLogs);
+        model.addAttribute("dailyProblems", dailyProblems);
         model.addAttribute("recentNewUsersCount", recentNewUsersCount);
         model.addAttribute("periodVisitCount", periodVisitCount);
         model.addAttribute("periodActiveUserCount", periodActiveUserCount);
         model.addAttribute("periodUniqueVisitorCount", periodUniqueVisitorCount);
         model.addAttribute("periodPracticeNoteCount", periodPracticeNoteCount);
         model.addAttribute("periodPracticeLogCount", periodPracticeLogCount);
+        model.addAttribute("periodProblemCount", periodProblemCount);
+        model.addAttribute("periodCompletedAnalysisCount", periodCompletedAnalysisCount);
+        model.addAttribute("periodFailedAnalysisCount", periodFailedAnalysisCount);
+        model.addAttribute("periodProcessingAnalysisCount", periodProcessingAnalysisCount);
+        model.addAttribute("periodNotStartedAnalysisCount", periodNotStartedAnalysisCount);
+        model.addAttribute("periodNoImageAnalysisCount", periodNoImageAnalysisCount);
+        model.addAttribute("periodAnalysisFailureRate", periodAnalysisFailureRate);
         model.addAttribute("averageDailyVisitors", averageDailyVisitors);
         model.addAttribute("startDate", selectedStartDate);
         model.addAttribute("endDate", selectedEndDate);

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
@@ -30,20 +30,36 @@ public class AdminAnalysisController {
     private final MissionLogService missionLogService;
 
     @GetMapping("/analysis")
-    public String getAllAnalysis(Model model) {
+    public String getAllAnalysis(
+            @RequestParam(name = "startDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(name = "endDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            Model model
+    ) {
         int allUserCount = userService.findAllUsers().size();
         int allProblemCount = problemService.findAllProblems().size();
 
-        // 최근 30일간 날짜별 출석 유저 수 및 신규 가입자 수
-        Map<LocalDate, Long> dailyActiveUsers = missionLogService.getDailyActiveUsersCount(30);
-        Map<LocalDate, Long> dailyNewUsers = userService.getDailyNewUsersCount(30);
+        LocalDate today = LocalDate.now();
+        LocalDate selectedStartDate = startDate != null ? startDate : today.minusDays(29);
+        LocalDate selectedEndDate = endDate != null ? endDate : today;
 
-        // 최근 30일 신규 가입자 총합
+        if (selectedStartDate.isAfter(selectedEndDate)) {
+            LocalDate temp = selectedStartDate;
+            selectedStartDate = selectedEndDate;
+            selectedEndDate = temp;
+        }
+
+        // 선택 기간 날짜별 출석 유저 수 및 신규 가입자 수
+        Map<LocalDate, Long> dailyActiveUsers = missionLogService.getDailyActiveUsersCount(selectedStartDate, selectedEndDate);
+        Map<LocalDate, Long> dailyNewUsers = userService.getDailyNewUsersCount(selectedStartDate, selectedEndDate);
+
+        // 선택 기간 신규 가입자 총합
         long recentNewUsersCount = dailyNewUsers.values().stream()
                 .mapToLong(Long::longValue)
                 .sum();
 
-        // 하루 평균 방문자 수 (최근 30일)
+        // 하루 평균 방문자 수 (선택 기간)
         double averageDailyVisitors = dailyActiveUsers.values().stream()
                 .mapToLong(Long::longValue)
                 .average()
@@ -55,6 +71,8 @@ public class AdminAnalysisController {
         model.addAttribute("dailyNewUsers", dailyNewUsers);
         model.addAttribute("recentNewUsersCount", recentNewUsersCount);
         model.addAttribute("averageDailyVisitors", averageDailyVisitors);
+        model.addAttribute("startDate", selectedStartDate);
+        model.addAttribute("endDate", selectedEndDate);
 
         return "analysis";
     }

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
@@ -56,12 +56,19 @@ public class AdminAnalysisController {
 
         // 선택 기간 날짜별 출석 유저 수 및 신규 가입자 수
         Map<LocalDate, Long> dailyActiveUsers = missionLogService.getDailyActiveUsersCount(selectedStartDate, selectedEndDate);
+        Map<LocalDate, Long> dailyVisits = missionLogService.getDailyVisitCount(selectedStartDate, selectedEndDate);
         Map<LocalDate, Long> dailyNewUsers = userService.getDailyNewUsersCount(selectedStartDate, selectedEndDate);
         Map<LocalDate, Long> dailyPracticeNotes = practiceNoteService.getDailyPracticeNotesCount(selectedStartDate, selectedEndDate);
         Map<LocalDate, Long> dailyPracticeLogs = missionLogService.getDailyNotePracticeLogsCount(selectedStartDate, selectedEndDate);
 
         // 선택 기간 신규 가입자 총합
         long recentNewUsersCount = dailyNewUsers.values().stream()
+                .mapToLong(Long::longValue)
+                .sum();
+        long periodVisitCount = dailyVisits.values().stream()
+                .mapToLong(Long::longValue)
+                .sum();
+        long periodActiveUserCount = dailyActiveUsers.values().stream()
                 .mapToLong(Long::longValue)
                 .sum();
         long periodPracticeNoteCount = dailyPracticeNotes.values().stream()
@@ -82,10 +89,13 @@ public class AdminAnalysisController {
         model.addAttribute("allPracticeNoteCount", allPracticeNoteCount);
         model.addAttribute("allPracticeLogCount", allPracticeLogCount);
         model.addAttribute("dailyActiveUsers", dailyActiveUsers);
+        model.addAttribute("dailyVisits", dailyVisits);
         model.addAttribute("dailyNewUsers", dailyNewUsers);
         model.addAttribute("dailyPracticeNotes", dailyPracticeNotes);
         model.addAttribute("dailyPracticeLogs", dailyPracticeLogs);
         model.addAttribute("recentNewUsersCount", recentNewUsersCount);
+        model.addAttribute("periodVisitCount", periodVisitCount);
+        model.addAttribute("periodActiveUserCount", periodActiveUserCount);
         model.addAttribute("periodPracticeNoteCount", periodPracticeNoteCount);
         model.addAttribute("periodPracticeLogCount", periodPracticeLogCount);
         model.addAttribute("averageDailyVisitors", averageDailyVisitors);

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.admin.controller;
 
 import com.aisip.OnO.backend.mission.service.MissionLogService;
+import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
 import com.aisip.OnO.backend.problem.service.ProblemService;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.entity.User;
@@ -28,6 +29,7 @@ public class AdminAnalysisController {
     private final UserService userService;
     private final ProblemService problemService;
     private final MissionLogService missionLogService;
+    private final PracticeNoteService practiceNoteService;
 
     @GetMapping("/analysis")
     public String getAllAnalysis(
@@ -37,8 +39,10 @@ public class AdminAnalysisController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             Model model
     ) {
-        int allUserCount = userService.findAllUsers().size();
-        int allProblemCount = problemService.findAllProblems().size();
+        long allUserCount = userService.countAllUsers();
+        long allProblemCount = problemService.countAllProblems();
+        long allPracticeNoteCount = practiceNoteService.countAllPracticeNotes();
+        long allPracticeLogCount = missionLogService.countNotePracticeLogs();
 
         LocalDate today = LocalDate.now();
         LocalDate selectedStartDate = startDate != null ? startDate : today.minusDays(29);
@@ -53,9 +57,17 @@ public class AdminAnalysisController {
         // 선택 기간 날짜별 출석 유저 수 및 신규 가입자 수
         Map<LocalDate, Long> dailyActiveUsers = missionLogService.getDailyActiveUsersCount(selectedStartDate, selectedEndDate);
         Map<LocalDate, Long> dailyNewUsers = userService.getDailyNewUsersCount(selectedStartDate, selectedEndDate);
+        Map<LocalDate, Long> dailyPracticeNotes = practiceNoteService.getDailyPracticeNotesCount(selectedStartDate, selectedEndDate);
+        Map<LocalDate, Long> dailyPracticeLogs = missionLogService.getDailyNotePracticeLogsCount(selectedStartDate, selectedEndDate);
 
         // 선택 기간 신규 가입자 총합
         long recentNewUsersCount = dailyNewUsers.values().stream()
+                .mapToLong(Long::longValue)
+                .sum();
+        long periodPracticeNoteCount = dailyPracticeNotes.values().stream()
+                .mapToLong(Long::longValue)
+                .sum();
+        long periodPracticeLogCount = dailyPracticeLogs.values().stream()
                 .mapToLong(Long::longValue)
                 .sum();
 
@@ -67,9 +79,15 @@ public class AdminAnalysisController {
 
         model.addAttribute("allUserCount", allUserCount);
         model.addAttribute("allProblemCount", allProblemCount);
+        model.addAttribute("allPracticeNoteCount", allPracticeNoteCount);
+        model.addAttribute("allPracticeLogCount", allPracticeLogCount);
         model.addAttribute("dailyActiveUsers", dailyActiveUsers);
         model.addAttribute("dailyNewUsers", dailyNewUsers);
+        model.addAttribute("dailyPracticeNotes", dailyPracticeNotes);
+        model.addAttribute("dailyPracticeLogs", dailyPracticeLogs);
         model.addAttribute("recentNewUsersCount", recentNewUsersCount);
+        model.addAttribute("periodPracticeNoteCount", periodPracticeNoteCount);
+        model.addAttribute("periodPracticeLogCount", periodPracticeLogCount);
         model.addAttribute("averageDailyVisitors", averageDailyVisitors);
         model.addAttribute("startDate", selectedStartDate);
         model.addAttribute("endDate", selectedEndDate);

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
@@ -91,6 +91,10 @@ public class AdminAnalysisController {
         model.addAttribute("averageDailyVisitors", averageDailyVisitors);
         model.addAttribute("startDate", selectedStartDate);
         model.addAttribute("endDate", selectedEndDate);
+        model.addAttribute("quickStart7Days", today.minusDays(6));
+        model.addAttribute("quickStart30Days", today.minusDays(29));
+        model.addAttribute("quickStart90Days", today.minusDays(89));
+        model.addAttribute("today", today);
 
         return "analysis";
     }

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminPracticeNoteController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminPracticeNoteController.java
@@ -25,41 +25,54 @@ public class AdminPracticeNoteController {
     @GetMapping("/practice-notes")
     public String getPracticeNotes(
             @RequestParam(defaultValue = "0", name = "notePage") int notePage,
-            @RequestParam(defaultValue = "0", name = "logPage") int logPage,
             @RequestParam(defaultValue = "20", name = "size") int size,
             Model model
     ) {
         int selectedNotePage = Math.max(notePage, 0);
-        int selectedLogPage = Math.max(logPage, 0);
         int selectedSize = Math.max(size, 1);
 
         Page<AdminPracticeNoteResponseDto> practiceNotes = practiceNoteService.findAdminPracticeNotes(selectedNotePage, selectedSize);
-        Page<AdminPracticeLogResponseDto> practiceLogs = missionLogService.findAdminPracticeLogs(selectedLogPage, selectedSize);
         int noteTotalPages = practiceNotes.getTotalPages();
-        int logTotalPages = practiceLogs.getTotalPages();
         int notePageBlockStart = (selectedNotePage / 10) * 10;
-        int logPageBlockStart = (selectedLogPage / 10) * 10;
         int notePageBlockEnd = Math.min(notePageBlockStart + 9, Math.max(noteTotalPages - 1, 0));
-        int logPageBlockEnd = Math.min(logPageBlockStart + 9, Math.max(logTotalPages - 1, 0));
 
         model.addAttribute("practiceNotes", practiceNotes.getContent());
-        model.addAttribute("practiceLogs", practiceLogs.getContent());
         model.addAttribute("notePage", selectedNotePage);
-        model.addAttribute("logPage", selectedLogPage);
         model.addAttribute("noteTotalPages", noteTotalPages);
-        model.addAttribute("logTotalPages", logTotalPages);
         model.addAttribute("notePageBlockStart", notePageBlockStart);
         model.addAttribute("notePageBlockEnd", notePageBlockEnd);
-        model.addAttribute("logPageBlockStart", logPageBlockStart);
-        model.addAttribute("logPageBlockEnd", logPageBlockEnd);
         model.addAttribute("hasPreviousNoteBlock", notePageBlockStart > 0);
         model.addAttribute("hasNextNoteBlock", notePageBlockEnd < noteTotalPages - 1);
-        model.addAttribute("hasPreviousLogBlock", logPageBlockStart > 0);
-        model.addAttribute("hasNextLogBlock", logPageBlockEnd < logTotalPages - 1);
         model.addAttribute("totalPracticeNotes", practiceNotes.getTotalElements());
-        model.addAttribute("totalPracticeLogs", practiceLogs.getTotalElements());
         model.addAttribute("size", selectedSize);
 
         return "practice-notes";
+    }
+
+    @GetMapping("/practice-logs")
+    public String getPracticeLogs(
+            @RequestParam(defaultValue = "0", name = "logPage") int logPage,
+            @RequestParam(defaultValue = "20", name = "size") int size,
+            Model model
+    ) {
+        int selectedLogPage = Math.max(logPage, 0);
+        int selectedSize = Math.max(size, 1);
+
+        Page<AdminPracticeLogResponseDto> practiceLogs = missionLogService.findAdminPracticeLogs(selectedLogPage, selectedSize);
+        int logTotalPages = practiceLogs.getTotalPages();
+        int logPageBlockStart = (selectedLogPage / 10) * 10;
+        int logPageBlockEnd = Math.min(logPageBlockStart + 9, Math.max(logTotalPages - 1, 0));
+
+        model.addAttribute("practiceLogs", practiceLogs.getContent());
+        model.addAttribute("logPage", selectedLogPage);
+        model.addAttribute("logTotalPages", logTotalPages);
+        model.addAttribute("logPageBlockStart", logPageBlockStart);
+        model.addAttribute("logPageBlockEnd", logPageBlockEnd);
+        model.addAttribute("hasPreviousLogBlock", logPageBlockStart > 0);
+        model.addAttribute("hasNextLogBlock", logPageBlockEnd < logTotalPages - 1);
+        model.addAttribute("totalPracticeLogs", practiceLogs.getTotalElements());
+        model.addAttribute("size", selectedSize);
+
+        return "practice-logs";
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminPracticeNoteController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminPracticeNoteController.java
@@ -35,13 +35,27 @@ public class AdminPracticeNoteController {
 
         Page<AdminPracticeNoteResponseDto> practiceNotes = practiceNoteService.findAdminPracticeNotes(selectedNotePage, selectedSize);
         Page<AdminPracticeLogResponseDto> practiceLogs = missionLogService.findAdminPracticeLogs(selectedLogPage, selectedSize);
+        int noteTotalPages = practiceNotes.getTotalPages();
+        int logTotalPages = practiceLogs.getTotalPages();
+        int notePageBlockStart = (selectedNotePage / 10) * 10;
+        int logPageBlockStart = (selectedLogPage / 10) * 10;
+        int notePageBlockEnd = Math.min(notePageBlockStart + 9, Math.max(noteTotalPages - 1, 0));
+        int logPageBlockEnd = Math.min(logPageBlockStart + 9, Math.max(logTotalPages - 1, 0));
 
         model.addAttribute("practiceNotes", practiceNotes.getContent());
         model.addAttribute("practiceLogs", practiceLogs.getContent());
         model.addAttribute("notePage", selectedNotePage);
         model.addAttribute("logPage", selectedLogPage);
-        model.addAttribute("noteTotalPages", practiceNotes.getTotalPages());
-        model.addAttribute("logTotalPages", practiceLogs.getTotalPages());
+        model.addAttribute("noteTotalPages", noteTotalPages);
+        model.addAttribute("logTotalPages", logTotalPages);
+        model.addAttribute("notePageBlockStart", notePageBlockStart);
+        model.addAttribute("notePageBlockEnd", notePageBlockEnd);
+        model.addAttribute("logPageBlockStart", logPageBlockStart);
+        model.addAttribute("logPageBlockEnd", logPageBlockEnd);
+        model.addAttribute("hasPreviousNoteBlock", notePageBlockStart > 0);
+        model.addAttribute("hasNextNoteBlock", notePageBlockEnd < noteTotalPages - 1);
+        model.addAttribute("hasPreviousLogBlock", logPageBlockStart > 0);
+        model.addAttribute("hasNextLogBlock", logPageBlockEnd < logTotalPages - 1);
         model.addAttribute("totalPracticeNotes", practiceNotes.getTotalElements());
         model.addAttribute("totalPracticeLogs", practiceLogs.getTotalElements());
         model.addAttribute("size", selectedSize);

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminPracticeNoteController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminPracticeNoteController.java
@@ -1,0 +1,51 @@
+package com.aisip.OnO.backend.admin.controller;
+
+import com.aisip.OnO.backend.admin.dto.AdminPracticeLogResponseDto;
+import com.aisip.OnO.backend.admin.dto.AdminPracticeNoteResponseDto;
+import com.aisip.OnO.backend.mission.service.MissionLogService;
+import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/admin")
+public class AdminPracticeNoteController {
+
+    private final PracticeNoteService practiceNoteService;
+    private final MissionLogService missionLogService;
+
+    @GetMapping("/practice-notes")
+    public String getPracticeNotes(
+            @RequestParam(defaultValue = "0", name = "notePage") int notePage,
+            @RequestParam(defaultValue = "0", name = "logPage") int logPage,
+            @RequestParam(defaultValue = "20", name = "size") int size,
+            Model model
+    ) {
+        int selectedNotePage = Math.max(notePage, 0);
+        int selectedLogPage = Math.max(logPage, 0);
+        int selectedSize = Math.max(size, 1);
+
+        Page<AdminPracticeNoteResponseDto> practiceNotes = practiceNoteService.findAdminPracticeNotes(selectedNotePage, selectedSize);
+        Page<AdminPracticeLogResponseDto> practiceLogs = missionLogService.findAdminPracticeLogs(selectedLogPage, selectedSize);
+
+        model.addAttribute("practiceNotes", practiceNotes.getContent());
+        model.addAttribute("practiceLogs", practiceLogs.getContent());
+        model.addAttribute("notePage", selectedNotePage);
+        model.addAttribute("logPage", selectedLogPage);
+        model.addAttribute("noteTotalPages", practiceNotes.getTotalPages());
+        model.addAttribute("logTotalPages", practiceLogs.getTotalPages());
+        model.addAttribute("totalPracticeNotes", practiceNotes.getTotalElements());
+        model.addAttribute("totalPracticeLogs", practiceLogs.getTotalElements());
+        model.addAttribute("size", selectedSize);
+
+        return "practice-notes";
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.admin.controller;
 
+import com.aisip.OnO.backend.admin.dto.AdminProblemResponseDto;
 import com.aisip.OnO.backend.folder.dto.FolderResponseDto;
 import com.aisip.OnO.backend.folder.entity.Folder;
 import com.aisip.OnO.backend.folder.service.FolderService;
@@ -9,14 +10,13 @@ import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,21 +34,24 @@ public class AdminProblemController {
             @RequestParam(defaultValue = "20", name = "size") int size,
             Model model
     ) {
-        List<ProblemResponseDto> allProblems = problemService.findAllProblems();
+        int selectedPage = Math.max(page, 0);
+        int selectedSize = Math.max(size, 1);
+        Page<AdminProblemResponseDto> problemPage = problemService.findAdminProblems(selectedPage, selectedSize);
+        int totalPages = problemPage.getTotalPages();
+        int pageBlockStart = (selectedPage / 10) * 10;
+        int pageBlockEnd = Math.min(pageBlockStart + 9, Math.max(totalPages - 1, 0));
 
-        // 페이징 계산
-        int totalProblems = allProblems.size();
-        int totalPages = (int) Math.ceil((double) totalProblems / size);
-        int startIndex = page * size;
-        int endIndex = Math.min(startIndex + size, totalProblems);
-
-        List<ProblemResponseDto> pagedProblems = allProblems.subList(startIndex, endIndex);
-
-        model.addAttribute("problems", pagedProblems);
-        model.addAttribute("currentPage", page);
+        model.addAttribute("problems", problemPage.getContent());
+        model.addAttribute("currentPage", selectedPage);
         model.addAttribute("totalPages", totalPages);
-        model.addAttribute("totalProblems", totalProblems);
-        model.addAttribute("size", size);
+        model.addAttribute("totalProblems", problemPage.getTotalElements());
+        model.addAttribute("size", selectedSize);
+        model.addAttribute("pageStartItem", problemPage.isEmpty() ? 0 : selectedPage * selectedSize + 1);
+        model.addAttribute("pageEndItem", selectedPage * selectedSize + problemPage.getNumberOfElements());
+        model.addAttribute("pageBlockStart", pageBlockStart);
+        model.addAttribute("pageBlockEnd", pageBlockEnd);
+        model.addAttribute("hasPreviousBlock", pageBlockStart > 0);
+        model.addAttribute("hasNextBlock", pageBlockEnd < totalPages - 1);
 
         return "problems";
     }

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
@@ -43,6 +43,13 @@ public class AdminProblemController {
         int selectedSize = Math.max(size, 1);
         Page<AdminProblemResponseDto> problemPage = problemService.findAdminProblems(selectedPage, selectedSize);
         int totalPages = problemPage.getTotalPages();
+
+        if (totalPages > 0 && selectedPage >= totalPages) {
+            selectedPage = totalPages - 1;
+            problemPage = problemService.findAdminProblems(selectedPage, selectedSize);
+            totalPages = problemPage.getTotalPages();
+        }
+
         int pageBlockStart = (selectedPage / 10) * 10;
         int pageBlockEnd = Math.min(pageBlockStart + 9, Math.max(totalPages - 1, 0));
 

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
@@ -6,6 +6,8 @@ import com.aisip.OnO.backend.folder.entity.Folder;
 import com.aisip.OnO.backend.folder.service.FolderService;
 import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
 import com.aisip.OnO.backend.problem.service.ProblemService;
+import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveResponseDto;
+import com.aisip.OnO.backend.problemsolve.service.ProblemSolveService;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @Controller
@@ -27,6 +31,7 @@ public class AdminProblemController {
     private final ProblemService problemService;
     private final UserService userService;
     private final FolderService folderService;
+    private final ProblemSolveService problemSolveService;
 
     @GetMapping("/problems")
     public String getAllProblems(
@@ -64,8 +69,11 @@ public class AdminProblemController {
         // 폴더 및 작성자 정보 조회
         FolderResponseDto folder = folderService.findFolder(problem.folderId());
         UserResponseDto user = userService.findUser(folder.userId());
+        List<ProblemSolveResponseDto> problemSolves = problemSolveService.getAdminProblemSolvesByProblemId(problemId);
         model.addAttribute("folder", folder);
         model.addAttribute("user", user);
+        model.addAttribute("problemSolves", problemSolves);
+        model.addAttribute("problemSolveCount", problemSolves.size());
 
         return "problem";
     }

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminUserController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminUserController.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.admin.controller;
 
+import com.aisip.OnO.backend.admin.dto.AdminUserResponseDto;
 import com.aisip.OnO.backend.folder.dto.FolderResponseDto;
 import com.aisip.OnO.backend.folder.service.FolderService;
 import com.aisip.OnO.backend.mission.entity.MissionLog;
@@ -14,15 +15,12 @@ import com.aisip.OnO.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -44,61 +42,28 @@ public class AdminUserController {
             @RequestParam(defaultValue = "desc", name = "direction") String direction,
             Model model
     ) {
-        List<UserResponseDto> allUsers = userService.findAllUsers();
-        Map<Long, Long> problemCountByUserId = allUsers.stream()
-                .collect(Collectors.toMap(
-                        UserResponseDto::userId,
-                        user -> problemService.findProblemCountByUser(user.userId())
-                ));
+        int selectedPage = Math.max(page, 0);
+        int selectedSize = Math.max(size, 1);
+        Page<AdminUserResponseDto> userPage = userService.findAdminUsers(selectedPage, selectedSize, sortBy, direction);
+        int totalPages = userPage.getTotalPages();
+        int pageBlockStart = (selectedPage / 10) * 10;
+        int pageBlockEnd = Math.min(pageBlockStart + 9, Math.max(totalPages - 1, 0));
 
-        Comparator<UserResponseDto> comparator = getUserComparator(sortBy, problemCountByUserId);
-        if ("desc".equalsIgnoreCase(direction)) {
-            comparator = comparator.reversed();
-        }
-
-        List<UserResponseDto> sortedUsers = allUsers.stream()
-                .sorted(comparator.thenComparing(UserResponseDto::userId, Comparator.reverseOrder()))
-                .toList();
-
-        // 페이징 계산
-        int totalUsers = sortedUsers.size();
-        int totalPages = (int) Math.ceil((double) totalUsers / size);
-        int startIndex = page * size;
-        int endIndex = Math.min(startIndex + size, totalUsers);
-
-        List<UserResponseDto> pagedUsers = startIndex >= totalUsers
-                ? List.of()
-                : sortedUsers.subList(startIndex, endIndex);
-
-        // 각 유저의 문제 개수 계산
-        List<Long> problemCounts = pagedUsers.stream()
-                .map(user -> problemCountByUserId.get(user.userId()))
-                .toList();
-
-        model.addAttribute("users", pagedUsers);
-        model.addAttribute("problemCounts", problemCounts);
-        model.addAttribute("currentPage", page);
+        model.addAttribute("users", userPage.getContent());
+        model.addAttribute("currentPage", selectedPage);
         model.addAttribute("totalPages", totalPages);
-        model.addAttribute("totalUsers", totalUsers);
-        model.addAttribute("size", size);
+        model.addAttribute("totalUsers", userPage.getTotalElements());
+        model.addAttribute("size", selectedSize);
+        model.addAttribute("pageStartItem", userPage.isEmpty() ? 0 : selectedPage * selectedSize + 1);
+        model.addAttribute("pageEndItem", selectedPage * selectedSize + userPage.getNumberOfElements());
         model.addAttribute("sortBy", sortBy);
         model.addAttribute("direction", direction);
+        model.addAttribute("pageBlockStart", pageBlockStart);
+        model.addAttribute("pageBlockEnd", pageBlockEnd);
+        model.addAttribute("hasPreviousBlock", pageBlockStart > 0);
+        model.addAttribute("hasNextBlock", pageBlockEnd < totalPages - 1);
 
         return "users";
-    }
-
-    private Comparator<UserResponseDto> getUserComparator(String sortBy, Map<Long, Long> problemCountByUserId) {
-        Function<UserResponseDto, Long> sortKey = switch (sortBy) {
-            case "level" -> UserResponseDto::totalStudyLevel;
-            case "problemCount" -> user -> problemCountByUserId.getOrDefault(user.userId(), 0L);
-            default -> null;
-        };
-
-        if (sortKey == null) {
-            return Comparator.comparing(UserResponseDto::createdAt);
-        }
-
-        return Comparator.comparing(sortKey);
     }
 
     @GetMapping("/user/{userId}")

--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminUserController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminUserController.java
@@ -18,7 +18,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,21 +40,39 @@ public class AdminUserController {
     public String getAllUsers(
             @RequestParam(defaultValue = "0", name = "page") int page,
             @RequestParam(defaultValue = "20", name = "size") int size,
+            @RequestParam(defaultValue = "createdAt", name = "sortBy") String sortBy,
+            @RequestParam(defaultValue = "desc", name = "direction") String direction,
             Model model
     ) {
         List<UserResponseDto> allUsers = userService.findAllUsers();
+        Map<Long, Long> problemCountByUserId = allUsers.stream()
+                .collect(Collectors.toMap(
+                        UserResponseDto::userId,
+                        user -> problemService.findProblemCountByUser(user.userId())
+                ));
+
+        Comparator<UserResponseDto> comparator = getUserComparator(sortBy, problemCountByUserId);
+        if ("desc".equalsIgnoreCase(direction)) {
+            comparator = comparator.reversed();
+        }
+
+        List<UserResponseDto> sortedUsers = allUsers.stream()
+                .sorted(comparator.thenComparing(UserResponseDto::userId, Comparator.reverseOrder()))
+                .toList();
 
         // 페이징 계산
-        int totalUsers = allUsers.size();
+        int totalUsers = sortedUsers.size();
         int totalPages = (int) Math.ceil((double) totalUsers / size);
         int startIndex = page * size;
         int endIndex = Math.min(startIndex + size, totalUsers);
 
-        List<UserResponseDto> pagedUsers = allUsers.subList(startIndex, endIndex);
+        List<UserResponseDto> pagedUsers = startIndex >= totalUsers
+                ? List.of()
+                : sortedUsers.subList(startIndex, endIndex);
 
         // 각 유저의 문제 개수 계산
         List<Long> problemCounts = pagedUsers.stream()
-                .map(user -> problemService.findProblemCountByUser(user.userId()))
+                .map(user -> problemCountByUserId.get(user.userId()))
                 .toList();
 
         model.addAttribute("users", pagedUsers);
@@ -59,8 +81,24 @@ public class AdminUserController {
         model.addAttribute("totalPages", totalPages);
         model.addAttribute("totalUsers", totalUsers);
         model.addAttribute("size", size);
+        model.addAttribute("sortBy", sortBy);
+        model.addAttribute("direction", direction);
 
         return "users";
+    }
+
+    private Comparator<UserResponseDto> getUserComparator(String sortBy, Map<Long, Long> problemCountByUserId) {
+        Function<UserResponseDto, Long> sortKey = switch (sortBy) {
+            case "level" -> UserResponseDto::totalStudyLevel;
+            case "problemCount" -> user -> problemCountByUserId.getOrDefault(user.userId(), 0L);
+            default -> null;
+        };
+
+        if (sortKey == null) {
+            return Comparator.comparing(UserResponseDto::createdAt);
+        }
+
+        return Comparator.comparing(sortKey);
     }
 
     @GetMapping("/user/{userId}")

--- a/src/main/java/com/aisip/OnO/backend/admin/dto/AdminPracticeLogResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/dto/AdminPracticeLogResponseDto.java
@@ -1,0 +1,29 @@
+package com.aisip.OnO.backend.admin.dto;
+
+import com.aisip.OnO.backend.mission.entity.MissionLog;
+import com.aisip.OnO.backend.practicenote.entity.PracticeNote;
+import java.time.LocalDateTime;
+
+public record AdminPracticeLogResponseDto(
+        Long missionLogId,
+        Long userId,
+        String userName,
+        String userEmail,
+        Long practiceNoteId,
+        String practiceTitle,
+        Long point,
+        LocalDateTime createdAt
+) {
+    public static AdminPracticeLogResponseDto from(MissionLog missionLog, PracticeNote practiceNote) {
+        return new AdminPracticeLogResponseDto(
+                missionLog.getId(),
+                missionLog.getUser().getId(),
+                missionLog.getUser().getName(),
+                missionLog.getUser().getEmail(),
+                missionLog.getReferenceId(),
+                practiceNote != null ? practiceNote.getTitle() : "-",
+                missionLog.getPoint(),
+                missionLog.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/admin/dto/AdminPracticeNoteResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/dto/AdminPracticeNoteResponseDto.java
@@ -1,0 +1,31 @@
+package com.aisip.OnO.backend.admin.dto;
+
+import com.aisip.OnO.backend.practicenote.entity.PracticeNote;
+import com.aisip.OnO.backend.user.entity.User;
+import java.time.LocalDateTime;
+
+public record AdminPracticeNoteResponseDto(
+        Long practiceNoteId,
+        Long userId,
+        String userName,
+        String userEmail,
+        String practiceTitle,
+        Long problemCount,
+        Long practiceCount,
+        LocalDateTime lastSolvedAt,
+        LocalDateTime createdAt
+) {
+    public static AdminPracticeNoteResponseDto from(PracticeNote practiceNote, User user, Long problemCount) {
+        return new AdminPracticeNoteResponseDto(
+                practiceNote.getId(),
+                practiceNote.getUserId(),
+                user != null ? user.getName() : "-",
+                user != null ? user.getEmail() : "-",
+                practiceNote.getTitle(),
+                problemCount,
+                practiceNote.getPracticeCount(),
+                practiceNote.getLastSolvedAt(),
+                practiceNote.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/admin/dto/AdminProblemResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/dto/AdminProblemResponseDto.java
@@ -1,0 +1,14 @@
+package com.aisip.OnO.backend.admin.dto;
+
+import java.time.LocalDateTime;
+
+public record AdminProblemResponseDto(
+        Long problemId,
+        Long folderId,
+        String memo,
+        String reference,
+        String analysisStatus,
+        LocalDateTime solvedAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/aisip/OnO/backend/admin/dto/AdminUserResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/dto/AdminUserResponseDto.java
@@ -1,0 +1,27 @@
+package com.aisip.OnO.backend.admin.dto;
+
+import com.aisip.OnO.backend.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record AdminUserResponseDto(
+        Long userId,
+        String name,
+        String email,
+        Long totalStudyLevel,
+        Long totalStudyCurrentPoint,
+        Long problemCount,
+        LocalDateTime createdAt
+) {
+    public static AdminUserResponseDto from(User user, Long problemCount) {
+        return new AdminUserResponseDto(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getUserMissionStatus().getTotalStudyLevel(),
+                user.getUserMissionStatus().getTotalStudyPoint(),
+                problemCount != null ? problemCount : 0L,
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
@@ -14,6 +14,9 @@ public interface MissionLogRepository extends JpaRepository<MissionLog, Long>, M
 
     List<MissionLog> findAllByMissionType(MissionType missionType, Pageable pageable);
 
+    @Query("SELECT m FROM MissionLog m JOIN FETCH m.user WHERE m.missionType = :missionType")
+    List<MissionLog> findAllByMissionTypeWithUser(@Param("missionType") MissionType missionType, Pageable pageable);
+
     long countByMissionType(MissionType missionType);
 
     long countByMissionTypeAndCreatedAtBetween(

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
@@ -26,6 +26,18 @@ public interface MissionLogRepository extends JpaRepository<MissionLog, Long>, M
     );
 
     @Query("""
+            SELECT COUNT(DISTINCT m.user.id)
+            FROM MissionLog m
+            WHERE m.missionType = :missionType
+              AND m.createdAt BETWEEN :startDateTime AND :endDateTime
+            """)
+    long countDistinctUsersByMissionTypeAndCreatedAtBetween(
+            @Param("missionType") MissionType missionType,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
+
+    @Query("""
             SELECT FUNCTION('DATE', m.createdAt), COUNT(m)
             FROM MissionLog m
             WHERE m.missionType = :missionType

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
@@ -1,9 +1,15 @@
 package com.aisip.OnO.backend.mission.repository;
 
+import com.aisip.OnO.backend.mission.entity.MissionType;
 import com.aisip.OnO.backend.mission.entity.MissionLog;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionLogRepository extends JpaRepository<MissionLog, Long>, MissionLogRepositoryCustom {
     List<MissionLog> findAllByUserId(Long userId);
+
+    List<MissionLog> findAllByMissionType(MissionType missionType, Pageable pageable);
+
+    long countByMissionType(MissionType missionType);
 }

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepository.java
@@ -2,9 +2,12 @@ package com.aisip.OnO.backend.mission.repository;
 
 import com.aisip.OnO.backend.mission.entity.MissionType;
 import com.aisip.OnO.backend.mission.entity.MissionLog;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MissionLogRepository extends JpaRepository<MissionLog, Long>, MissionLogRepositoryCustom {
     List<MissionLog> findAllByUserId(Long userId);
@@ -12,4 +15,23 @@ public interface MissionLogRepository extends JpaRepository<MissionLog, Long>, M
     List<MissionLog> findAllByMissionType(MissionType missionType, Pageable pageable);
 
     long countByMissionType(MissionType missionType);
+
+    long countByMissionTypeAndCreatedAtBetween(
+            MissionType missionType,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
+    );
+
+    @Query("""
+            SELECT FUNCTION('DATE', m.createdAt), COUNT(m)
+            FROM MissionLog m
+            WHERE m.missionType = :missionType
+              AND m.createdAt BETWEEN :startDateTime AND :endDateTime
+            GROUP BY FUNCTION('DATE', m.createdAt)
+            """)
+    List<Object[]> countDailyByMissionType(
+            @Param("missionType") MissionType missionType,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
 }

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryCustom.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryCustom.java
@@ -19,5 +19,7 @@ public interface MissionLogRepositoryCustom {
 
     Map<LocalDate, Long> getDailyActiveUsersCount(int days);
 
+    Map<LocalDate, Long> getDailyActiveUsersCount(LocalDate startDate, LocalDate endDate);
+
     List<User> getActiveUsersByDate(LocalDate date);
 }

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
@@ -2,6 +2,10 @@ package com.aisip.OnO.backend.mission.repository;
 
 import com.aisip.OnO.backend.mission.entity.MissionType;
 import com.aisip.OnO.backend.user.entity.User;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.DateExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 
@@ -94,21 +98,33 @@ public class MissionLogRepositoryImpl implements MissionLogRepositoryCustom {
     @Override
     public Map<LocalDate, Long> getDailyActiveUsersCount(LocalDate startDate, LocalDate endDate) {
         Map<LocalDate, Long> result = new LinkedHashMap<>();
+        DateExpression<LocalDate> createdDate = Expressions.dateTemplate(
+                LocalDate.class,
+                "date({0})",
+                missionLog.createdAt
+        );
+        NumberExpression<Long> activeUserCount = missionLog.user.id.countDistinct();
 
-        // 최근 날짜가 위로 오도록 역순으로 조회
+        java.util.List<Tuple> dailyCounts = queryFactory
+                .select(createdDate, activeUserCount)
+                .from(missionLog)
+                .where(missionLog.missionType.eq(MissionType.USER_LOGIN)
+                        .and(missionLog.createdAt.between(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)))
+                )
+                .groupBy(createdDate)
+                .fetch();
+
+        Map<LocalDate, Long> countByDate = new LinkedHashMap<>();
+        for (Tuple row : dailyCounts) {
+            LocalDate date = row.get(createdDate);
+            Long count = row.get(activeUserCount);
+            if (date != null) {
+                countByDate.put(date, count != null ? count : 0L);
+            }
+        }
+
         for (LocalDate date = endDate; !date.isBefore(startDate); date = date.minusDays(1)) {
-            LocalDateTime startOfDay = date.atStartOfDay();
-            LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
-
-            Long count = queryFactory
-                    .select(missionLog.user.id.countDistinct())
-                    .from(missionLog)
-                    .where(missionLog.missionType.eq(MissionType.USER_LOGIN)
-                            .and(missionLog.createdAt.between(startOfDay, endOfDay))
-                    )
-                    .fetchOne();
-
-            result.put(date, count != null ? count : 0L);
+            result.put(date, countByDate.getOrDefault(date, 0L));
         }
 
         return result;

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
@@ -87,12 +87,16 @@ public class MissionLogRepositoryImpl implements MissionLogRepositoryCustom {
 
     @Override
     public Map<LocalDate, Long> getDailyActiveUsersCount(int days) {
-        Map<LocalDate, Long> result = new LinkedHashMap<>();
         LocalDate today = LocalDate.now();
+        return getDailyActiveUsersCount(today.minusDays(days - 1L), today);
+    }
+
+    @Override
+    public Map<LocalDate, Long> getDailyActiveUsersCount(LocalDate startDate, LocalDate endDate) {
+        Map<LocalDate, Long> result = new LinkedHashMap<>();
 
         // 최근 날짜가 위로 오도록 역순으로 조회
-        for (int i = 0; i < days; i++) {
-            LocalDate date = today.minusDays(i);
+        for (LocalDate date = endDate; !date.isBefore(startDate); date = date.minusDays(1)) {
             LocalDateTime startOfDay = date.atStartOfDay();
             LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
@@ -9,6 +9,8 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -116,7 +118,7 @@ public class MissionLogRepositoryImpl implements MissionLogRepositoryCustom {
 
         Map<LocalDate, Long> countByDate = new LinkedHashMap<>();
         for (Tuple row : dailyCounts) {
-            LocalDate date = row.get(createdDate);
+            LocalDate date = toLocalDate(row.get(createdDate));
             Long count = row.get(activeUserCount);
             if (date != null) {
                 countByDate.put(date, count != null ? count : 0L);
@@ -151,5 +153,21 @@ public class MissionLogRepositoryImpl implements MissionLogRepositoryCustom {
 
     private LocalDateTime getEndOfToday() {
         return LocalDate.now().atTime(LocalTime.MAX);
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof LocalDate localDate) {
+            return localDate;
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime.toLocalDate();
+        }
+        if (value instanceof Date date) {
+            return date.toLocalDate();
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toLocalDateTime().toLocalDate();
+        }
+        return value != null ? LocalDate.parse(value.toString()) : null;
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
@@ -180,6 +180,11 @@ public class MissionLogService {
     }
 
     @Transactional(readOnly = true)
+    public Map<LocalDate, Long> getDailyVisitCount(LocalDate startDate, LocalDate endDate) {
+        return getDailyMissionCount(MissionType.USER_LOGIN, startDate, endDate);
+    }
+
+    @Transactional(readOnly = true)
     public List<com.aisip.OnO.backend.user.entity.User> getActiveUsersByDate(LocalDate date) {
         return missionLogRepository.getActiveUsersByDate(date);
     }
@@ -214,9 +219,13 @@ public class MissionLogService {
 
     @Transactional(readOnly = true)
     public Map<LocalDate, Long> getDailyNotePracticeLogsCount(LocalDate startDate, LocalDate endDate) {
+        return getDailyMissionCount(MissionType.NOTE_PRACTICE, startDate, endDate);
+    }
+
+    private Map<LocalDate, Long> getDailyMissionCount(MissionType missionType, LocalDate startDate, LocalDate endDate) {
         Map<LocalDate, Long> result = new LinkedHashMap<>();
         missionLogRepository.countDailyByMissionType(
-                        MissionType.NOTE_PRACTICE,
+                        missionType,
                         startDate.atStartOfDay(),
                         endDate.atTime(LocalTime.MAX)
                 )

--- a/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
@@ -11,7 +11,12 @@ import com.aisip.OnO.backend.practicenote.entity.PracticeNote;
 import com.aisip.OnO.backend.practicenote.repository.PracticeNoteRepository;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.repository.UserRepository;
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -193,5 +198,44 @@ public class MissionLogService {
                 .toList();
 
         return new PageImpl<>(content, pageRequest, total);
+    }
+
+    @Transactional(readOnly = true)
+    public long countNotePracticeLogs() {
+        return missionLogRepository.countByMissionType(MissionType.NOTE_PRACTICE);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<LocalDate, Long> getDailyNotePracticeLogsCount(LocalDate startDate, LocalDate endDate) {
+        Map<LocalDate, Long> result = new LinkedHashMap<>();
+        missionLogRepository.countDailyByMissionType(
+                        MissionType.NOTE_PRACTICE,
+                        startDate.atStartOfDay(),
+                        endDate.atTime(LocalTime.MAX)
+                )
+                .forEach(row -> result.put(toLocalDate(row[0]), (Long) row[1]));
+
+        Map<LocalDate, Long> orderedResult = new LinkedHashMap<>();
+        for (LocalDate date = endDate; !date.isBefore(startDate); date = date.minusDays(1)) {
+            orderedResult.put(date, result.getOrDefault(date, 0L));
+        }
+
+        return orderedResult;
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof LocalDate localDate) {
+            return localDate;
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime.toLocalDate();
+        }
+        if (value instanceof Date date) {
+            return date.toLocalDate();
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toLocalDateTime().toLocalDate();
+        }
+        return LocalDate.parse(value.toString());
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
@@ -159,6 +159,11 @@ public class MissionLogService {
     }
 
     @Transactional(readOnly = true)
+    public Map<LocalDate, Long> getDailyActiveUsersCount(LocalDate startDate, LocalDate endDate) {
+        return missionLogRepository.getDailyActiveUsersCount(startDate, endDate);
+    }
+
+    @Transactional(readOnly = true)
     public List<com.aisip.OnO.backend.user.entity.User> getActiveUsersByDate(LocalDate date) {
         return missionLogRepository.getActiveUsersByDate(date);
     }

--- a/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
@@ -185,6 +185,15 @@ public class MissionLogService {
     }
 
     @Transactional(readOnly = true)
+    public long countUniqueVisitors(LocalDate startDate, LocalDate endDate) {
+        return missionLogRepository.countDistinctUsersByMissionTypeAndCreatedAtBetween(
+                MissionType.USER_LOGIN,
+                startDate.atStartOfDay(),
+                endDate.atTime(LocalTime.MAX)
+        );
+    }
+
+    @Transactional(readOnly = true)
     public List<com.aisip.OnO.backend.user.entity.User> getActiveUsersByDate(LocalDate date) {
         return missionLogRepository.getActiveUsersByDate(date);
     }

--- a/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
@@ -19,6 +19,8 @@ import java.time.LocalTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
@@ -185,16 +187,21 @@ public class MissionLogService {
     @Transactional(readOnly = true)
     public Page<AdminPracticeLogResponseDto> findAdminPracticeLogs(int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        List<MissionLog> missionLogs = missionLogRepository.findAllByMissionType(MissionType.NOTE_PRACTICE, pageRequest);
+        List<MissionLog> missionLogs = missionLogRepository.findAllByMissionTypeWithUser(MissionType.NOTE_PRACTICE, pageRequest);
         long total = missionLogRepository.countByMissionType(MissionType.NOTE_PRACTICE);
+        List<Long> practiceNoteIds = missionLogs.stream()
+                .map(MissionLog::getReferenceId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<Long, PracticeNote> practiceNotesById = practiceNoteRepository.findAllById(practiceNoteIds).stream()
+                .collect(Collectors.toMap(PracticeNote::getId, Function.identity()));
 
         List<AdminPracticeLogResponseDto> content = missionLogs.stream()
-                .map(missionLog -> {
-                    PracticeNote practiceNote = missionLog.getReferenceId() != null
-                            ? practiceNoteRepository.findById(missionLog.getReferenceId()).orElse(null)
-                            : null;
-                    return AdminPracticeLogResponseDto.from(missionLog, practiceNote);
-                })
+                .map(missionLog -> AdminPracticeLogResponseDto.from(
+                        missionLog,
+                        practiceNotesById.get(missionLog.getReferenceId())
+                ))
                 .toList();
 
         return new PageImpl<>(content, pageRequest, total);

--- a/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
@@ -1,11 +1,14 @@
 package com.aisip.OnO.backend.mission.service;
 
+import com.aisip.OnO.backend.admin.dto.AdminPracticeLogResponseDto;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.mission.dto.MissionRegisterDto;
 import com.aisip.OnO.backend.mission.entity.MissionLog;
 import com.aisip.OnO.backend.mission.entity.MissionType;
 import com.aisip.OnO.backend.mission.exception.MissionErrorCase;
 import com.aisip.OnO.backend.mission.repository.MissionLogRepository;
+import com.aisip.OnO.backend.practicenote.entity.PracticeNote;
+import com.aisip.OnO.backend.practicenote.repository.PracticeNoteRepository;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.repository.UserRepository;
 import java.time.LocalDate;
@@ -13,6 +16,10 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +31,8 @@ public class MissionLogService {
     private final MissionLogRepository missionLogRepository;
 
     private final UserRepository userRepository;
+
+    private final PracticeNoteRepository practiceNoteRepository;
 
     private static final Long DAILY_MISSION_POINT_LIMIT = 200L;
 
@@ -166,5 +175,23 @@ public class MissionLogService {
     @Transactional(readOnly = true)
     public List<com.aisip.OnO.backend.user.entity.User> getActiveUsersByDate(LocalDate date) {
         return missionLogRepository.getActiveUsersByDate(date);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AdminPracticeLogResponseDto> findAdminPracticeLogs(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<MissionLog> missionLogs = missionLogRepository.findAllByMissionType(MissionType.NOTE_PRACTICE, pageRequest);
+        long total = missionLogRepository.countByMissionType(MissionType.NOTE_PRACTICE);
+
+        List<AdminPracticeLogResponseDto> content = missionLogs.stream()
+                .map(missionLog -> {
+                    PracticeNote practiceNote = missionLog.getReferenceId() != null
+                            ? practiceNoteRepository.findById(missionLog.getReferenceId()).orElse(null)
+                            : null;
+                    return AdminPracticeLogResponseDto.from(missionLog, practiceNote);
+                })
+                .toList();
+
+        return new PageImpl<>(content, pageRequest, total);
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/practicenote/repository/PracticeNoteRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/repository/PracticeNoteRepository.java
@@ -25,6 +25,14 @@ public interface PracticeNoteRepository extends JpaRepository<PracticeNote, Long
             @Param("endDateTime") LocalDateTime endDateTime
     );
 
+    @Query("""
+            SELECT m.practiceNote.id, COUNT(m.problem.id)
+            FROM ProblemPracticeNoteMapping m
+            WHERE m.practiceNote.id IN :practiceNoteIds
+            GROUP BY m.practiceNote.id
+            """)
+    List<Object[]> countProblemsByPracticeNoteIds(@Param("practiceNoteIds") List<Long> practiceNoteIds);
+
     @Query("SELECT p.id FROM PracticeNote p WHERE p.userId = :userId")
     List<Long> findAllPracticeIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/aisip/OnO/backend/practicenote/repository/PracticeNoteRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/repository/PracticeNoteRepository.java
@@ -5,11 +5,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PracticeNoteRepository extends JpaRepository<PracticeNote, Long>, PracticeNoteRepositoryCustom {
 
     List<PracticeNote> findAllByUserId(Long userId);
+
+    long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    @Query("""
+            SELECT FUNCTION('DATE', p.createdAt), COUNT(p)
+            FROM PracticeNote p
+            WHERE p.createdAt BETWEEN :startDateTime AND :endDateTime
+            GROUP BY FUNCTION('DATE', p.createdAt)
+            """)
+    List<Object[]> countDailyPracticeNotes(
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
 
     @Query("SELECT p.id FROM PracticeNote p WHERE p.userId = :userId")
     List<Long> findAllPracticeIdsByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -247,11 +248,29 @@ public class PracticeNoteService {
     public Page<AdminPracticeNoteResponseDto> findAdminPracticeNotes(int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<PracticeNote> practiceNotePage = practiceNoteRepository.findAll(pageRequest);
+        List<PracticeNote> practiceNotes = practiceNotePage.getContent();
+        List<Long> userIds = practiceNotes.stream()
+                .map(PracticeNote::getUserId)
+                .distinct()
+                .toList();
+        List<Long> practiceNoteIds = practiceNotes.stream()
+                .map(PracticeNote::getId)
+                .toList();
 
-        List<AdminPracticeNoteResponseDto> content = practiceNotePage.getContent().stream()
+        Map<Long, User> usersById = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+        Map<Long, Long> problemCountsByPracticeNoteId = practiceNoteIds.isEmpty()
+                ? Map.of()
+                : practiceNoteRepository.countProblemsByPracticeNoteIds(practiceNoteIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        List<AdminPracticeNoteResponseDto> content = practiceNotes.stream()
                 .map(practiceNote -> {
-                    User user = userRepository.findById(practiceNote.getUserId()).orElse(null);
-                    Long problemCount = (long) practiceNoteRepository.findProblemIdListByPracticeNoteId(practiceNote.getId()).size();
+                    User user = usersById.get(practiceNote.getUserId());
+                    Long problemCount = problemCountsByPracticeNoteId.getOrDefault(practiceNote.getId(), 0L);
                     return AdminPracticeNoteResponseDto.from(practiceNote, user, problemCount);
                 })
                 .toList();

--- a/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
@@ -25,7 +25,14 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -250,5 +257,40 @@ public class PracticeNoteService {
                 .toList();
 
         return new PageImpl<>(content, pageRequest, practiceNotePage.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
+    public long countAllPracticeNotes() {
+        return practiceNoteRepository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public Map<LocalDate, Long> getDailyPracticeNotesCount(LocalDate startDate, LocalDate endDate) {
+        Map<LocalDate, Long> result = new LinkedHashMap<>();
+        practiceNoteRepository.countDailyPracticeNotes(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX))
+                .forEach(row -> result.put(toLocalDate(row[0]), (Long) row[1]));
+
+        Map<LocalDate, Long> orderedResult = new LinkedHashMap<>();
+        for (LocalDate date = endDate; !date.isBefore(startDate); date = date.minusDays(1)) {
+            orderedResult.put(date, result.getOrDefault(date, 0L));
+        }
+
+        return orderedResult;
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof LocalDate localDate) {
+            return localDate;
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime.toLocalDate();
+        }
+        if (value instanceof Date date) {
+            return date.toLocalDate();
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toLocalDateTime().toLocalDate();
+        }
+        return LocalDate.parse(value.toString());
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.practicenote.service;
 
+import com.aisip.OnO.backend.admin.dto.AdminPracticeNoteResponseDto;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.mission.service.MissionLogService;
@@ -13,8 +14,14 @@ import com.aisip.OnO.backend.practicenote.entity.ProblemPracticeNoteMapping;
 import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.practicenote.repository.PracticeNoteRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +45,8 @@ public class PracticeNoteService {
     private final PracticeNotificationScheduler practiceNotificationScheduler;
 
     private final MissionLogService missionLogService;
+
+    private final UserRepository userRepository;
 
     private PracticeNote getPracticeEntity(Long practiceId){
 
@@ -225,5 +234,21 @@ public class PracticeNoteService {
 
         log.info("userId: {} find practice thumbnails with cursor: {}, size: {}, hasNext: {}", userId, cursor, size, hasNext);
         return CursorPageResponse.of(dtoList, nextCursor, hasNext, size);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AdminPracticeNoteResponseDto> findAdminPracticeNotes(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<PracticeNote> practiceNotePage = practiceNoteRepository.findAll(pageRequest);
+
+        List<AdminPracticeNoteResponseDto> content = practiceNotePage.getContent().stream()
+                .map(practiceNote -> {
+                    User user = userRepository.findById(practiceNote.getUserId()).orElse(null);
+                    Long problemCount = (long) practiceNoteRepository.findProblemIdListByPracticeNoteId(practiceNote.getId()).size();
+                    return AdminPracticeNoteResponseDto.from(practiceNote, user, problemCount);
+                })
+                .toList();
+
+        return new PageImpl<>(content, pageRequest, practiceNotePage.getTotalElements());
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryCustom.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryCustom.java
@@ -1,6 +1,9 @@
 package com.aisip.OnO.backend.problem.repository;
 
+import com.aisip.OnO.backend.admin.dto.AdminProblemResponseDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +17,8 @@ public interface ProblemRepositoryCustom {
     List<Problem> findAllByFolderId(Long folderId);
 
     List<Problem> findAll();
+
+    Page<AdminProblemResponseDto> findAdminProblems(Pageable pageable);
 
     List<Problem> findAllProblemsByPracticeId(Long practiceId);
 

--- a/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryCustom.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryCustom.java
@@ -1,11 +1,14 @@
 package com.aisip.OnO.backend.problem.repository;
 
 import com.aisip.OnO.backend.admin.dto.AdminProblemResponseDto;
+import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface ProblemRepositoryCustom {
@@ -19,6 +22,14 @@ public interface ProblemRepositoryCustom {
     List<Problem> findAll();
 
     Page<AdminProblemResponseDto> findAdminProblems(Pageable pageable);
+
+    Map<LocalDate, Long> countDailyProblems(LocalDate startDate, LocalDate endDate);
+
+    long countProblemAnalysesForActiveProblems();
+
+    Map<AnalysisStatus, Long> countProblemAnalysesByStatusForActiveProblems();
+
+    Map<AnalysisStatus, Long> countProblemAnalysesByStatusForActiveProblems(LocalDate startDate, LocalDate endDate);
 
     List<Problem> findAllProblemsByPracticeId(Long practiceId);
 

--- a/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryImpl.java
@@ -1,18 +1,29 @@
 package com.aisip.OnO.backend.problem.repository;
 
 import com.aisip.OnO.backend.admin.dto.AdminProblemResponseDto;
+import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.entity.QProblem;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.DateExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static com.aisip.OnO.backend.folder.entity.QFolder.folder;
 import static com.aisip.OnO.backend.practicenote.entity.QPracticeNote.practiceNote;
 import static com.aisip.OnO.backend.practicenote.entity.QProblemPracticeNoteMapping.problemPracticeNoteMapping;
 import static com.aisip.OnO.backend.problem.entity.QProblem.problem;
@@ -78,7 +89,7 @@ public class ProblemRepositoryImpl implements ProblemRepositoryCustom {
                 .select(Projections.constructor(
                         AdminProblemResponseDto.class,
                         problem.id,
-                        problem.folder.id,
+                        folder.id,
                         problem.memo,
                         problem.reference,
                         problemAnalysis.status.stringValue(),
@@ -86,7 +97,7 @@ public class ProblemRepositoryImpl implements ProblemRepositoryCustom {
                         problem.createdAt
                 ))
                 .from(problem)
-                .leftJoin(problem.folder)
+                .leftJoin(problem.folder, folder)
                 .leftJoin(problem.problemAnalysis, problemAnalysis)
                 .orderBy(problem.createdAt.desc(), problem.id.desc())
                 .offset(pageable.getOffset())
@@ -99,6 +110,76 @@ public class ProblemRepositoryImpl implements ProblemRepositoryCustom {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    @Override
+    public Map<LocalDate, Long> countDailyProblems(LocalDate startDate, LocalDate endDate) {
+        DateExpression<Date> createdDate = Expressions.dateTemplate(
+                Date.class,
+                "date({0})",
+                problem.createdAt
+        );
+
+        List<Tuple> rows = queryFactory
+                .select(createdDate, problem.count())
+                .from(problem)
+                .where(problem.createdAt.between(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)))
+                .groupBy(createdDate)
+                .fetch();
+
+        Map<LocalDate, Long> countsByDate = new LinkedHashMap<>();
+        rows.forEach(row -> {
+            Date date = row.get(createdDate);
+            if (date != null) {
+                countsByDate.put(date.toLocalDate(), row.get(problem.count()));
+            }
+        });
+
+        Map<LocalDate, Long> result = new LinkedHashMap<>();
+        for (LocalDate date = endDate; !date.isBefore(startDate); date = date.minusDays(1)) {
+            result.put(date, countsByDate.getOrDefault(date, 0L));
+        }
+
+        return result;
+    }
+
+    @Override
+    public long countProblemAnalysesForActiveProblems() {
+        Long count = queryFactory
+                .select(problemAnalysis.count())
+                .from(problemAnalysis)
+                .join(problemAnalysis.problem, problem)
+                .where(problem.deletedAt.isNull())
+                .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public Map<AnalysisStatus, Long> countProblemAnalysesByStatusForActiveProblems() {
+        return countProblemAnalysesByStatusForActiveProblems(null, null);
+    }
+
+    @Override
+    public Map<AnalysisStatus, Long> countProblemAnalysesByStatusForActiveProblems(LocalDate startDate, LocalDate endDate) {
+        var query = queryFactory
+                .select(problemAnalysis.status, problemAnalysis.count())
+                .from(problemAnalysis)
+                .join(problemAnalysis.problem, problem)
+                .where(problem.deletedAt.isNull());
+
+        if (startDate != null && endDate != null) {
+            query.where(problemAnalysis.updatedAt.between(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)));
+        }
+
+        List<Tuple> rows = query
+                .groupBy(problemAnalysis.status)
+                .fetch();
+
+        Map<AnalysisStatus, Long> result = new EnumMap<>(AnalysisStatus.class);
+        rows.forEach(row -> result.put(row.get(problemAnalysis.status), row.get(problemAnalysis.count())));
+
+        return result;
     }
 
     @Override

--- a/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepositoryImpl.java
@@ -1,9 +1,14 @@
 package com.aisip.OnO.backend.problem.repository;
 
+import com.aisip.OnO.backend.admin.dto.AdminProblemResponseDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.entity.QProblem;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +16,7 @@ import java.util.Optional;
 import static com.aisip.OnO.backend.practicenote.entity.QPracticeNote.practiceNote;
 import static com.aisip.OnO.backend.practicenote.entity.QProblemPracticeNoteMapping.problemPracticeNoteMapping;
 import static com.aisip.OnO.backend.problem.entity.QProblem.problem;
+import static com.aisip.OnO.backend.problem.entity.QProblemAnalysis.problemAnalysis;
 import static com.aisip.OnO.backend.problem.entity.QProblemImageData.problemImageData;
 import static com.aisip.OnO.backend.tag.entity.QProblemTagMapping.problemTagMapping;
 
@@ -64,6 +70,35 @@ public class ProblemRepositoryImpl implements ProblemRepositoryCustom {
                 .leftJoin(problem.problemImageDataList, problemImageData).fetchJoin()
                 .orderBy(problem.id.asc())
                 .fetch();
+    }
+
+    @Override
+    public Page<AdminProblemResponseDto> findAdminProblems(Pageable pageable) {
+        List<AdminProblemResponseDto> content = queryFactory
+                .select(Projections.constructor(
+                        AdminProblemResponseDto.class,
+                        problem.id,
+                        problem.folder.id,
+                        problem.memo,
+                        problem.reference,
+                        problemAnalysis.status.stringValue(),
+                        problem.solvedAt,
+                        problem.createdAt
+                ))
+                .from(problem)
+                .leftJoin(problem.folder)
+                .leftJoin(problem.problemAnalysis, problemAnalysis)
+                .orderBy(problem.createdAt.desc(), problem.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(problem.count())
+                .from(problem)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     @Override

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.problem.service;
 
+import com.aisip.OnO.backend.admin.dto.AdminProblemResponseDto;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
@@ -32,6 +33,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -129,6 +132,11 @@ public class ProblemService {
     @Transactional(readOnly = true)
     public long countAllProblems() {
         return problemRepository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AdminProblemResponseDto> findAdminProblems(int page, int size) {
+        return problemRepository.findAdminProblems(PageRequest.of(page, size));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -36,10 +36,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -132,6 +137,36 @@ public class ProblemService {
     @Transactional(readOnly = true)
     public long countAllProblems() {
         return problemRepository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public long countAllProblemAnalyses() {
+        return problemRepository.countProblemAnalysesForActiveProblems();
+    }
+
+    @Transactional(readOnly = true)
+    public Map<LocalDate, Long> getDailyProblemsCount(LocalDate startDate, LocalDate endDate) {
+        return problemRepository.countDailyProblems(startDate, endDate);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<AnalysisStatus, Long> countProblemAnalysesByStatus() {
+        return fillMissingAnalysisStatuses(problemRepository.countProblemAnalysesByStatusForActiveProblems());
+    }
+
+    @Transactional(readOnly = true)
+    public Map<AnalysisStatus, Long> countProblemAnalysesByStatus(LocalDate startDate, LocalDate endDate) {
+        return fillMissingAnalysisStatuses(problemRepository.countProblemAnalysesByStatusForActiveProblems(startDate, endDate));
+    }
+
+    private Map<AnalysisStatus, Long> fillMissingAnalysisStatuses(Map<AnalysisStatus, Long> source) {
+        Map<AnalysisStatus, Long> result = new EnumMap<>(AnalysisStatus.class);
+
+        for (AnalysisStatus status : AnalysisStatus.values()) {
+            result.put(status, source.getOrDefault(status, 0L));
+        }
+
+        return result;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -127,6 +127,11 @@ public class ProblemService {
     }
 
     @Transactional(readOnly = true)
+    public long countAllProblems() {
+        return problemRepository.count();
+    }
+
+    @Transactional(readOnly = true)
     public Long findProblemCountByUser(Long userId) {
         log.info("userId: {} find problem count", userId);
         return problemRepository.countByUserId(userId);

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveRepository.java
@@ -15,7 +15,7 @@ public interface ProblemSolveRepository extends JpaRepository<ProblemSolve, Long
             "WHERE pr.id = :problemSolveId")
     Optional<ProblemSolve> findByIdWithImages(@Param("problemSolveId") Long problemSolveId);
 
-    @Query("SELECT pr FROM ProblemSolve pr " +
+    @Query("SELECT DISTINCT pr FROM ProblemSolve pr " +
             "LEFT JOIN FETCH pr.images " +
             "WHERE pr.problem.id = :problemId " +
             "ORDER BY pr.practicedAt DESC")

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
@@ -68,6 +68,15 @@ public class ProblemSolveService {
     }
 
     @Transactional(readOnly = true)
+    public List<ProblemSolveResponseDto> getAdminProblemSolvesByProblemId(Long problemId) {
+        List<ProblemSolve> problemSolves = problemSolveRepository.findAllByProblemIdWithImages(problemId);
+
+        return problemSolves.stream()
+                .map(ProblemSolveResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
     public List<ProblemSolveResponseDto> getUserProblemSolves(Long userId) {
         List<ProblemSolve> problemSolves = problemSolveRepository.findAllByUserId(userId);
 

--- a/src/main/java/com/aisip/OnO/backend/user/repository/UserAdminRow.java
+++ b/src/main/java/com/aisip/OnO/backend/user/repository/UserAdminRow.java
@@ -1,0 +1,9 @@
+package com.aisip.OnO.backend.user.repository;
+
+import com.aisip.OnO.backend.user.entity.User;
+
+public record UserAdminRow(
+        User user,
+        Long problemCount
+) {
+}

--- a/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByIdentifier(String identifier);

--- a/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
@@ -4,7 +4,11 @@ import com.aisip.OnO.backend.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -15,4 +19,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByName(String name);
 
     Page<User> findAll(Pageable pageable);
+
+    List<User> findAllByCreatedAtBetweenOrderByCreatedAtDesc(LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    @Query("""
+            SELECT FUNCTION('DATE', u.createdAt), COUNT(u)
+            FROM User u
+            WHERE u.createdAt BETWEEN :startDateTime AND :endDateTime
+            GROUP BY FUNCTION('DATE', u.createdAt)
+            """)
+    List<Object[]> countDailyNewUsers(
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
 }

--- a/src/main/java/com/aisip/OnO/backend/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/aisip/OnO/backend/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.aisip.OnO.backend.user.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserRepositoryCustom {
+    Page<UserAdminRow> findAdminUsers(Pageable pageable, String sortBy, String direction);
+}

--- a/src/main/java/com/aisip/OnO/backend/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.aisip.OnO.backend.user.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.aisip.OnO.backend.problem.entity.QProblem.problem;
+import static com.aisip.OnO.backend.user.entity.QUser.user;
+
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public UserRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public Page<UserAdminRow> findAdminUsers(Pageable pageable, String sortBy, String direction) {
+        NumberExpression<Long> problemCount = problem.id.count();
+
+        List<Tuple> rows = queryFactory
+                .select(user, problemCount)
+                .from(user)
+                .leftJoin(problem).on(problem.userId.eq(user.id))
+                .groupBy(user.id)
+                .orderBy(getOrderSpecifier(sortBy, direction, problemCount), user.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<UserAdminRow> content = rows.stream()
+                .map(row -> new UserAdminRow(row.get(user), row.get(problemCount)))
+                .toList();
+
+        Long total = queryFactory
+                .select(user.count())
+                .from(user)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(
+            String sortBy,
+            String direction,
+            NumberExpression<Long> problemCount
+    ) {
+        Order order = "asc".equalsIgnoreCase(direction) ? Order.ASC : Order.DESC;
+
+        return switch (sortBy) {
+            case "level" -> new OrderSpecifier<>(order, user.userMissionStatus.totalStudyLevel);
+            case "problemCount" -> new OrderSpecifier<>(order, problemCount);
+            default -> new OrderSpecifier<>(order, user.createdAt);
+        };
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -156,13 +156,17 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public Map<LocalDate, Long> getDailyNewUsersCount(int days) {
-        Map<LocalDate, Long> result = new LinkedHashMap<>();
         LocalDate today = LocalDate.now();
+        return getDailyNewUsersCount(today.minusDays(days - 1L), today);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<LocalDate, Long> getDailyNewUsersCount(LocalDate startDate, LocalDate endDate) {
+        Map<LocalDate, Long> result = new LinkedHashMap<>();
         List<User> allUsers = userRepository.findAll();
 
         // 최근 날짜가 위로 오도록 역순으로 조회
-        for (int i = 0; i < days; i++) {
-            LocalDate date = today.minusDays(i);
+        for (LocalDate date = endDate; !date.isBefore(startDate); date = date.minusDays(1)) {
             LocalDateTime startOfDay = date.atStartOfDay();
             LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.user.service;
 
+import com.aisip.OnO.backend.admin.dto.AdminUserResponseDto;
 import com.aisip.OnO.backend.folder.service.FolderService;
 import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
 import com.aisip.OnO.backend.problem.service.ProblemService;
@@ -12,19 +13,21 @@ import com.aisip.OnO.backend.user.repository.UserRepository;
 import com.aisip.OnO.backend.util.webhook.DiscordWebhookNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.sql.Date;
-import java.sql.Timestamp;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -103,6 +106,13 @@ public class UserService {
                 .sorted((u1, u2) -> u2.getCreatedAt().compareTo(u1.getCreatedAt())) // 최신순 정렬
                 .map(UserResponseDto::from)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AdminUserResponseDto> findAdminUsers(int page, int size, String sortBy, String direction) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        return userRepository.findAdminUsers(pageRequest, sortBy, direction)
+                .map(row -> AdminUserResponseDto.from(row.user(), row.problemCount()));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +105,11 @@ public class UserService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public long countAllUsers() {
+        return userRepository.count();
+    }
+
     @Transactional
     public void updateUser(Long userId, UserRegisterDto userRegisterDto) {
 
@@ -163,26 +170,15 @@ public class UserService {
     @Transactional(readOnly = true)
     public Map<LocalDate, Long> getDailyNewUsersCount(LocalDate startDate, LocalDate endDate) {
         Map<LocalDate, Long> result = new LinkedHashMap<>();
-        List<User> allUsers = userRepository.findAll();
+        userRepository.countDailyNewUsers(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX))
+                .forEach(row -> result.put(toLocalDate(row[0]), (Long) row[1]));
 
-        // 최근 날짜가 위로 오도록 역순으로 조회
+        Map<LocalDate, Long> orderedResult = new LinkedHashMap<>();
         for (LocalDate date = endDate; !date.isBefore(startDate); date = date.minusDays(1)) {
-            LocalDateTime startOfDay = date.atStartOfDay();
-            LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
-
-            long count = allUsers.stream()
-                    .filter(user -> {
-                        LocalDateTime createdAt = user.getCreatedAt();
-                        return createdAt != null &&
-                                !createdAt.isBefore(startOfDay) &&
-                                !createdAt.isAfter(endOfDay);
-                    })
-                    .count();
-
-            result.put(date, count);
+            orderedResult.put(date, result.getOrDefault(date, 0L));
         }
 
-        return result;
+        return orderedResult;
     }
 
     @Transactional(readOnly = true)
@@ -190,15 +186,24 @@ public class UserService {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 
-        return userRepository.findAll().stream()
-                .filter(user -> {
-                    LocalDateTime createdAt = user.getCreatedAt();
-                    return createdAt != null &&
-                            !createdAt.isBefore(startOfDay) &&
-                            !createdAt.isAfter(endOfDay);
-                })
-                .sorted((u1, u2) -> u2.getCreatedAt().compareTo(u1.getCreatedAt()))
+        return userRepository.findAllByCreatedAtBetweenOrderByCreatedAtDesc(startOfDay, endOfDay).stream()
                 .map(UserResponseDto::from)
                 .collect(Collectors.toList());
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof LocalDate localDate) {
+            return localDate;
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime.toLocalDate();
+        }
+        if (value instanceof Date date) {
+            return date.toLocalDate();
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toLocalDateTime().toLocalDate();
+        }
+        return LocalDate.parse(value.toString());
     }
 }

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -90,8 +90,8 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
             </svg>
           </div>
-          <h3 class="text-xl font-semibold text-gray-800 mb-2">복습 관리</h3>
-          <p class="text-gray-600 text-sm">복습노트 및 복습 기록 조회</p>
+          <h3 class="text-xl font-semibold text-gray-800 mb-2">복습노트 관리</h3>
+          <p class="text-gray-600 text-sm">복습노트 목록 조회</p>
         </div>
       </a>
 
@@ -124,8 +124,8 @@
         <a th:href="@{/admin/problems(page=0)}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
           <p class="text-sm text-gray-600">최신 문제 목록 보기</p>
         </a>
-        <a th:href="@{/admin/practice-notes}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
-          <p class="text-sm text-gray-600">복습 목록 보기</p>
+        <a th:href="@{/admin/practice-logs}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
+          <p class="text-sm text-gray-600">복습 기록 보기</p>
         </a>
         <a th:href="@{/admin/analysis}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
           <p class="text-sm text-gray-600">통계 보기</p>

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -18,6 +18,9 @@
           <a th:href="@{/admin/main}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             대시보드
           </a>
+          <a th:href="@{/admin/practice-notes}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
+            복습
+          </a>
           <form th:action="@{/logout}" method="post">
             <button type="submit" class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium transition duration-150">
               로그아웃
@@ -37,7 +40,7 @@
     </div>
 
     <!-- Grid Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       <!-- Users Card -->
       <a th:href="@{/admin/users}" class="block group">
         <div class="bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 p-6 border-l-4 border-blue-500">
@@ -74,6 +77,24 @@
         </div>
       </a>
 
+      <!-- Practice Notes Card -->
+      <a th:href="@{/admin/practice-notes}" class="block group">
+        <div class="bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 p-6 border-l-4 border-pink-500">
+          <div class="flex items-center justify-between mb-4">
+            <div class="p-3 bg-pink-100 rounded-full">
+              <svg class="w-8 h-8 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2m4-2a8 8 0 11-16 0 8 8 0 0116 0z"></path>
+              </svg>
+            </div>
+            <svg class="w-6 h-6 text-gray-400 group-hover:text-pink-600 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+            </svg>
+          </div>
+          <h3 class="text-xl font-semibold text-gray-800 mb-2">복습 관리</h3>
+          <p class="text-gray-600 text-sm">복습노트 및 복습 기록 조회</p>
+        </div>
+      </a>
+
       <!-- Analytics Card -->
       <a th:href="@{/admin/analysis}" class="block group">
         <div class="bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 p-6 border-l-4 border-purple-500">
@@ -96,12 +117,15 @@
     <!-- Quick Stats -->
     <div class="mt-12 bg-white rounded-lg shadow-md p-6">
       <h3 class="text-lg font-semibold text-gray-800 mb-4">빠른 이동</h3>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
         <a th:href="@{/admin/users(page=0)}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
           <p class="text-sm text-gray-600">최신 유저 목록 보기</p>
         </a>
         <a th:href="@{/admin/problems(page=0)}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
           <p class="text-sm text-gray-600">최신 문제 목록 보기</p>
+        </a>
+        <a th:href="@{/admin/practice-notes}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
+          <p class="text-sm text-gray-600">복습 목록 보기</p>
         </a>
         <a th:href="@{/admin/analysis}" class="text-center p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors">
           <p class="text-sm text-gray-600">통계 보기</p>

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -47,6 +47,31 @@
       <p class="text-gray-600 mt-1">OnO 애플리케이션 통계 개요</p>
     </div>
 
+    <form th:action="@{/admin/analysis}" method="get" class="mb-8 bg-white rounded-lg shadow-md p-4">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+        <div>
+          <label for="startDate" class="block text-sm font-medium text-gray-700 mb-1">시작일</label>
+          <input id="startDate" name="startDate" type="date" th:value="${startDate}"
+                 class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+        </div>
+        <div>
+          <label for="endDate" class="block text-sm font-medium text-gray-700 mb-1">종료일</label>
+          <input id="endDate" name="endDate" type="date" th:value="${endDate}"
+                 class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+        </div>
+        <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition">
+          기간 적용
+        </button>
+      </div>
+      <p class="mt-3 text-xs text-gray-500">
+        현재 기간:
+        <span th:text="${#temporals.format(startDate, 'yyyy-MM-dd')}">2024-01-01</span>
+        부터
+        <span th:text="${#temporals.format(endDate, 'yyyy-MM-dd')}">2024-01-30</span>
+        까지
+      </p>
+    </form>
+
     <!-- Key Metrics -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
       <!-- Total Users -->
@@ -100,15 +125,15 @@
           </div>
         </div>
         <div class="mt-4">
-          <p class="text-xs text-gray-500">최근 30일 기준</p>
+          <p class="text-xs text-gray-500">선택 기간 기준</p>
         </div>
       </div>
 
-      <!-- Recent 30 Days New Users -->
+      <!-- Selected Period New Users -->
       <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-orange-500">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500 uppercase">최근 30일 가입자 수</p>
+            <p class="text-sm font-medium text-gray-500 uppercase">선택 기간 가입자 수</p>
             <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${recentNewUsersCount}">0</p>
           </div>
           <div class="p-3 bg-orange-100 rounded-full">
@@ -118,7 +143,7 @@
           </div>
         </div>
         <div class="mt-4">
-          <p class="text-xs text-gray-500">지난 30일간 신규 가입</p>
+          <p class="text-xs text-gray-500">선택 기간 신규 가입</p>
         </div>
       </div>
 
@@ -186,7 +211,7 @@
     <!-- Daily Active Users -->
     <div class="bg-white rounded-lg shadow-md overflow-hidden mb-8">
       <div class="px-6 py-4 bg-gray-50 border-b border-gray-200">
-        <h3 class="text-lg font-semibold text-gray-900">날짜별 출석 유저 수 (최근 30일)</h3>
+        <h3 class="text-lg font-semibold text-gray-900">날짜별 출석 유저 수</h3>
       </div>
       <div class="p-6">
         <div class="overflow-x-auto">

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -26,6 +26,9 @@
           <a th:href="@{/admin/problems}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             문제
           </a>
+          <a th:href="@{/admin/practice-notes}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
+            복습
+          </a>
           <a th:href="@{/admin/analysis}" class="text-indigo-600 px-3 py-2 rounded-md text-sm font-medium border-b-2 border-indigo-600">
             통계
           </a>
@@ -265,7 +268,7 @@
     <!-- Quick Actions -->
     <div class="bg-white rounded-lg shadow-md p-6">
       <h3 class="text-lg font-semibold text-gray-900 mb-4">빠른 이동</h3>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
         <a th:href="@{/admin/users}" class="flex items-center p-4 bg-blue-50 hover:bg-blue-100 rounded-lg transition-colors group">
           <div class="p-2 bg-blue-200 rounded-lg group-hover:bg-blue-300 transition-colors">
             <svg class="w-6 h-6 text-blue-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -287,6 +290,18 @@
           <div class="ml-4">
             <p class="text-sm font-medium text-gray-900">문제 관리</p>
             <p class="text-xs text-gray-500">모든 유저 문제 보기</p>
+          </div>
+        </a>
+
+        <a th:href="@{/admin/practice-notes}" class="flex items-center p-4 bg-pink-50 hover:bg-pink-100 rounded-lg transition-colors group">
+          <div class="p-2 bg-pink-200 rounded-lg group-hover:bg-pink-300 transition-colors">
+            <svg class="w-6 h-6 text-pink-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2m4-2a8 8 0 11-16 0 8 8 0 0116 0z"></path>
+            </svg>
+          </div>
+          <div class="ml-4">
+            <p class="text-sm font-medium text-gray-900">복습 관리</p>
+            <p class="text-xs text-gray-500">복습노트 및 기록 보기</p>
           </div>
         </a>
 

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -130,10 +130,27 @@
       </div>
 
       <!-- Average Daily Visitors -->
+      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-cyan-500">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium text-gray-500 uppercase">선택 기간 고유 방문 유저</p>
+            <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${periodUniqueVisitorCount}">0</p>
+          </div>
+          <div class="p-3 bg-cyan-100 rounded-full">
+            <svg class="w-8 h-8 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 18.72a9.094 9.094 0 003.75.78 9 9 0 00-9-9 9.094 9.094 0 00-3.75.78M18 18.72A8.966 8.966 0 0112.75 21a8.966 8.966 0 01-5.25-2.28M18 18.72A5.985 5.985 0 0012.75 15a5.985 5.985 0 00-5.25 3.72M15.75 6a3 3 0 11-6 0 3 3 0 016 0z"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="mt-4">
+          <p class="text-xs text-gray-500">선택 기간 로그인한 서로 다른 유저</p>
+        </div>
+      </div>
+
       <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-purple-500">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500 uppercase">하루 평균 방문자 수</p>
+            <p class="text-sm font-medium text-gray-500 uppercase">선택 기간 평균 DAU</p>
             <p class="mt-2 text-3xl font-bold text-gray-900"
                th:text="${#numbers.formatDecimal(averageDailyVisitors, 1, 1)}">0.0</p>
           </div>
@@ -144,7 +161,7 @@
           </div>
         </div>
         <div class="mt-4">
-          <p class="text-xs text-gray-500">선택 기간 기준</p>
+          <p class="text-xs text-gray-500">날짜별 출석 유저 수 평균</p>
         </div>
       </div>
 
@@ -225,6 +242,15 @@
               <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
                 <span class="text-sm font-medium text-gray-600">선택 기간 방문 횟수</span>
                 <span class="text-sm font-bold text-gray-900" th:text="${periodVisitCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 고유 방문 유저</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${periodUniqueVisitorCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 평균 DAU</span>
+                <span class="text-sm font-bold text-gray-900"
+                      th:text="${#numbers.formatDecimal(averageDailyVisitors, 1, 1)}">0.0</span>
               </div>
             </div>
           </div>

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -130,6 +130,41 @@
       </div>
 
       <!-- Average Daily Visitors -->
+      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-emerald-500">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium text-gray-500 uppercase">선택 기간 문제 등록 수</p>
+            <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${periodProblemCount}">0</p>
+          </div>
+          <div class="p-3 bg-emerald-100 rounded-full">
+            <svg class="w-8 h-8 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="mt-4">
+          <p class="text-xs text-gray-500">선택 기간 작성된 문제</p>
+        </div>
+      </div>
+
+      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-red-500">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium text-gray-500 uppercase">선택 기간 분석 실패율</p>
+            <p class="mt-2 text-3xl font-bold text-gray-900"
+               th:text="${#numbers.formatDecimal(periodAnalysisFailureRate, 1, 1)} + '%'">0.0%</p>
+          </div>
+          <div class="p-3 bg-red-100 rounded-full">
+            <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="mt-4">
+          <p class="text-xs text-gray-500">완료/실패 처리된 분석 기준</p>
+        </div>
+      </div>
+
       <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-cyan-500">
         <div class="flex items-center justify-between">
           <div>
@@ -268,6 +303,59 @@
                 <span class="text-sm font-medium text-gray-600">총 문제 수</span>
                 <span class="text-sm font-bold text-gray-900" th:text="${allProblemCount}">0</span>
               </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 문제 등록</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${periodProblemCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">총 분석 데이터 수</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${allProblemAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">전체 분석 완료</span>
+                <span class="text-sm font-bold text-green-700" th:text="${allCompletedAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">전체 분석 실패</span>
+                <span class="text-sm font-bold text-red-700" th:text="${allFailedAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">전체 분석 중</span>
+                <span class="text-sm font-bold text-yellow-700" th:text="${allProcessingAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">전체 분석 대기</span>
+                <span class="text-sm font-bold text-blue-700" th:text="${allNotStartedAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">전체 이미지 없음</span>
+                <span class="text-sm font-bold text-gray-700" th:text="${allNoImageAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 분석 완료</span>
+                <span class="text-sm font-bold text-green-700" th:text="${periodCompletedAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 분석 실패</span>
+                <span class="text-sm font-bold text-red-700" th:text="${periodFailedAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 분석 실패율</span>
+                <span class="text-sm font-bold text-red-700"
+                      th:text="${#numbers.formatDecimal(periodAnalysisFailureRate, 1, 1)} + '%'">0.0%</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 분석 중</span>
+                <span class="text-sm font-bold text-yellow-700" th:text="${periodProcessingAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 분석 대기</span>
+                <span class="text-sm font-bold text-blue-700" th:text="${periodNotStartedAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 이미지 없음</span>
+                <span class="text-sm font-bold text-gray-700" th:text="${periodNoImageAnalysisCount}">0</span>
+              </div>
             </div>
           </div>
 
@@ -316,6 +404,7 @@
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">방문 횟수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">출석 유저 수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">신규 가입자 수</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">문제 등록 수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습노트 생성 수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습 수행 수</th>
               </tr>
@@ -353,6 +442,11 @@
                   </span>
                 </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                  <span class="font-semibold" th:classappend="${dailyProblems[entry.key] > 0 ? 'text-emerald-600' : 'text-gray-400'}"
+                        th:text="${dailyProblems[entry.key]}">0</span>
+                  <span class="ml-1 text-gray-500">개</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
                   <span class="font-semibold" th:classappend="${dailyPracticeNotes[entry.key] > 0 ? 'text-pink-600' : 'text-gray-400'}"
                         th:text="${dailyPracticeNotes[entry.key]}">0</span>
                   <span class="ml-1 text-gray-500">개</span>
@@ -364,7 +458,7 @@
                 </td>
               </tr>
               <tr th:if="${#maps.isEmpty(dailyActiveUsers)}">
-                <td colspan="6" class="px-4 py-8 text-center text-gray-500">
+                <td colspan="7" class="px-4 py-8 text-center text-gray-500">
                   데이터가 없습니다
                 </td>
               </tr>
@@ -383,6 +477,10 @@
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
                   <span class="font-bold text-orange-700" th:text="${recentNewUsersCount}">0</span>
                   <span class="ml-1 text-gray-500">명</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                  <span class="font-bold text-emerald-700" th:text="${periodProblemCount}">0</span>
+                  <span class="ml-1 text-gray-500">개</span>
                 </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
                   <span class="font-bold text-pink-700" th:text="${periodPracticeNoteCount}">0</span>

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -50,29 +50,45 @@
       <p class="text-gray-600 mt-1">OnO 애플리케이션 통계 개요</p>
     </div>
 
-    <form th:action="@{/admin/analysis}" method="get" class="mb-8 bg-white rounded-lg shadow-md p-4">
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+    <form th:action="@{/admin/analysis}" method="get" class="mb-8 bg-white rounded-lg shadow-md border border-gray-100 overflow-hidden">
+      <div class="px-5 py-4 bg-gray-50 border-b border-gray-100 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <label for="startDate" class="block text-sm font-medium text-gray-700 mb-1">시작일</label>
-          <input id="startDate" name="startDate" type="date" th:value="${startDate}"
-                 class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+          <p class="text-sm font-semibold text-gray-900">기간별 통계 조회</p>
+          <p class="mt-1 text-xs text-gray-500">
+            <span th:text="${#temporals.format(startDate, 'yyyy-MM-dd')}">2024-01-01</span>
+            부터
+            <span th:text="${#temporals.format(endDate, 'yyyy-MM-dd')}">2024-01-30</span>
+            까지
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <a th:href="@{/admin/analysis(startDate=${quickStart7Days}, endDate=${today})}"
+             class="px-3 py-2 bg-white border border-gray-200 rounded-md text-xs font-medium text-gray-700 hover:border-indigo-300 hover:text-indigo-700 transition">최근 7일</a>
+          <a th:href="@{/admin/analysis(startDate=${quickStart30Days}, endDate=${today})}"
+             class="px-3 py-2 bg-white border border-gray-200 rounded-md text-xs font-medium text-gray-700 hover:border-indigo-300 hover:text-indigo-700 transition">최근 30일</a>
+          <a th:href="@{/admin/analysis(startDate=${quickStart90Days}, endDate=${today})}"
+             class="px-3 py-2 bg-white border border-gray-200 rounded-md text-xs font-medium text-gray-700 hover:border-indigo-300 hover:text-indigo-700 transition">최근 90일</a>
+        </div>
+      </div>
+      <div class="p-5 grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-4 items-end">
+        <div>
+          <label for="startDate" class="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">시작일</label>
+          <div class="relative">
+            <input id="startDate" name="startDate" type="date" th:value="${startDate}"
+                   class="w-full h-11 rounded-lg border border-gray-200 bg-gray-50 px-4 text-sm text-gray-900 shadow-sm outline-none transition focus:border-indigo-500 focus:bg-white focus:ring-4 focus:ring-indigo-100">
+          </div>
         </div>
         <div>
-          <label for="endDate" class="block text-sm font-medium text-gray-700 mb-1">종료일</label>
-          <input id="endDate" name="endDate" type="date" th:value="${endDate}"
-                 class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+          <label for="endDate" class="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">종료일</label>
+          <div class="relative">
+            <input id="endDate" name="endDate" type="date" th:value="${endDate}"
+                   class="w-full h-11 rounded-lg border border-gray-200 bg-gray-50 px-4 text-sm text-gray-900 shadow-sm outline-none transition focus:border-indigo-500 focus:bg-white focus:ring-4 focus:ring-indigo-100">
+          </div>
         </div>
-        <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition">
-          기간 적용
+        <button type="submit" class="h-11 bg-indigo-600 hover:bg-indigo-700 text-white px-5 rounded-lg text-sm font-semibold shadow-sm transition">
+          적용
         </button>
       </div>
-      <p class="mt-3 text-xs text-gray-500">
-        현재 기간:
-        <span th:text="${#temporals.format(startDate, 'yyyy-MM-dd')}">2024-01-01</span>
-        부터
-        <span th:text="${#temporals.format(endDate, 'yyyy-MM-dd')}">2024-01-30</span>
-        까지
-      </p>
     </form>
 
     <!-- Key Metrics -->

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -222,6 +222,10 @@
                 <span class="text-sm font-medium text-gray-600">총 유저 수</span>
                 <span class="text-sm font-bold text-gray-900" th:text="${allUserCount}">0</span>
               </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 방문 횟수</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${periodVisitCount}">0</span>
+              </div>
             </div>
           </div>
 
@@ -283,6 +287,7 @@
             <thead class="bg-gray-50">
               <tr>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">날짜</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">방문 횟수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">출석 유저 수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">신규 가입자 수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습노트 생성 수</th>
@@ -292,6 +297,11 @@
             <tbody class="bg-white divide-y divide-gray-200">
               <tr th:each="entry : ${dailyActiveUsers}" class="hover:bg-gray-50">
                 <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900" th:text="${#temporals.format(entry.key, 'yyyy-MM-dd (E)')}">2024-01-01</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                  <span class="font-semibold" th:classappend="${dailyVisits[entry.key] > 0 ? 'text-cyan-600' : 'text-gray-400'}"
+                        th:text="${dailyVisits[entry.key]}">0</span>
+                  <span class="ml-1 text-gray-500">회</span>
+                </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
                   <a th:if="${entry.value > 0}"
                      th:href="@{/admin/analysis/daily-active-users(date=${entry.key})}"
@@ -328,11 +338,36 @@
                 </td>
               </tr>
               <tr th:if="${#maps.isEmpty(dailyActiveUsers)}">
-                <td colspan="5" class="px-4 py-8 text-center text-gray-500">
+                <td colspan="6" class="px-4 py-8 text-center text-gray-500">
                   데이터가 없습니다
                 </td>
               </tr>
             </tbody>
+            <tfoot class="bg-gray-50 border-t border-gray-200">
+              <tr>
+                <td class="px-4 py-3 whitespace-nowrap text-sm font-bold text-gray-900">합계</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                  <span class="font-bold text-cyan-700" th:text="${periodVisitCount}">0</span>
+                  <span class="ml-1 text-gray-500">회</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                  <span class="font-bold text-blue-700" th:text="${periodActiveUserCount}">0</span>
+                  <span class="ml-1 text-gray-500">명</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                  <span class="font-bold text-orange-700" th:text="${recentNewUsersCount}">0</span>
+                  <span class="ml-1 text-gray-500">명</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                  <span class="font-bold text-pink-700" th:text="${periodPracticeNoteCount}">0</span>
+                  <span class="ml-1 text-gray-500">개</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                  <span class="font-bold text-indigo-700" th:text="${periodPracticeLogCount}">0</span>
+                  <span class="ml-1 text-gray-500">회</span>
+                </td>
+              </tr>
+            </tfoot>
           </table>
         </div>
       </div>
@@ -373,8 +408,8 @@
             </svg>
           </div>
           <div class="ml-4">
-            <p class="text-sm font-medium text-gray-900">복습 관리</p>
-            <p class="text-xs text-gray-500">복습노트 및 기록 보기</p>
+            <p class="text-sm font-medium text-gray-900">복습노트 관리</p>
+            <p class="text-xs text-gray-500">복습노트 목록 보기</p>
           </div>
         </a>
 

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -151,20 +151,37 @@
       </div>
 
       <!-- System Health -->
-      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-indigo-500">
+      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-pink-500">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-gray-500 uppercase">시스템 상태</p>
-            <p class="mt-2 text-xl font-bold text-green-600">정상</p>
+            <p class="text-sm font-medium text-gray-500 uppercase">총 복습노트 수</p>
+            <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${allPracticeNoteCount}">0</p>
           </div>
-          <div class="p-3 bg-indigo-100 rounded-full">
-            <svg class="w-8 h-8 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          <div class="p-3 bg-pink-100 rounded-full">
+            <svg class="w-8 h-8 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2m4-2a8 8 0 11-16 0 8 8 0 0116 0z"></path>
             </svg>
           </div>
         </div>
         <div class="mt-4">
-          <p class="text-sm text-gray-500">모든 시스템 작동 중</p>
+          <a th:href="@{/admin/practice-notes}" class="text-sm text-pink-600 hover:text-pink-800 font-medium">복습 관리 보기 →</a>
+        </div>
+      </div>
+
+      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-indigo-500">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium text-gray-500 uppercase">총 복습 기록 수</p>
+            <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${allPracticeLogCount}">0</p>
+          </div>
+          <div class="p-3 bg-indigo-100 rounded-full">
+            <svg class="w-8 h-8 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2m-4 0V3m0 2v4m0-4h4m-4 0H7"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="mt-4">
+          <p class="text-xs text-gray-500">복습노트 사용 미션 기준</p>
         </div>
       </div>
     </div>
@@ -175,7 +192,7 @@
         <h3 class="text-lg font-semibold text-gray-900">상세 통계</h3>
       </div>
       <div class="p-6">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
           <!-- User Statistics -->
           <div>
             <h4 class="text-md font-semibold text-gray-800 mb-4 flex items-center">
@@ -207,6 +224,34 @@
               </div>
             </div>
           </div>
+
+          <!-- Practice Statistics -->
+          <div>
+            <h4 class="text-md font-semibold text-gray-800 mb-4 flex items-center">
+              <svg class="w-5 h-5 mr-2 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2m4-2a8 8 0 11-16 0 8 8 0 0116 0z"></path>
+              </svg>
+              복습 통계
+            </h4>
+            <div class="space-y-3">
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">총 복습노트 수</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${allPracticeNoteCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">총 복습 기록 수</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${allPracticeLogCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 복습노트 생성</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${periodPracticeNoteCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 복습 수행</span>
+                <span class="text-sm font-bold text-gray-900" th:text="${periodPracticeLogCount}">0</span>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -224,6 +269,8 @@
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">날짜</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">출석 유저 수</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">신규 가입자 수</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습노트 생성 수</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습 수행 수</th>
               </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
@@ -253,9 +300,19 @@
                     <span class="ml-1 text-gray-500">명</span>
                   </span>
                 </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                  <span class="font-semibold" th:classappend="${dailyPracticeNotes[entry.key] > 0 ? 'text-pink-600' : 'text-gray-400'}"
+                        th:text="${dailyPracticeNotes[entry.key]}">0</span>
+                  <span class="ml-1 text-gray-500">개</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                  <span class="font-semibold" th:classappend="${dailyPracticeLogs[entry.key] > 0 ? 'text-indigo-600' : 'text-gray-400'}"
+                        th:text="${dailyPracticeLogs[entry.key]}">0</span>
+                  <span class="ml-1 text-gray-500">회</span>
+                </td>
               </tr>
               <tr th:if="${#maps.isEmpty(dailyActiveUsers)}">
-                <td colspan="3" class="px-4 py-8 text-center text-gray-500">
+                <td colspan="5" class="px-4 py-8 text-center text-gray-500">
                   데이터가 없습니다
                 </td>
               </tr>

--- a/src/main/resources/templates/daily-users.html
+++ b/src/main/resources/templates/daily-users.html
@@ -26,6 +26,9 @@
           <a th:href="@{/admin/problems}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             문제
           </a>
+          <a th:href="@{/admin/practice-notes}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
+            복습
+          </a>
           <a th:href="@{/admin/analysis}" class="text-indigo-600 px-3 py-2 rounded-md text-sm font-medium border-b-2 border-indigo-600">
             통계
           </a>

--- a/src/main/resources/templates/practice-logs.html
+++ b/src/main/resources/templates/practice-logs.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OnO 관리자 - 복습 기록</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-gray-50 to-gray-100 min-h-screen">
+  <nav class="bg-white shadow-lg">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between h-16">
+        <div class="flex items-center">
+          <a th:href="@{/admin/main}">
+            <h1 class="text-2xl font-bold text-indigo-600">OnO 관리자</h1>
+          </a>
+        </div>
+        <div class="flex items-center space-x-4">
+          <a th:href="@{/admin/main}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">대시보드</a>
+          <a th:href="@{/admin/users}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">유저</a>
+          <a th:href="@{/admin/problems}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">문제</a>
+          <a th:href="@{/admin/practice-notes}" class="text-indigo-600 px-3 py-2 rounded-md text-sm font-medium border-b-2 border-indigo-600">복습</a>
+          <a th:href="@{/admin/analysis}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">통계</a>
+          <form th:action="@{/logout}" method="post">
+            <button type="submit" class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium transition duration-150">
+              로그아웃
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="mb-6 flex items-start justify-between">
+      <div>
+        <h2 class="text-2xl font-bold text-gray-900">복습 기록</h2>
+        <p class="text-gray-600 mt-1">
+          총 <span class="font-semibold text-pink-600" th:text="${totalPracticeLogs}">0</span>개
+        </p>
+      </div>
+      <a th:href="@{/admin/practice-notes}" class="px-4 py-2 bg-white border border-gray-200 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">
+        복습노트 목록
+      </a>
+    </div>
+
+    <section class="bg-white rounded-lg shadow-md overflow-hidden">
+      <div class="px-6 py-4 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+        <h3 class="text-lg font-semibold text-gray-900">복습 기록 목록</h3>
+        <form th:action="@{/admin/practice-logs}" method="get" class="flex items-center space-x-2">
+          <input type="hidden" name="logPage" value="0">
+          <select name="size" class="rounded-md border-gray-300 text-sm">
+            <option value="20" th:selected="${size == 20}">20개</option>
+            <option value="50" th:selected="${size == 50}">50개</option>
+            <option value="100" th:selected="${size == 100}">100개</option>
+          </select>
+          <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-2 rounded-md text-sm font-medium">적용</button>
+        </form>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">기록 ID</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">유저</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습노트</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">포인트</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">완료일</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-200">
+            <tr th:each="log : ${practiceLogs}" class="hover:bg-gray-50">
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" th:text="${log.missionLogId}">1</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <a th:href="@{/admin/user/{userId}(userId=${log.userId})}" class="text-indigo-600 hover:text-indigo-800 font-medium" th:text="${log.userName}">유저</a>
+                <p class="text-xs text-gray-500" th:text="${log.userEmail}">user@example.com</p>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-900">
+                <span th:text="${log.practiceTitle}">복습노트</span>
+                <span class="text-xs text-gray-500" th:text="'#' + ${log.practiceNoteId}">#1</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${log.point} + 'pt'">15pt</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${#temporals.format(log.createdAt, 'yyyy-MM-dd HH:mm')}">2024-01-01 00:00</td>
+            </tr>
+            <tr th:if="${#lists.isEmpty(practiceLogs)}">
+              <td colspan="5" class="px-6 py-8 text-center text-gray-500">복습 기록이 없습니다</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div th:if="${logTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex flex-wrap justify-end gap-2">
+        <a th:if="${logPage > 0}" th:href="@{/admin/practice-logs(logPage=${logPage - 1}, size=${size})}"
+           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">이전</a>
+        <span th:if="${logPage == 0}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">이전</span>
+
+        <a th:if="${hasPreviousLogBlock}" th:href="@{/admin/practice-logs(logPage=${logPageBlockStart - 10}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&lt;&lt;</a>
+        <span th:unless="${hasPreviousLogBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&lt;&lt;</span>
+
+        <span th:each="page : ${#numbers.sequence(logPageBlockStart, logPageBlockEnd)}">
+          <a th:if="${page == logPage}"
+             class="px-4 py-2 bg-indigo-600 border border-indigo-600 rounded-md text-sm font-medium text-white" th:text="${page + 1}">1</a>
+          <a th:if="${page != logPage}" th:href="@{/admin/practice-logs(logPage=${page}, size=${size})}"
+             class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50" th:text="${page + 1}">1</a>
+        </span>
+
+        <a th:if="${hasNextLogBlock}" th:href="@{/admin/practice-logs(logPage=${logPageBlockStart + 10}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&gt;&gt;</a>
+        <span th:unless="${hasNextLogBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&gt;&gt;</span>
+
+        <a th:if="${logPage < logTotalPages - 1}" th:href="@{/admin/practice-logs(logPage=${logPage + 1}, size=${size})}"
+           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">다음</a>
+        <span th:if="${logPage >= logTotalPages - 1}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">다음</span>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/practice-notes.html
+++ b/src/main/resources/templates/practice-notes.html
@@ -101,13 +101,26 @@
         </table>
       </div>
 
-      <div th:if="${noteTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end space-x-2">
+      <div th:if="${noteTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex flex-wrap justify-end gap-2">
         <a th:if="${notePage > 0}" th:href="@{/admin/practice-notes(notePage=${notePage - 1}, logPage=${logPage}, size=${size})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">이전</a>
         <span th:if="${notePage == 0}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">이전</span>
-        <span class="px-4 py-2 text-sm text-gray-600">
-          <span th:text="${notePage + 1}">1</span> / <span th:text="${noteTotalPages}">1</span>
+
+        <a th:if="${hasPreviousNoteBlock}" th:href="@{/admin/practice-notes(notePage=${notePageBlockStart - 10}, logPage=${logPage}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&lt;&lt;</a>
+        <span th:unless="${hasPreviousNoteBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&lt;&lt;</span>
+
+        <span th:each="page : ${#numbers.sequence(notePageBlockStart, notePageBlockEnd)}">
+          <a th:if="${page == notePage}"
+             class="px-4 py-2 bg-indigo-600 border border-indigo-600 rounded-md text-sm font-medium text-white" th:text="${page + 1}">1</a>
+          <a th:if="${page != notePage}" th:href="@{/admin/practice-notes(notePage=${page}, logPage=${logPage}, size=${size})}"
+             class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50" th:text="${page + 1}">1</a>
         </span>
+
+        <a th:if="${hasNextNoteBlock}" th:href="@{/admin/practice-notes(notePage=${notePageBlockStart + 10}, logPage=${logPage}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&gt;&gt;</a>
+        <span th:unless="${hasNextNoteBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&gt;&gt;</span>
+
         <a th:if="${notePage < noteTotalPages - 1}" th:href="@{/admin/practice-notes(notePage=${notePage + 1}, logPage=${logPage}, size=${size})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">다음</a>
         <span th:if="${notePage >= noteTotalPages - 1}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">다음</span>
@@ -150,13 +163,26 @@
         </table>
       </div>
 
-      <div th:if="${logTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end space-x-2">
+      <div th:if="${logTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex flex-wrap justify-end gap-2">
         <a th:if="${logPage > 0}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPage - 1}, size=${size})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">이전</a>
         <span th:if="${logPage == 0}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">이전</span>
-        <span class="px-4 py-2 text-sm text-gray-600">
-          <span th:text="${logPage + 1}">1</span> / <span th:text="${logTotalPages}">1</span>
+
+        <a th:if="${hasPreviousLogBlock}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPageBlockStart - 10}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&lt;&lt;</a>
+        <span th:unless="${hasPreviousLogBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&lt;&lt;</span>
+
+        <span th:each="page : ${#numbers.sequence(logPageBlockStart, logPageBlockEnd)}">
+          <a th:if="${page == logPage}"
+             class="px-4 py-2 bg-indigo-600 border border-indigo-600 rounded-md text-sm font-medium text-white" th:text="${page + 1}">1</a>
+          <a th:if="${page != logPage}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${page}, size=${size})}"
+             class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50" th:text="${page + 1}">1</a>
         </span>
+
+        <a th:if="${hasNextLogBlock}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPageBlockStart + 10}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&gt;&gt;</a>
+        <span th:unless="${hasNextLogBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&gt;&gt;</span>
+
         <a th:if="${logPage < logTotalPages - 1}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPage + 1}, size=${size})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">다음</a>
         <span th:if="${logPage >= logTotalPages - 1}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">다음</span>

--- a/src/main/resources/templates/practice-notes.html
+++ b/src/main/resources/templates/practice-notes.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OnO 관리자 - 복습 관리</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-gray-50 to-gray-100 min-h-screen">
+  <nav class="bg-white shadow-lg">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between h-16">
+        <div class="flex items-center">
+          <a th:href="@{/admin/main}">
+            <h1 class="text-2xl font-bold text-indigo-600">OnO 관리자</h1>
+          </a>
+        </div>
+        <div class="flex items-center space-x-4">
+          <a th:href="@{/admin/main}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">대시보드</a>
+          <a th:href="@{/admin/users}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">유저</a>
+          <a th:href="@{/admin/problems}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">문제</a>
+          <a th:href="@{/admin/practice-notes}" class="text-indigo-600 px-3 py-2 rounded-md text-sm font-medium border-b-2 border-indigo-600">복습</a>
+          <a th:href="@{/admin/analysis}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">통계</a>
+          <form th:action="@{/logout}" method="post">
+            <button type="submit" class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium transition duration-150">
+              로그아웃
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="mb-6">
+      <h2 class="text-2xl font-bold text-gray-900">복습 관리</h2>
+      <p class="text-gray-600 mt-1">
+        복습노트 <span class="font-semibold text-indigo-600" th:text="${totalPracticeNotes}">0</span>개,
+        복습 기록 <span class="font-semibold text-pink-600" th:text="${totalPracticeLogs}">0</span>개
+      </p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-indigo-500">
+        <p class="text-sm font-medium text-gray-500 uppercase">총 복습노트 수</p>
+        <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${totalPracticeNotes}">0</p>
+      </div>
+      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-pink-500">
+        <p class="text-sm font-medium text-gray-500 uppercase">총 복습 기록 수</p>
+        <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${totalPracticeLogs}">0</p>
+      </div>
+    </div>
+
+    <section class="bg-white rounded-lg shadow-md overflow-hidden mb-8">
+      <div class="px-6 py-4 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+        <h3 class="text-lg font-semibold text-gray-900">복습노트 목록</h3>
+        <form th:action="@{/admin/practice-notes}" method="get" class="flex items-center space-x-2">
+          <input type="hidden" name="notePage" value="0">
+          <input type="hidden" name="logPage" th:value="${logPage}">
+          <select name="size" class="rounded-md border-gray-300 text-sm">
+            <option value="20" th:selected="${size == 20}">20개</option>
+            <option value="50" th:selected="${size == 50}">50개</option>
+            <option value="100" th:selected="${size == 100}">100개</option>
+          </select>
+          <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-2 rounded-md text-sm font-medium">적용</button>
+        </form>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습노트 ID</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">유저</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">제목</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">문제 수</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습 횟수</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">마지막 복습일</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">작성일</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-200">
+            <tr th:each="note : ${practiceNotes}" class="hover:bg-gray-50">
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" th:text="${note.practiceNoteId}">1</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <a th:href="@{/admin/user/{userId}(userId=${note.userId})}" class="text-indigo-600 hover:text-indigo-800 font-medium" th:text="${note.userName}">유저</a>
+                <p class="text-xs text-gray-500" th:text="${note.userEmail}">user@example.com</p>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-900" th:text="${note.practiceTitle}">복습노트</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${note.problemCount}">0</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${note.practiceCount}">0</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <span th:if="${note.lastSolvedAt != null}" th:text="${#temporals.format(note.lastSolvedAt, 'yyyy-MM-dd HH:mm')}">2024-01-01 00:00</span>
+                <span th:unless="${note.lastSolvedAt != null}" class="text-gray-400">-</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${#temporals.format(note.createdAt, 'yyyy-MM-dd HH:mm')}">2024-01-01 00:00</td>
+            </tr>
+            <tr th:if="${#lists.isEmpty(practiceNotes)}">
+              <td colspan="7" class="px-6 py-8 text-center text-gray-500">복습노트가 없습니다</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div th:if="${noteTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end space-x-2">
+        <a th:if="${notePage > 0}" th:href="@{/admin/practice-notes(notePage=${notePage - 1}, logPage=${logPage}, size=${size})}"
+           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">이전</a>
+        <span th:if="${notePage == 0}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">이전</span>
+        <span class="px-4 py-2 text-sm text-gray-600">
+          <span th:text="${notePage + 1}">1</span> / <span th:text="${noteTotalPages}">1</span>
+        </span>
+        <a th:if="${notePage < noteTotalPages - 1}" th:href="@{/admin/practice-notes(notePage=${notePage + 1}, logPage=${logPage}, size=${size})}"
+           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">다음</a>
+        <span th:if="${notePage >= noteTotalPages - 1}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">다음</span>
+      </div>
+    </section>
+
+    <section class="bg-white rounded-lg shadow-md overflow-hidden">
+      <div class="px-6 py-4 bg-gray-50 border-b border-gray-200">
+        <h3 class="text-lg font-semibold text-gray-900">복습 기록</h3>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">기록 ID</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">유저</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습노트</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">포인트</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">완료일</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-200">
+            <tr th:each="log : ${practiceLogs}" class="hover:bg-gray-50">
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" th:text="${log.missionLogId}">1</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <a th:href="@{/admin/user/{userId}(userId=${log.userId})}" class="text-indigo-600 hover:text-indigo-800 font-medium" th:text="${log.userName}">유저</a>
+                <p class="text-xs text-gray-500" th:text="${log.userEmail}">user@example.com</p>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-900">
+                <span th:text="${log.practiceTitle}">복습노트</span>
+                <span class="text-xs text-gray-500" th:text="'#' + ${log.practiceNoteId}">#1</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${log.point} + 'pt'">15pt</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${#temporals.format(log.createdAt, 'yyyy-MM-dd HH:mm')}">2024-01-01 00:00</td>
+            </tr>
+            <tr th:if="${#lists.isEmpty(practiceLogs)}">
+              <td colspan="5" class="px-6 py-8 text-center text-gray-500">복습 기록이 없습니다</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div th:if="${logTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end space-x-2">
+        <a th:if="${logPage > 0}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPage - 1}, size=${size})}"
+           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">이전</a>
+        <span th:if="${logPage == 0}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">이전</span>
+        <span class="px-4 py-2 text-sm text-gray-600">
+          <span th:text="${logPage + 1}">1</span> / <span th:text="${logTotalPages}">1</span>
+        </span>
+        <a th:if="${logPage < logTotalPages - 1}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPage + 1}, size=${size})}"
+           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">다음</a>
+        <span th:if="${logPage >= logTotalPages - 1}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">다음</span>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/practice-notes.html
+++ b/src/main/resources/templates/practice-notes.html
@@ -35,8 +35,7 @@
     <div class="mb-6">
       <h2 class="text-2xl font-bold text-gray-900">복습 관리</h2>
       <p class="text-gray-600 mt-1">
-        복습노트 <span class="font-semibold text-indigo-600" th:text="${totalPracticeNotes}">0</span>개,
-        복습 기록 <span class="font-semibold text-pink-600" th:text="${totalPracticeLogs}">0</span>개
+        복습노트 <span class="font-semibold text-indigo-600" th:text="${totalPracticeNotes}">0</span>개
       </p>
     </div>
 
@@ -45,10 +44,10 @@
         <p class="text-sm font-medium text-gray-500 uppercase">총 복습노트 수</p>
         <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${totalPracticeNotes}">0</p>
       </div>
-      <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-pink-500">
-        <p class="text-sm font-medium text-gray-500 uppercase">총 복습 기록 수</p>
-        <p class="mt-2 text-3xl font-bold text-gray-900" th:text="${totalPracticeLogs}">0</p>
-      </div>
+      <a th:href="@{/admin/practice-logs}" class="bg-white rounded-lg shadow-md p-6 border-l-4 border-pink-500 hover:bg-pink-50 transition">
+        <p class="text-sm font-medium text-gray-500 uppercase">복습 기록</p>
+        <p class="mt-2 text-lg font-bold text-gray-900">복습 기록 페이지로 이동</p>
+      </a>
     </div>
 
     <section class="bg-white rounded-lg shadow-md overflow-hidden mb-8">
@@ -56,7 +55,6 @@
         <h3 class="text-lg font-semibold text-gray-900">복습노트 목록</h3>
         <form th:action="@{/admin/practice-notes}" method="get" class="flex items-center space-x-2">
           <input type="hidden" name="notePage" value="0">
-          <input type="hidden" name="logPage" th:value="${logPage}">
           <select name="size" class="rounded-md border-gray-300 text-sm">
             <option value="20" th:selected="${size == 20}">20개</option>
             <option value="50" th:selected="${size == 50}">50개</option>
@@ -102,92 +100,31 @@
       </div>
 
       <div th:if="${noteTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex flex-wrap justify-end gap-2">
-        <a th:if="${notePage > 0}" th:href="@{/admin/practice-notes(notePage=${notePage - 1}, logPage=${logPage}, size=${size})}"
+        <a th:if="${notePage > 0}" th:href="@{/admin/practice-notes(notePage=${notePage - 1}, size=${size})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">이전</a>
         <span th:if="${notePage == 0}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">이전</span>
 
-        <a th:if="${hasPreviousNoteBlock}" th:href="@{/admin/practice-notes(notePage=${notePageBlockStart - 10}, logPage=${logPage}, size=${size})}"
+        <a th:if="${hasPreviousNoteBlock}" th:href="@{/admin/practice-notes(notePage=${notePageBlockStart - 10}, size=${size})}"
            class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&lt;&lt;</a>
         <span th:unless="${hasPreviousNoteBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&lt;&lt;</span>
 
         <span th:each="page : ${#numbers.sequence(notePageBlockStart, notePageBlockEnd)}">
           <a th:if="${page == notePage}"
              class="px-4 py-2 bg-indigo-600 border border-indigo-600 rounded-md text-sm font-medium text-white" th:text="${page + 1}">1</a>
-          <a th:if="${page != notePage}" th:href="@{/admin/practice-notes(notePage=${page}, logPage=${logPage}, size=${size})}"
+          <a th:if="${page != notePage}" th:href="@{/admin/practice-notes(notePage=${page}, size=${size})}"
              class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50" th:text="${page + 1}">1</a>
         </span>
 
-        <a th:if="${hasNextNoteBlock}" th:href="@{/admin/practice-notes(notePage=${notePageBlockStart + 10}, logPage=${logPage}, size=${size})}"
+        <a th:if="${hasNextNoteBlock}" th:href="@{/admin/practice-notes(notePage=${notePageBlockStart + 10}, size=${size})}"
            class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&gt;&gt;</a>
         <span th:unless="${hasNextNoteBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&gt;&gt;</span>
 
-        <a th:if="${notePage < noteTotalPages - 1}" th:href="@{/admin/practice-notes(notePage=${notePage + 1}, logPage=${logPage}, size=${size})}"
+        <a th:if="${notePage < noteTotalPages - 1}" th:href="@{/admin/practice-notes(notePage=${notePage + 1}, size=${size})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">다음</a>
         <span th:if="${notePage >= noteTotalPages - 1}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">다음</span>
       </div>
     </section>
 
-    <section class="bg-white rounded-lg shadow-md overflow-hidden">
-      <div class="px-6 py-4 bg-gray-50 border-b border-gray-200">
-        <h3 class="text-lg font-semibold text-gray-900">복습 기록</h3>
-      </div>
-      <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">기록 ID</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">유저</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습노트</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">포인트</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">완료일</th>
-            </tr>
-          </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
-            <tr th:each="log : ${practiceLogs}" class="hover:bg-gray-50">
-              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" th:text="${log.missionLogId}">1</td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                <a th:href="@{/admin/user/{userId}(userId=${log.userId})}" class="text-indigo-600 hover:text-indigo-800 font-medium" th:text="${log.userName}">유저</a>
-                <p class="text-xs text-gray-500" th:text="${log.userEmail}">user@example.com</p>
-              </td>
-              <td class="px-6 py-4 text-sm text-gray-900">
-                <span th:text="${log.practiceTitle}">복습노트</span>
-                <span class="text-xs text-gray-500" th:text="'#' + ${log.practiceNoteId}">#1</span>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${log.point} + 'pt'">15pt</td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${#temporals.format(log.createdAt, 'yyyy-MM-dd HH:mm')}">2024-01-01 00:00</td>
-            </tr>
-            <tr th:if="${#lists.isEmpty(practiceLogs)}">
-              <td colspan="5" class="px-6 py-8 text-center text-gray-500">복습 기록이 없습니다</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div th:if="${logTotalPages > 1}" class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex flex-wrap justify-end gap-2">
-        <a th:if="${logPage > 0}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPage - 1}, size=${size})}"
-           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">이전</a>
-        <span th:if="${logPage == 0}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">이전</span>
-
-        <a th:if="${hasPreviousLogBlock}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPageBlockStart - 10}, size=${size})}"
-           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&lt;&lt;</a>
-        <span th:unless="${hasPreviousLogBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&lt;&lt;</span>
-
-        <span th:each="page : ${#numbers.sequence(logPageBlockStart, logPageBlockEnd)}">
-          <a th:if="${page == logPage}"
-             class="px-4 py-2 bg-indigo-600 border border-indigo-600 rounded-md text-sm font-medium text-white" th:text="${page + 1}">1</a>
-          <a th:if="${page != logPage}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${page}, size=${size})}"
-             class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50" th:text="${page + 1}">1</a>
-        </span>
-
-        <a th:if="${hasNextLogBlock}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPageBlockStart + 10}, size=${size})}"
-           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">&gt;&gt;</a>
-        <span th:unless="${hasNextLogBlock}" class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">&gt;&gt;</span>
-
-        <a th:if="${logPage < logTotalPages - 1}" th:href="@{/admin/practice-notes(notePage=${notePage}, logPage=${logPage + 1}, size=${size})}"
-           class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">다음</a>
-        <span th:if="${logPage >= logTotalPages - 1}" class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400">다음</span>
-      </div>
-    </section>
   </div>
 </body>
 </html>

--- a/src/main/resources/templates/problem.html
+++ b/src/main/resources/templates/problem.html
@@ -26,6 +26,9 @@
           <a th:href="@{/admin/problems}" class="text-indigo-600 px-3 py-2 rounded-md text-sm font-medium border-b-2 border-indigo-600">
             문제
           </a>
+          <a th:href="@{/admin/practice-notes}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
+            복습
+          </a>
           <a th:href="@{/admin/analysis}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             통계
           </a>

--- a/src/main/resources/templates/problem.html
+++ b/src/main/resources/templates/problem.html
@@ -221,6 +221,57 @@
       </div>
     </div>
 
+    <!-- Problem Solve Records -->
+    <div class="bg-white rounded-lg shadow-md overflow-hidden mt-6">
+      <div class="px-6 py-5 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+        <h3 class="text-lg font-semibold text-gray-900">문제 복습 기록</h3>
+        <span class="text-sm text-gray-500">
+          총 <span class="font-semibold text-indigo-600" th:text="${problemSolveCount}">0</span>개
+        </span>
+      </div>
+      <div class="px-6 py-5">
+        <div th:if="${!#lists.isEmpty(problemSolves)}" class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">기록 ID</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">유저 ID</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">복습일</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">정답 상태</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">소요 시간</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">회고</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이미지</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <tr th:each="solve : ${problemSolves}" class="hover:bg-gray-50">
+                <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900" th:text="${solve.problemSolveId}">1</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                  <a th:href="@{/admin/user/{userId}(userId=${solve.userId})}" class="text-indigo-600 hover:text-indigo-800 font-medium" th:text="${solve.userId}">1</a>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600" th:text="${#temporals.format(solve.practicedAt, 'yyyy-MM-dd HH:mm')}">2024-01-01</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600" th:text="${solve.answerStatus}">CORRECT</td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                  <span th:if="${solve.timeSpentSeconds != null}" th:text="${solve.timeSpentSeconds} + '초'">60초</span>
+                  <span th:unless="${solve.timeSpentSeconds != null}" class="text-gray-400">-</span>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600">
+                  <span th:if="${solve.reflection != null and !solve.reflection.isEmpty()}" th:text="${#strings.abbreviate(solve.reflection, 60)}">회고</span>
+                  <span th:unless="${solve.reflection != null and !solve.reflection.isEmpty()}" class="text-gray-400">-</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                  <span th:text="${#lists.size(solve.imageUrls)} + '장'">0장</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div th:if="${#lists.isEmpty(problemSolves)}" class="text-center py-8 text-gray-500">
+          이 문제에 작성된 복습 기록이 없습니다
+        </div>
+      </div>
+    </div>
+
     <!-- Back Button -->
     <div class="mt-6 flex justify-end">
       <a th:href="@{/admin/problems}"

--- a/src/main/resources/templates/problems.html
+++ b/src/main/resources/templates/problems.html
@@ -26,6 +26,9 @@
           <a th:href="@{/admin/problems}" class="text-indigo-600 px-3 py-2 rounded-md text-sm font-medium border-b-2 border-indigo-600">
             문제
           </a>
+          <a th:href="@{/admin/practice-notes}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
+            복습
+          </a>
           <a th:href="@{/admin/analysis}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             통계
           </a>

--- a/src/main/resources/templates/problems.html
+++ b/src/main/resources/templates/problems.html
@@ -60,7 +60,6 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">폴더 ID</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">메모</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">출처</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이미지</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">분석</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">푼 날짜</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">작성일</th>
@@ -80,37 +79,27 @@
                 <span th:unless="${problem.reference != null and !problem.reference.isEmpty()}" class="text-gray-400">-</span>
               </td>
               <td class="px-6 py-4 text-sm text-gray-600">
-                <div class="flex flex-wrap gap-1">
-                  <span th:each="image : ${problem.imageUrlList}" class="inline-block">
-                    <a th:href="@{/admin/user/image/view(url=${image.imageUrl})}" target="_blank"
-                       class="block border border-gray-200 rounded hover:border-indigo-400 transition"
-                       th:title="${image.problemImageType}">
-                      <img th:src="${image.imageUrl}"
-                           alt="문제 이미지"
-                           class="w-12 h-12 object-cover rounded">
-                    </a>
-                  </span>
-                  <span th:if="${#lists.isEmpty(problem.imageUrlList)}" class="text-gray-400 text-xs">이미지 없음</span>
-                </div>
-              </td>
-              <td class="px-6 py-4 text-sm text-gray-600">
-                <span th:if="${problem.analysis != null and problem.analysis.status == 'COMPLETED'}"
+                <span th:if="${problem.analysisStatus == 'COMPLETED'}"
                       class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
                   분석 완료
                 </span>
-                <span th:if="${problem.analysis != null and problem.analysis.status == 'PENDING'}"
+                <span th:if="${problem.analysisStatus == 'PROCESSING'}"
                       class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
                   분석중
                 </span>
-                <span th:if="${problem.analysis != null and problem.analysis.status == 'NOT_STARTED'}"
+                <span th:if="${problem.analysisStatus == 'NOT_STARTED'}"
                       class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                   분석 대기
                 </span>
-                <span th:if="${problem.analysis != null and problem.analysis.status == 'FAILED'}"
+                <span th:if="${problem.analysisStatus == 'FAILED'}"
                       class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
                   분석 실패
                 </span>
-                <span th:if="${problem.analysis == null}"
+                <span th:if="${problem.analysisStatus == 'NO_IMAGE'}"
+                      class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                  이미지 없음
+                </span>
+                <span th:if="${problem.analysisStatus == null}"
                       class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
                   미등록
                 </span>
@@ -122,7 +111,7 @@
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${#temporals.format(problem.createdAt, 'yyyy-MM-dd HH:mm')}">2024-01-01 00:00</td>
             </tr>
             <tr th:if="${#lists.isEmpty(problems)}">
-              <td colspan="8" class="px-6 py-8 text-center text-gray-500">
+              <td colspan="7" class="px-6 py-8 text-center text-gray-500">
                 문제가 없습니다
               </td>
             </tr>
@@ -134,12 +123,12 @@
     <!-- Pagination -->
     <div th:if="${totalPages > 1}" class="mt-6 flex items-center justify-between">
       <div class="text-sm text-gray-700">
-        <span class="font-medium" th:text="${currentPage * size + 1}">1</span>
-        부터 <span class="font-medium" th:text="${currentPage * size + #lists.size(problems)}">20</span>
+        <span class="font-medium" th:text="${pageStartItem}">1</span>
+        부터 <span class="font-medium" th:text="${pageEndItem}">20</span>
         까지 (총 <span class="font-medium" th:text="${totalProblems}">100</span>개)
       </div>
 
-      <div class="flex space-x-2">
+      <div class="flex flex-wrap justify-end gap-2">
         <!-- Previous Button -->
         <a th:if="${currentPage > 0}"
            th:href="@{/admin/problems(page=${currentPage - 1}, size=${size})}"
@@ -151,9 +140,19 @@
           이전
         </span>
 
+        <a th:if="${hasPreviousBlock}"
+           th:href="@{/admin/problems(page=${pageBlockStart - 10}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
+          &lt;&lt;
+        </a>
+        <span th:unless="${hasPreviousBlock}"
+              class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400 cursor-not-allowed">
+          &lt;&lt;
+        </span>
+
         <!-- Page Numbers -->
-        <div class="flex space-x-1">
-          <th:block th:each="page : ${#numbers.sequence(0, totalPages - 1)}">
+        <div class="flex flex-wrap gap-1">
+          <th:block th:each="page : ${#numbers.sequence(pageBlockStart, pageBlockEnd)}">
             <a th:if="${page == currentPage}"
                class="px-4 py-2 bg-indigo-600 border border-indigo-600 rounded-md text-sm font-medium text-white">
               <span th:text="${page + 1}">1</span>
@@ -165,6 +164,16 @@
             </a>
           </th:block>
         </div>
+
+        <a th:if="${hasNextBlock}"
+           th:href="@{/admin/problems(page=${pageBlockStart + 10}, size=${size})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
+          &gt;&gt;
+        </a>
+        <span th:unless="${hasNextBlock}"
+              class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400 cursor-not-allowed">
+          &gt;&gt;
+        </span>
 
         <!-- Next Button -->
         <a th:if="${currentPage < totalPages - 1}"

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -26,6 +26,9 @@
           <a th:href="@{/admin/problems}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             문제
           </a>
+          <a th:href="@{/admin/practice-notes}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
+            복습
+          </a>
           <a th:href="@{/admin/analysis}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             통계
           </a>

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -109,7 +109,7 @@
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
-            <tr th:each="user, iterStat : ${users}" class="hover:bg-gray-50 transition-colors cursor-pointer"
+            <tr th:each="user : ${users}" class="hover:bg-gray-50 transition-colors cursor-pointer"
                 th:onclick="'location.href=\'/admin/user/' + ${user.userId} + '\''">
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" th:text="${user.userId}">1</td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900" th:text="${user.name}">유저 이름</td>
@@ -120,7 +120,7 @@
                   <span class="ml-2 text-xs text-gray-500" th:text="'(' + ${user.totalStudyCurrentPoint} + 'pt)'"> (0pt)</span>
                 </div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900" th:text="${problemCounts[iterStat.index]}">0</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900" th:text="${user.problemCount}">0</td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${#temporals.format(user.createdAt, 'yyyy-MM-dd HH:mm')}">2024-01-01 00:00</td>
             </tr>
             <tr th:if="${#lists.isEmpty(users)}">
@@ -136,12 +136,12 @@
     <!-- Pagination -->
     <div th:if="${totalPages > 1}" class="mt-6 flex items-center justify-between">
       <div class="text-sm text-gray-700">
-        <span class="font-medium" th:text="${currentPage * size + 1}">1</span>
-        부터 <span class="font-medium" th:text="${currentPage * size + #lists.size(users)}">20</span>
+        <span class="font-medium" th:text="${pageStartItem}">1</span>
+        부터 <span class="font-medium" th:text="${pageEndItem}">20</span>
         까지 (총 <span class="font-medium" th:text="${totalUsers}">100</span>개)
       </div>
 
-      <div class="flex space-x-2">
+      <div class="flex flex-wrap justify-end gap-2">
         <!-- Previous Button -->
         <a th:if="${currentPage > 0}"
            th:href="@{/admin/users(page=${currentPage - 1}, size=${size}, sortBy=${sortBy}, direction=${direction})}"
@@ -153,9 +153,20 @@
           이전
         </span>
 
+        <!-- Previous Page Block -->
+        <a th:if="${hasPreviousBlock}"
+           th:href="@{/admin/users(page=${pageBlockStart - 10}, size=${size}, sortBy=${sortBy}, direction=${direction})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
+          &lt;&lt;
+        </a>
+        <span th:unless="${hasPreviousBlock}"
+              class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400 cursor-not-allowed">
+          &lt;&lt;
+        </span>
+
         <!-- Page Numbers -->
-        <div class="flex space-x-1">
-          <th:block th:each="page : ${#numbers.sequence(0, totalPages - 1)}">
+        <div class="flex flex-wrap gap-1">
+          <th:block th:each="page : ${#numbers.sequence(pageBlockStart, pageBlockEnd)}">
             <a th:if="${page == currentPage}"
                class="px-4 py-2 bg-indigo-600 border border-indigo-600 rounded-md text-sm font-medium text-white">
               <span th:text="${page + 1}">1</span>
@@ -167,6 +178,17 @@
             </a>
           </th:block>
         </div>
+
+        <!-- Next Page Block -->
+        <a th:if="${hasNextBlock}"
+           th:href="@{/admin/users(page=${pageBlockStart + 10}, size=${size}, sortBy=${sortBy}, direction=${direction})}"
+           class="px-3 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
+          &gt;&gt;
+        </a>
+        <span th:unless="${hasNextBlock}"
+              class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm font-medium text-gray-400 cursor-not-allowed">
+          &gt;&gt;
+        </span>
 
         <!-- Next Button -->
         <a th:if="${currentPage < totalPages - 1}"

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -47,6 +47,38 @@
       <p class="text-gray-600 mt-1">총 <span class="font-semibold text-indigo-600" th:text="${totalUsers}">0</span>명의 유저</p>
     </div>
 
+    <form th:action="@{/admin/users}" method="get" class="mb-6 bg-white rounded-lg shadow-md p-4">
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+        <input type="hidden" name="page" value="0">
+        <div>
+          <label for="sortBy" class="block text-sm font-medium text-gray-700 mb-1">정렬 기준</label>
+          <select id="sortBy" name="sortBy" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+            <option value="createdAt" th:selected="${sortBy == 'createdAt'}">가입일</option>
+            <option value="level" th:selected="${sortBy == 'level'}">총 학습 레벨</option>
+            <option value="problemCount" th:selected="${sortBy == 'problemCount'}">문제 수</option>
+          </select>
+        </div>
+        <div>
+          <label for="direction" class="block text-sm font-medium text-gray-700 mb-1">정렬 방향</label>
+          <select id="direction" name="direction" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+            <option value="desc" th:selected="${direction == 'desc'}">내림차순</option>
+            <option value="asc" th:selected="${direction == 'asc'}">오름차순</option>
+          </select>
+        </div>
+        <div>
+          <label for="size" class="block text-sm font-medium text-gray-700 mb-1">페이지 크기</label>
+          <select id="size" name="size" class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+            <option value="20" th:selected="${size == 20}">20개</option>
+            <option value="50" th:selected="${size == 50}">50개</option>
+            <option value="100" th:selected="${size == 100}">100개</option>
+          </select>
+        </div>
+        <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition">
+          적용
+        </button>
+      </div>
+    </form>
+
     <!-- Users Table -->
     <div class="bg-white rounded-lg shadow-md overflow-hidden">
       <div class="overflow-x-auto">
@@ -56,8 +88,20 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">유저 ID</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이름</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이메일</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">총 학습 레벨</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">문제 수</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <a th:href="@{/admin/users(page=0, size=${size}, sortBy='level', direction=${sortBy == 'level' && direction == 'desc' ? 'asc' : 'desc'})}"
+                   class="hover:text-indigo-600">
+                  총 학습 레벨
+                  <span th:if="${sortBy == 'level'}" th:text="${direction == 'desc' ? '내림차순' : '오름차순'}" class="ml-1 text-indigo-600">내림차순</span>
+                </a>
+              </th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <a th:href="@{/admin/users(page=0, size=${size}, sortBy='problemCount', direction=${sortBy == 'problemCount' && direction == 'desc' ? 'asc' : 'desc'})}"
+                   class="hover:text-indigo-600">
+                  문제 수
+                  <span th:if="${sortBy == 'problemCount'}" th:text="${direction == 'desc' ? '내림차순' : '오름차순'}" class="ml-1 text-indigo-600">내림차순</span>
+                </a>
+              </th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">가입일</th>
             </tr>
           </thead>
@@ -97,7 +141,7 @@
       <div class="flex space-x-2">
         <!-- Previous Button -->
         <a th:if="${currentPage > 0}"
-           th:href="@{/admin/users(page=${currentPage - 1}, size=${size})}"
+           th:href="@{/admin/users(page=${currentPage - 1}, size=${size}, sortBy=${sortBy}, direction=${direction})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
           이전
         </a>
@@ -114,7 +158,7 @@
               <span th:text="${page + 1}">1</span>
             </a>
             <a th:if="${page != currentPage}"
-               th:href="@{/admin/users(page=${page}, size=${size})}"
+               th:href="@{/admin/users(page=${page}, size=${size}, sortBy=${sortBy}, direction=${direction})}"
                class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
               <span th:text="${page + 1}">1</span>
             </a>
@@ -123,7 +167,7 @@
 
         <!-- Next Button -->
         <a th:if="${currentPage < totalPages - 1}"
-           th:href="@{/admin/users(page=${currentPage + 1}, size=${size})}"
+           th:href="@{/admin/users(page=${currentPage + 1}, size=${size}, sortBy=${sortBy}, direction=${direction})}"
            class="px-4 py-2 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 transition">
           다음
         </a>

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -26,6 +26,9 @@
           <a th:href="@{/admin/problems}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             문제
           </a>
+          <a th:href="@{/admin/practice-notes}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
+            복습
+          </a>
           <a th:href="@{/admin/analysis}" class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium">
             통계
           </a>

--- a/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -75,7 +76,9 @@ class ProblemControllerTest {
                     LocalDateTime.now(),
                     LocalDateTime.now(),
                     imageUrlList,
-                    null
+                    null,
+                    List.of(),
+                    List.of()
             );
 
             problemResponseDtoList.add(problemResponseDto);
@@ -181,18 +184,20 @@ class ProblemControllerTest {
     @WithMockCustomUser()
     void registerProblemImageData() throws Exception {
         // When & Then
-        mockMvc.perform(post("/api/problems/imageData")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(
-                                new ProblemImageDataRegisterDto(
-                                        1L,
-                                        "problemImage",
-                                        ProblemImageType.PROBLEM_IMAGE
-                                )
-                        )))
+        MockMultipartFile image = new MockMultipartFile(
+                "problemImages",
+                "problem.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "problem-image".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/problems/{problemId}/imageData", 1L)
+                        .file(image)
+                        .param("problemImageTypes", ProblemImageType.PROBLEM_IMAGE.name()))
                 .andExpect(status().isOk());
 
-        //verify(problemService, times(1)).registerProblemImageData(any(), eq(1L));  // userId가 1L인 것도 검증
+        verify(problemService, times(1)).uploadProblemImages(eq(1L), eq(1L), any(), any());
+        verify(problemService, times(1)).analysisProblem(eq(1L));
     }
 
     @Test


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #190
- close #155 

## 📝 작업 내용

- 관리자 페이지에 복습노트/복습 기록 조회 화면을 추가했습니다.
- 유저, 문제, 복습, 통계 화면의 조회성과 운영 지표를 개선했습니다.
- 통계 화면에서 기간별 방문/가입/문제/복습/분석 지표를 확인할 수 있도록 확장했습니다.
- 관리자 문제 목록과 문제 관련 테스트를 현재 API/데이터 구조에 맞게 보정했습니다.

## 변경 사항

### Admin dashboard/navigation
- 관리자 메인 화면에 복습 관리 진입 카드를 추가했습니다.
- 기존 관리자 화면 상단 내비게이션에 복습 메뉴를 추가했습니다.
- 문제 목록/유저 목록 등 관리자 목록 페이지의 페이지네이션 사용성을 개선했습니다.

### User admin list
- 유저 목록을 레벨, 문제 수 등 기준으로 정렬할 수 있도록 개선했습니다.
- 유저 목록 조회를 관리자 전용 projection 기반 페이징으로 최적화했습니다.

### Practice note admin
- `/admin/practice-notes` 복습노트 관리 화면을 추가했습니다.
- `/admin/practice-logs` 복습 기록 관리 화면을 추가했습니다.
- 복습노트 목록에서 유저, 제목, 문제 수, 복습 횟수, 마지막 복습일, 생성일을 확인할 수 있습니다.
- 복습 기록 목록에서 유저, 복습노트, 포인트, 완료일을 확인할 수 있습니다.
- 문제 상세 페이지에 해당 문제의 복습 기록을 표시하도록 개선했습니다.

### Analysis/statistics
- 통계 조회 기간을 직접 선택할 수 있도록 개선했습니다.
- 빠른 기간 선택 버튼을 추가했습니다.
- 선택 기간 기준 방문 횟수, 고유 방문 유저 수, 평균 DAU, 신규 가입자 수를 표시합니다.
- 선택 기간 기준 문제 등록 수, 복습노트 생성 수, 복습 수행 수를 표시합니다.
- 문제 분석 상태별 지표를 추가했습니다.
  - 완료
  - 실패
  - 분석 중
  - 분석 대기
  - 이미지 없음
- 분석 실패율을 표시합니다.
- 날짜별 통계 테이블에 방문/유저/문제/복습 지표와 합계 행을 추가했습니다.

### Problem admin
- 관리자 문제 목록 조회를 전용 DTO 기반 페이징 조회로 개선했습니다.
- 폴더 join alias를 명시해 관리자 문제 목록 projection이 안정적으로 동작하도록 수정했습니다.
- 요청 page가 총 페이지 범위를 넘는 경우 마지막 페이지로 보정하도록 처리했습니다.
- soft delete된 문제와 active 문제의 통계 모집단이 섞이지 않도록, 분석 통계는 삭제되지 않은 문제 기준으로 집계하도록 수정했습니다.
- 날짜별 문제 등록 수 집계를 반복 count 쿼리에서 `GROUP BY date(created_at)` 기반 집계로 개선했습니다.
- MySQL `date(created_at)` 결과가 `java.sql.Date`로 반환되는 문제를 `LocalDate` 변환 처리로 수정했습니다.


### 스크린샷 (선택)

<img width="1047" height="851" alt="image" src="https://github.com/user-attachments/assets/c61ac761-66d8-47cd-bde2-08724225bca8" />

<br>

<img width="989" height="237" alt="image" src="https://github.com/user-attachments/assets/fdba8ec7-6808-4387-9c4f-4d5c9fa71890" />

<br>

<img width="1054" height="194" alt="image" src="https://github.com/user-attachments/assets/08a8f102-dde0-44fd-80ac-aaa57cc6ba35" />
