### PR TITLE
[Feat] Loki 로그 수집 스택 추가

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -159,13 +159,13 @@ jobs:
       - name: Deploy Monitoring Stack
         run: |
           docker-compose -f docker-compose.dev.yml --env-file .env.dev --profile monitoring pull \
-            mysql-exporter-dev prometheus-dev grafana-dev
-          docker-compose -f docker-compose.dev.yml --env-file .env.dev --profile monitoring stop prometheus-dev grafana-dev mysql-exporter-dev || true
-          docker-compose -f docker-compose.dev.yml --env-file .env.dev --profile monitoring rm -f prometheus-dev grafana-dev mysql-exporter-dev || true
+            mysql-exporter-dev prometheus-dev loki-dev promtail-dev grafana-dev
+          docker-compose -f docker-compose.dev.yml --env-file .env.dev --profile monitoring stop prometheus-dev grafana-dev loki-dev promtail-dev mysql-exporter-dev || true
+          docker-compose -f docker-compose.dev.yml --env-file .env.dev --profile monitoring rm -f prometheus-dev grafana-dev loki-dev promtail-dev mysql-exporter-dev || true
           docker-compose -f docker-compose.dev.yml --env-file .env.dev --profile monitoring up -d --force-recreate \
-            mysql-exporter-dev prometheus-dev grafana-dev
+            mysql-exporter-dev prometheus-dev loki-dev promtail-dev grafana-dev
           docker-compose -f docker-compose.dev.yml --env-file .env.dev ps \
-            mysql-exporter-dev prometheus-dev grafana-dev
+            mysql-exporter-dev prometheus-dev loki-dev promtail-dev grafana-dev
         shell: bash
 
       - name: Verify Monitoring Integration
@@ -200,6 +200,43 @@ jobs:
           docker exec ono-prometheus-dev sh -lc 'wget -qO- "http://localhost:9090/prometheus/api/v1/targets"' || true
           docker logs --tail=200 ono-app-dev || true
           docker logs --tail=200 ono-prometheus-dev || true
+          exit 1
+        shell: bash
+
+      - name: Verify Loki Log Collection
+        run: |
+          echo "Checking Loki readiness..."
+          for i in $(seq 1 12); do
+            if curl -fsS http://localhost:3101/ready | grep -q ready; then
+              echo "Loki is ready"
+              break
+            fi
+            echo "Waiting Loki ready... ($i/12)"
+            sleep 5
+          done
+
+          if ! curl -fsS http://localhost:3101/ready | grep -q ready; then
+            echo "ERROR: Loki did not become ready"
+            docker logs --tail=200 ono-loki-dev || true
+            docker logs --tail=200 ono-promtail-dev || true
+            exit 1
+          fi
+
+          echo "Checking Loki received dev logs..."
+          for i in $(seq 1 12); do
+            result=$(curl -fsG "http://localhost:3101/loki/api/v1/label/container/values" || true)
+            if echo "$result" | grep -Eq '"ono-(app|mysql|redis|rabbitmq|prometheus|grafana|loki|promtail|mysql-exporter)-dev"'; then
+              echo "Loki received dev log labels"
+              exit 0
+            fi
+            echo "Waiting Loki log labels... ($i/12)"
+            sleep 5
+          done
+
+          echo "ERROR: Loki did not receive expected dev log labels"
+          curl -fsG "http://localhost:3101/loki/api/v1/labels" || true
+          docker logs --tail=200 ono-loki-dev || true
+          docker logs --tail=200 ono-promtail-dev || true
           exit 1
         shell: bash
 

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -219,13 +219,13 @@ jobs:
       - name: Deploy Monitoring Stack
         run: |
           docker-compose -f docker-compose.prod.yml --env-file .env.prod --profile monitoring pull \
-            mysql-exporter-prod prometheus-prod grafana-prod
-          docker-compose -f docker-compose.prod.yml --env-file .env.prod --profile monitoring stop prometheus-prod grafana-prod mysql-exporter-prod || true
-          docker-compose -f docker-compose.prod.yml --env-file .env.prod --profile monitoring rm -f prometheus-prod grafana-prod mysql-exporter-prod || true
+            mysql-exporter-prod prometheus-prod loki-prod promtail-prod grafana-prod
+          docker-compose -f docker-compose.prod.yml --env-file .env.prod --profile monitoring stop prometheus-prod grafana-prod loki-prod promtail-prod mysql-exporter-prod || true
+          docker-compose -f docker-compose.prod.yml --env-file .env.prod --profile monitoring rm -f prometheus-prod grafana-prod loki-prod promtail-prod mysql-exporter-prod || true
           docker-compose -f docker-compose.prod.yml --env-file .env.prod --profile monitoring up -d --force-recreate \
-            mysql-exporter-prod prometheus-prod grafana-prod
+            mysql-exporter-prod prometheus-prod loki-prod promtail-prod grafana-prod
           docker-compose -f docker-compose.prod.yml --env-file .env.prod ps \
-            mysql-exporter-prod prometheus-prod grafana-prod
+            mysql-exporter-prod prometheus-prod loki-prod promtail-prod grafana-prod
         shell: bash
 
       - name: Verify Monitoring Integration
@@ -246,6 +246,44 @@ jobs:
           echo "WARNING: Prometheus scrape for production targets is still down"
           docker exec ono-prometheus-prod sh -lc 'wget -qO- "http://localhost:9090/prometheus/api/v1/targets"' || true
           docker logs --tail=200 ono-prometheus-prod || true
+        shell: bash
+
+      - name: Verify Loki Log Collection
+        continue-on-error: true
+        run: |
+          echo "Checking Loki readiness..."
+          for i in $(seq 1 12); do
+            if curl -fsS http://localhost:3100/ready | grep -q ready; then
+              echo "Loki is ready"
+              break
+            fi
+            echo "Waiting Loki ready... ($i/12)"
+            sleep 5
+          done
+
+          if ! curl -fsS http://localhost:3100/ready | grep -q ready; then
+            echo "WARNING: Loki did not become ready"
+            docker logs --tail=200 ono-loki-prod || true
+            docker logs --tail=200 ono-promtail-prod || true
+            exit 1
+          fi
+
+          echo "Checking Loki received production logs..."
+          for i in $(seq 1 12); do
+            result=$(curl -fsG "http://localhost:3100/loki/api/v1/label/container/values" || true)
+            if echo "$result" | grep -Eq '"ono-(app-prod-blue|app-prod-green|mysql-prod|redis-prod|rabbitmq-prod|prometheus-prod|grafana-prod|loki-prod|promtail-prod|mysql-exporter-prod)"'; then
+              echo "Loki received production log labels"
+              exit 0
+            fi
+            echo "Waiting Loki production log labels... ($i/12)"
+            sleep 5
+          done
+
+          echo "WARNING: Loki did not receive expected production log labels"
+          curl -fsG "http://localhost:3100/loki/api/v1/labels" || true
+          docker logs --tail=200 ono-loki-prod || true
+          docker logs --tail=200 ono-promtail-prod || true
+          exit 1
         shell: bash
 
       - name: Clean up old Docker images

--- a/.github/workflows/restart-monitoring.yml
+++ b/.github/workflows/restart-monitoring.yml
@@ -56,16 +56,16 @@ jobs:
         if: ${{ github.event.inputs.target == 'dev' }}
         run: |
           docker compose -f docker-compose.dev.yml --env-file .env.dev --profile monitoring up -d --force-recreate \
-            mysql-exporter-dev prometheus-dev grafana-dev
+            mysql-exporter-dev prometheus-dev loki-dev promtail-dev grafana-dev
           docker compose -f docker-compose.dev.yml --env-file .env.dev ps \
-            mysql-exporter-dev prometheus-dev grafana-dev
+            mysql-exporter-dev prometheus-dev loki-dev promtail-dev grafana-dev
         shell: bash
 
       - name: Restart monitoring stack (prod)
         if: ${{ github.event.inputs.target == 'prod' }}
         run: |
           docker compose -f docker-compose.prod.yml --env-file .env.prod --profile monitoring up -d --force-recreate \
-            mysql-exporter-prod prometheus-prod grafana-prod
+            mysql-exporter-prod prometheus-prod loki-prod promtail-prod grafana-prod
           docker compose -f docker-compose.prod.yml --env-file .env.prod ps \
-            mysql-exporter-prod prometheus-prod grafana-prod
+            mysql-exporter-prod prometheus-prod loki-prod promtail-prod grafana-prod
         shell: bash

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -145,6 +145,46 @@ services:
     profiles:
       - monitoring
 
+  # Loki - DEVELOPMENT (Profile: monitoring)
+  loki-dev:
+    image: grafana/loki:2.9.8
+    container_name: ono-loki-dev
+    restart: unless-stopped
+    command:
+      - -config.file=/etc/loki/loki.yml
+    ports:
+      - "127.0.0.1:3101:3100"
+    volumes:
+      - ./monitoring/loki.dev.yml:/etc/loki/loki.yml:ro
+      - loki_dev_data:/loki
+    mem_limit: 512m
+    cpus: "0.50"
+    networks:
+      - ono-network
+    profiles:
+      - monitoring
+
+  # Promtail - DEVELOPMENT (Profile: monitoring)
+  promtail-dev:
+    image: grafana/promtail:2.9.8
+    container_name: ono-promtail-dev
+    restart: unless-stopped
+    command:
+      - -config.file=/etc/promtail/promtail.yml
+    volumes:
+      - ./monitoring/promtail.dev.yml:/etc/promtail/promtail.yml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail_dev_positions:/tmp
+    mem_limit: 256m
+    cpus: "0.25"
+    depends_on:
+      - loki-dev
+    networks:
+      - ono-network
+    profiles:
+      - monitoring
+
   mysql-exporter-dev:
     image: prom/mysqld-exporter:v0.15.1
     container_name: ono-mysql-exporter-dev
@@ -180,6 +220,7 @@ services:
       - ./monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
     depends_on:
       - prometheus-dev
+      - loki-dev
     networks:
       - ono-network
     profiles:
@@ -200,6 +241,10 @@ volumes:
   app_dev_logs:
     driver: local
   prometheus_dev_data:
+    driver: local
+  loki_dev_data:
+    driver: local
+  promtail_dev_positions:
     driver: local
   grafana_dev_data:
     driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -199,6 +199,46 @@ services:
     profiles:
       - monitoring
 
+  # Loki - PRODUCTION (Profile: monitoring)
+  loki-prod:
+    image: grafana/loki:2.9.8
+    container_name: ono-loki-prod
+    restart: unless-stopped
+    command:
+      - -config.file=/etc/loki/loki.yml
+    ports:
+      - "127.0.0.1:3100:3100"
+    volumes:
+      - ./monitoring/loki.prod.yml:/etc/loki/loki.yml:ro
+      - loki_prod_data:/loki
+    mem_limit: 768m
+    cpus: "0.75"
+    networks:
+      - ono-network
+    profiles:
+      - monitoring
+
+  # Promtail - PRODUCTION (Profile: monitoring)
+  promtail-prod:
+    image: grafana/promtail:2.9.8
+    container_name: ono-promtail-prod
+    restart: unless-stopped
+    command:
+      - -config.file=/etc/promtail/promtail.yml
+    volumes:
+      - ./monitoring/promtail.prod.yml:/etc/promtail/promtail.yml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail_prod_positions:/tmp
+    mem_limit: 256m
+    cpus: "0.25"
+    depends_on:
+      - loki-prod
+    networks:
+      - ono-network
+    profiles:
+      - monitoring
+
   mysql-exporter-prod:
     image: prom/mysqld-exporter:v0.15.1
     container_name: ono-mysql-exporter-prod
@@ -234,6 +274,7 @@ services:
       - ./monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
     depends_on:
       - prometheus-prod
+      - loki-prod
     networks:
       - ono-network
     profiles:
@@ -253,6 +294,10 @@ volumes:
   app_prod_logs:
     driver: local
   prometheus_prod_data:
+    driver: local
+  loki_prod_data:
+    driver: local
+  promtail_prod_positions:
     driver: local
   grafana_prod_data:
     driver: local

--- a/monitoring/grafana/dashboards/ono-error-logs.json
+++ b/monitoring/grafana/dashboards/ono-error-logs.json
@@ -1,0 +1,296 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({environment=~\"$environment\", level=\"ERROR\"}[$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (container) (count_over_time({environment=~\"$environment\", level=\"ERROR\"}[$__interval]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors by Container",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{environment=~\"$environment\", level=\"ERROR\"} |~ \"$search\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Log Stream",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "ono",
+    "logs",
+    "errors",
+    "loki"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "dev",
+            "prod"
+          ],
+          "value": [
+            "dev",
+            "prod"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Environment",
+        "multi": true,
+        "name": "environment",
+        "options": [
+          {
+            "selected": true,
+            "text": "dev",
+            "value": "dev"
+          },
+          {
+            "selected": true,
+            "text": "prod",
+            "value": "prod"
+          }
+        ],
+        "query": "dev,prod",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": ".+",
+          "value": ".+"
+        },
+        "hide": 0,
+        "label": "Search",
+        "name": "search",
+        "options": [
+          {
+            "selected": true,
+            "text": ".+",
+            "value": ".+"
+          }
+        ],
+        "query": ".+",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "OnO Error Logs",
+  "uid": "ono-error-logs",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/dev/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/dev/datasources/datasource.yml
@@ -8,3 +8,10 @@ datasources:
     url: http://prometheus-dev:9090/prometheus
     isDefault: true
     editable: true
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki-dev:3100
+    editable: true

--- a/monitoring/grafana/provisioning/prod/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/prod/datasources/datasource.yml
@@ -8,3 +8,10 @@ datasources:
     url: http://prometheus-prod:9090/prometheus
     isDefault: true
     editable: true
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki-prod:3100
+    editable: true

--- a/monitoring/loki.dev.yml
+++ b/monitoring/loki.dev.yml
@@ -1,0 +1,53 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h
+  allow_structured_metadata: false
+  ingestion_rate_mb: 4
+  ingestion_burst_size_mb: 8
+  per_stream_rate_limit: 1MB
+  per_stream_rate_limit_burst: 2MB
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/monitoring/loki.prod.yml
+++ b/monitoring/loki.prod.yml
@@ -1,0 +1,53 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 720h
+  allow_structured_metadata: false
+  ingestion_rate_mb: 4
+  ingestion_burst_size_mb: 8
+  per_stream_rate_limit: 1MB
+  per_stream_rate_limit_burst: 2MB
+  reject_old_samples: true
+  reject_old_samples_max_age: 720h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/monitoring/promtail.dev.yml
+++ b/monitoring/promtail.dev.yml
@@ -1,0 +1,52 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yml
+
+clients:
+  - url: http://loki-dev:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: ono-dev-docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: name
+            values:
+              - ono-app-dev
+              - ono-mysql-dev
+              - ono-redis-dev
+              - ono-rabbitmq-dev
+              - ono-prometheus-dev
+              - ono-grafana-dev
+              - ono-loki-dev
+              - ono-promtail-dev
+              - ono-mysql-exporter-dev
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: compose_service
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+      - source_labels: [__meta_docker_container_id]
+        target_label: __path__
+        replacement: /var/lib/docker/containers/$1/$1-json.log
+      - target_label: job
+        replacement: ono-service
+      - target_label: environment
+        replacement: dev
+      - target_label: source
+        replacement: docker-json
+    pipeline_stages:
+      - docker: {}
+      - drop:
+          older_than: 168h
+      - regex:
+          expression: '(^|[[:space:]])(?P<level>TRACE|DEBUG|INFO|WARN|ERROR|FATAL)([[:space:]]|$)'
+      - labels:
+          level:

--- a/monitoring/promtail.prod.yml
+++ b/monitoring/promtail.prod.yml
@@ -1,0 +1,53 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yml
+
+clients:
+  - url: http://loki-prod:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: ono-prod-docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: name
+            values:
+              - ono-app-prod-blue
+              - ono-app-prod-green
+              - ono-mysql-prod
+              - ono-redis-prod
+              - ono-rabbitmq-prod
+              - ono-prometheus-prod
+              - ono-grafana-prod
+              - ono-loki-prod
+              - ono-promtail-prod
+              - ono-mysql-exporter-prod
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: compose_service
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+      - source_labels: [__meta_docker_container_id]
+        target_label: __path__
+        replacement: /var/lib/docker/containers/$1/$1-json.log
+      - target_label: job
+        replacement: ono-service
+      - target_label: environment
+        replacement: prod
+      - target_label: source
+        replacement: docker-json
+    pipeline_stages:
+      - docker: {}
+      - drop:
+          older_than: 720h
+      - regex:
+          expression: '(^|[[:space:]])(?P<level>TRACE|DEBUG|INFO|WARN|ERROR|FATAL)([[:space:]]|$)'
+      - labels:
+          level:


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #193

## 📝 작업 내용

> Spring 서버 및 주요 인프라 컨테이너의 에러 로그를 Grafana에서 조회할 수 있도록 Loki 기반 로그 수집 스택을 추가했습니다.

- Loki/Promtail 기반 로그 수집 스택을 dev/prod 모니터링 구성에 추가했습니다.
- Promtail이 전체 Docker 컨테이너를 수집하지 않도록 dev/prod별 OnO 컨테이너 allowlist를 적용했습니다.
- Docker stdout/stderr 로그에서 `ERROR`, `WARN`, `INFO` 등 로그 레벨을 추출해 Loki 라벨로 저장하도록 구성했습니다.
- Loki 로그 보관 기간과 ingestion 제한을 설정하고, Loki/Promtail 컨테이너 리소스 제한을 추가했습니다.
- Grafana에 Loki datasource를 자동 등록하고, `OnO Error Logs` 대시보드를 추가했습니다.
- CI/CD 및 모니터링 재시작 워크플로우에서 Loki/Promtail을 함께 배포하도록 반영했습니다.
- 배포 검증 단계에서 Loki readiness뿐 아니라 실제 환경별 로그 라벨 유입 여부도 확인하도록 개선했습니다.

### 스크린샷 (선택)

- 없음
