### PR TITLE
[Feat] 운영 로그 추적성 개선 및 에러 코드 체계 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ jar {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.1.0'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	implementation 'com.google.api-client:google-api-client:2.4.0'

--- a/monitoring/promtail.prod.yml
+++ b/monitoring/promtail.prod.yml
@@ -47,7 +47,18 @@ scrape_configs:
       - docker: {}
       - drop:
           older_than: 720h
-      - regex:
-          expression: '(^|[[:space:]])(?P<level>TRACE|DEBUG|INFO|WARN|ERROR|FATAL)([[:space:]]|$)'
+      - json:
+          expressions:
+            level: level
+            service: service
+            traceId: traceId
+            userId: userId
+            method: method
+            uri: uri
+            status: status
+            latencyMs: latencyMs
+            errorCode: errorCode
+            exceptionType: exceptionType
       - labels:
           level:
+          service:

--- a/src/main/java/com/aisip/OnO/backend/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/auth/exception/AuthErrorCase.java
@@ -16,9 +16,15 @@ public enum AuthErrorCase implements ErrorCase {
 
     REFRESH_TOKEN_NOT_EQUAL(400, 1004, "리프레시 토큰이 일치하지 않습니다."),
 
-    ACCESS_TOKEN_EXPIRED(400, 1005, "엑세스 토큰이 만료되었습니다."),
+    ACCESS_TOKEN_EXPIRED(401, 1005, "엑세스 토큰이 만료되었습니다."),
 
-    REFRESH_TOKEN_EXPIRED(401, 1006, "리프레시 토큰이 만료되었습니다.");
+    REFRESH_TOKEN_EXPIRED(401, 1006, "리프레시 토큰이 만료되었습니다."),
+
+    AUTHENTICATION_FAILED(401, 1007, "인증이 실패했습니다."),
+
+    ACCESS_DENIED(403, 1008, "접근 권한이 없습니다."),
+
+    INVALID_ACCESS_TOKEN(401, 1009, "유효하지 않은 엑세스 토큰입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/auth/service/JwtTokenizer.java
+++ b/src/main/java/com/aisip/OnO/backend/auth/service/JwtTokenizer.java
@@ -77,7 +77,7 @@ public class JwtTokenizer {
         try{
             Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(token);
         } catch (Exception e) {
-            log.error("엑세스 토큰 검증 실패: {} / token={}", e.getMessage(), token);
+            log.warn("엑세스 토큰 검증 실패: {}", e.getMessage());
             throw new ApplicationException(AuthErrorCase.ACCESS_TOKEN_EXPIRED);
         }
     }
@@ -89,7 +89,7 @@ public class JwtTokenizer {
             log.warn("리프레시 토큰 만료: {}", e.getMessage());
             throw new ApplicationException(AuthErrorCase.REFRESH_TOKEN_EXPIRED);
         } catch (Exception e) {
-            log.error("리프레시 토큰 검증 실패: {} / token={}", e.getMessage(), token);
+            log.warn("리프레시 토큰 검증 실패: {}", e.getMessage());
             throw new ApplicationException(AuthErrorCase.INVALID_REFRESH_TOKEN);
         }
     }

--- a/src/main/java/com/aisip/OnO/backend/common/aop/LoggingAspect.java
+++ b/src/main/java/com/aisip/OnO/backend/common/aop/LoggingAspect.java
@@ -1,54 +1,24 @@
 package com.aisip.OnO.backend.common.aop;
 
+import com.aisip.OnO.backend.common.exception.ApplicationException;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
 @Slf4j
 class LoggingAspect {
-    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
 
-    // 예외 발생 시 로깅
     @AfterThrowing(pointcut = "execution(* com.aisip..service..*(..))",
             throwing = "ex")
     public void logAfterThrowing(JoinPoint joinPoint, Throwable ex) {
-        String methodName = joinPoint.getSignature().getName();
-        String className = joinPoint.getSignature().getDeclaringTypeName();
-        String layer = getLayerName(className);
-        logger.error("[{}] [Exception] {}.{}(): {}", layer, className, methodName, ex.getMessage(), ex);
-    }
-
-    // 메서드 실행 이전 로깅
-    @Before("execution(* com.aisip..service..*(..))")
-    public void logBefore(JoinPoint joinPoint) {
-        String methodName = joinPoint.getSignature().getName();
-        String className = joinPoint.getSignature().getDeclaringTypeName();
-        String layer = getLayerName(className);
-        logger.info("[{}] [Executing] {}.{}()", layer, className, methodName);
-    }
-
-    // 메서드 실행 이후 로깅
-    @After("execution(* com.aisip..service..*(..))")
-    public void logAfter(JoinPoint joinPoint) {
-        String methodName = joinPoint.getSignature().getName();
-        String className = joinPoint.getSignature().getDeclaringTypeName();
-        String layer = getLayerName(className);
-        logger.info("[{}] [Completed] {}.{}()", layer, className, methodName);
-    }
-
-    // 클래스 이름으로부터 계층(layer) 이름 추출
-    private String getLayerName(String className) {
-        if (className.contains("service")) {
-            return "Service";
+        if (ex instanceof ApplicationException) {
+            return;
         }
-        return "Unknown";
+
+        log.error("Unhandled service exception - method: {}", joinPoint.getSignature().toShortString(), ex);
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/common/aop/LoggingAspect.java
+++ b/src/main/java/com/aisip/OnO/backend/common/aop/LoggingAspect.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 @Aspect
@@ -16,6 +17,13 @@ class LoggingAspect {
             throwing = "ex")
     public void logAfterThrowing(JoinPoint joinPoint, Throwable ex) {
         if (ex instanceof ApplicationException) {
+            return;
+        }
+
+        if (MDC.get("traceId") != null) {
+            log.debug("Service exception propagated to request handler - method: {}, exceptionType: {}",
+                    joinPoint.getSignature().toShortString(),
+                    ex.getClass().getSimpleName());
             return;
         }
 

--- a/src/main/java/com/aisip/OnO/backend/common/aop/LoggingAspect.java
+++ b/src/main/java/com/aisip/OnO/backend/common/aop/LoggingAspect.java
@@ -23,7 +23,7 @@ class LoggingAspect {
         String methodName = joinPoint.getSignature().getName();
         String className = joinPoint.getSignature().getDeclaringTypeName();
         String layer = getLayerName(className);
-        logger.error("[{}] [Exception] {}.{}(): {}", layer, className, methodName, ex.getMessage());
+        logger.error("[{}] [Exception] {}.{}(): {}", layer, className, methodName, ex.getMessage(), ex);
     }
 
     // 메서드 실행 이전 로깅

--- a/src/main/java/com/aisip/OnO/backend/common/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/aisip/OnO/backend/common/auth/CustomAccessDeniedHandler.java
@@ -1,7 +1,11 @@
 package com.aisip.OnO.backend.common.auth;
 
+import com.aisip.OnO.backend.auth.exception.AuthErrorCase;
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -9,13 +13,15 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);  // 403 Forbidden 상태 코드
+        response.setStatus(AuthErrorCase.ACCESS_DENIED.getHttpStatusCode());
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{\"errorCode\":\"403\",\n\"message\":\"접근 권한이 없습니다.\"}");  // 사용자 정의 메시지
+        objectMapper.writeValue(response.getWriter(), CommonResponse.error(AuthErrorCase.ACCESS_DENIED));
     }
 }
-

--- a/src/main/java/com/aisip/OnO/backend/common/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/aisip/OnO/backend/common/auth/CustomAuthenticationEntryPoint.java
@@ -1,7 +1,12 @@
 package com.aisip.OnO.backend.common.auth;
 
+import com.aisip.OnO.backend.auth.exception.AuthErrorCase;
+import com.aisip.OnO.backend.common.exception.ErrorCase;
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -9,7 +14,10 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
@@ -30,14 +38,18 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         ) {
             return;
         }
-        String errorMessage = (String) request.getAttribute("errorMessage");
-
-        if(errorMessage == null)
-            errorMessage = "인증이 실패했습니다.";
+        ErrorCase errorCase = resolveErrorCase(request);
 
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 UNAUTHORIZED 상태 코드
-        response.getWriter().write("{\"errorCode\":\"401\",\n\"message\":\"" + errorMessage + "\"}");
+        response.setStatus(errorCase.getHttpStatusCode());
+        objectMapper.writeValue(response.getWriter(), CommonResponse.error(errorCase));
     }
 
+    private ErrorCase resolveErrorCase(HttpServletRequest request) {
+        Object errorCase = request.getAttribute(JwtTokenFilter.AUTH_ERROR_CASE_ATTRIBUTE);
+        if (errorCase instanceof ErrorCase resolvedErrorCase) {
+            return resolvedErrorCase;
+        }
+        return AuthErrorCase.AUTHENTICATION_FAILED;
+    }
 }

--- a/src/main/java/com/aisip/OnO/backend/common/auth/JwtTokenFilter.java
+++ b/src/main/java/com/aisip/OnO/backend/common/auth/JwtTokenFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -84,6 +85,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                         new UsernamePasswordAuthenticationToken(userId, null, authorities);
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                MDC.put("userId", String.valueOf(userId));
             } catch (ExpiredJwtException e) {
                 request.setAttribute("errorMessage", "토큰이 만료되었습니다.");
             } catch (Exception e) {

--- a/src/main/java/com/aisip/OnO/backend/common/auth/JwtTokenFilter.java
+++ b/src/main/java/com/aisip/OnO/backend/common/auth/JwtTokenFilter.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.common.auth;
 
 import com.aisip.OnO.backend.auth.entity.Authority;
+import com.aisip.OnO.backend.auth.exception.AuthErrorCase;
 import com.aisip.OnO.backend.auth.service.JwtTokenizer;
 import com.aisip.OnO.backend.util.redis.RedisTokenService;
 import io.jsonwebtoken.Claims;
@@ -28,6 +29,7 @@ import static com.aisip.OnO.backend.auth.service.JwtTokenizer.BEARER_PREFIX;
 public class JwtTokenFilter extends OncePerRequestFilter {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String AUTH_ERROR_CASE_ATTRIBUTE = "authErrorCase";
 
     private final JwtTokenizer jwtTokenizer;
     private final RedisTokenService redisTokenService;
@@ -69,7 +71,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
                 // 2. 블랙리스트 체크 (로그아웃된 토큰인지 확인)
                 if (redisTokenService.isBlacklisted(accessToken)) {
-                    request.setAttribute("errorMessage", "로그아웃된 토큰입니다.");
+                    request.setAttribute(AUTH_ERROR_CASE_ATTRIBUTE, AuthErrorCase.INVALID_ACCESS_TOKEN);
                     filterChain.doFilter(request, response);
                     return;
                 }
@@ -87,9 +89,9 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 MDC.put("userId", String.valueOf(userId));
             } catch (ExpiredJwtException e) {
-                request.setAttribute("errorMessage", "토큰이 만료되었습니다.");
+                request.setAttribute(AUTH_ERROR_CASE_ATTRIBUTE, AuthErrorCase.ACCESS_TOKEN_EXPIRED);
             } catch (Exception e) {
-                request.setAttribute("errorMessage", "인증이 실패했습니다.");
+                request.setAttribute(AUTH_ERROR_CASE_ATTRIBUTE, AuthErrorCase.AUTHENTICATION_FAILED);
             }
         }
 

--- a/src/main/java/com/aisip/OnO/backend/common/config/LoggingFilterConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/common/config/LoggingFilterConfig.java
@@ -12,9 +12,8 @@ public class LoggingFilterConfig {
         CommonsRequestLoggingFilter filter = new CommonsRequestLoggingFilter();
         filter.setIncludeClientInfo(true);
         filter.setIncludeQueryString(true);
-        filter.setIncludePayload(true);
+        filter.setIncludePayload(false);
         filter.setIncludeHeaders(false);
-        filter.setMaxPayloadLength(10000);
         return filter;
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/common/config/RequestLoggingMdcFilter.java
+++ b/src/main/java/com/aisip/OnO/backend/common/config/RequestLoggingMdcFilter.java
@@ -1,0 +1,92 @@
+package com.aisip.OnO.backend.common.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestLoggingMdcFilter extends OncePerRequestFilter {
+
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.contains("/actuator/")
+                || path.equals("/robots.txt")
+                || path.startsWith("/images/")
+                || path.startsWith("/css/")
+                || path.startsWith("/js/")
+                || path.startsWith("/swagger-ui/")
+                || path.startsWith("/v3/api-docs/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        long startedAt = System.currentTimeMillis();
+        String traceId = resolveTraceId(request);
+
+        MDC.put("traceId", traceId);
+        MDC.put("method", request.getMethod());
+        MDC.put("uri", request.getRequestURI());
+
+        Exception failure = null;
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ServletException | IOException | RuntimeException ex) {
+            failure = ex;
+            MDC.put("exceptionType", ex.getClass().getSimpleName());
+            throw ex;
+        } finally {
+            long latencyMs = System.currentTimeMillis() - startedAt;
+            int status = failure == null ? response.getStatus() : resolveFailureStatus(response);
+
+            MDC.put("status", String.valueOf(status));
+            MDC.put("latencyMs", String.valueOf(latencyMs));
+
+            log.info("HTTP request completed");
+            clearMdc();
+        }
+    }
+
+    private String resolveTraceId(HttpServletRequest request) {
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        if (requestId == null || requestId.isBlank()) {
+            return UUID.randomUUID().toString();
+        }
+        return requestId;
+    }
+
+    private int resolveFailureStatus(HttpServletResponse response) {
+        int status = response.getStatus();
+        if (status < HttpServletResponse.SC_BAD_REQUEST) {
+            return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        }
+        return status;
+    }
+
+    private void clearMdc() {
+        MDC.remove("traceId");
+        MDC.remove("userId");
+        MDC.remove("method");
+        MDC.remove("uri");
+        MDC.remove("status");
+        MDC.remove("latencyMs");
+        MDC.remove("errorCode");
+        MDC.remove("exceptionType");
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/common/config/RequestLoggingMdcFilter.java
+++ b/src/main/java/com/aisip/OnO/backend/common/config/RequestLoggingMdcFilter.java
@@ -6,9 +6,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -20,6 +22,11 @@ import java.util.UUID;
 public class RequestLoggingMdcFilter extends OncePerRequestFilter {
 
     private static final String REQUEST_ID_HEADER = "X-Request-Id";
+    private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private static final String REAL_IP_HEADER = "X-Real-IP";
+
+    @Value("${logging.http.slow-request-threshold-ms:1000}")
+    private long slowRequestThresholdMs;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -43,6 +50,8 @@ public class RequestLoggingMdcFilter extends OncePerRequestFilter {
         MDC.put("traceId", traceId);
         MDC.put("method", request.getMethod());
         MDC.put("uri", request.getRequestURI());
+        MDC.put("clientIp", resolveClientIp(request));
+        response.setHeader(REQUEST_ID_HEADER, traceId);
 
         Exception failure = null;
         try {
@@ -57,8 +66,9 @@ public class RequestLoggingMdcFilter extends OncePerRequestFilter {
 
             MDC.put("status", String.valueOf(status));
             MDC.put("latencyMs", String.valueOf(latencyMs));
+            MDC.put("uri", resolveUriPattern(request));
 
-            log.info("HTTP request completed");
+            logRequestCompleted(status, latencyMs);
             clearMdc();
         }
     }
@@ -79,11 +89,53 @@ public class RequestLoggingMdcFilter extends OncePerRequestFilter {
         return status;
     }
 
+    private String resolveUriPattern(HttpServletRequest request) {
+        Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (pattern instanceof String matchedPattern && !matchedPattern.isBlank()) {
+            return matchedPattern;
+        }
+        return request.getRequestURI();
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",", 2)[0].trim();
+        }
+
+        String realIp = request.getHeader(REAL_IP_HEADER);
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp;
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    private void logRequestCompleted(int status, long latencyMs) {
+        if (status >= HttpServletResponse.SC_INTERNAL_SERVER_ERROR) {
+            log.error("HTTP request completed");
+            return;
+        }
+
+        if (status >= HttpServletResponse.SC_BAD_REQUEST) {
+            log.warn("HTTP request completed");
+            return;
+        }
+
+        if (latencyMs >= slowRequestThresholdMs) {
+            log.info("HTTP slow request completed");
+            return;
+        }
+
+        log.debug("HTTP request completed");
+    }
+
     private void clearMdc() {
         MDC.remove("traceId");
         MDC.remove("userId");
         MDC.remove("method");
         MDC.remove("uri");
+        MDC.remove("clientIp");
         MDC.remove("status");
         MDC.remove("latencyMs");
         MDC.remove("errorCode");

--- a/src/main/java/com/aisip/OnO/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aisip/OnO/backend/common/exception/GlobalExceptionHandler.java
@@ -2,34 +2,41 @@ package com.aisip.OnO.backend.common.exception;
 
 import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.util.webhook.DiscordWebhookNotificationService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import jakarta.validation.ConstraintViolationException;
 import org.slf4j.MDC;
 import org.springframework.http.*;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.ErrorResponseException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @ControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
-    private final ObjectMapper objectMapper;
     private final DiscordWebhookNotificationService discordWebhookNotificationService;
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<CommonResponse> handleApplicationException(ApplicationException e, WebRequest request) {
         CommonResponse commonResponse = CommonResponse.error(e.getErrorCase());
 
-        HttpStatus status = HttpStatus.valueOf(e.getErrorCase().getHttpStatusCode());
+        HttpStatusCode status = HttpStatusCode.valueOf(e.getErrorCase().getHttpStatusCode());
         putErrorMdc(e.getErrorCase().getErrorCode(), e);
         logByStatus(status, "Application exception handled: {}", e.getMessage(), e);
-        sendToDiscord(e, request, status);
+        notifyIfServerError(e, request, status);
 
         return ResponseEntity
                 .status(e.getErrorCase().getHttpStatusCode())
@@ -45,27 +52,74 @@ public class GlobalExceptionHandler {
 
         putErrorMdc(400, ex);
         log.warn("Validation exception handled: {}", message);
-        sendToDiscord(ex, request, HttpStatus.BAD_REQUEST);
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(commonResponse);
     }
 
+    @ExceptionHandler(ErrorResponseException.class)
+    public ResponseEntity<CommonResponse> handleErrorResponseException(ErrorResponseException ex, WebRequest request) {
+        return handleSpringStatusException(ex, request, ex.getStatusCode(), resolveErrorMessage(ex));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<CommonResponse> handleNoResourceFoundException(NoResourceFoundException ex, WebRequest request) {
+        return handleSpringStatusException(ex, request, ex.getStatusCode(), "요청한 리소스를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class,
+            MissingRequestHeaderException.class,
+            BindException.class,
+            ConstraintViolationException.class
+    })
+    public ResponseEntity<CommonResponse> handleBadRequestException(Exception ex, WebRequest request) {
+        return handleSpringStatusException(ex, request, HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<CommonResponse> handleException(Exception ex, WebRequest request) {
+        if (ex instanceof ErrorResponse errorResponse) {
+            return handleSpringStatusException(ex, request, errorResponse.getStatusCode(), resolveErrorMessage(errorResponse));
+        }
+
         CommonResponse commonResponse = CommonResponse.error(500, "서버 내부 오류가 발생했습니다.");
 
         putErrorMdc(500, ex);
         log.error("Unhandled exception occurred", ex);
-        sendToDiscord(ex, request, HttpStatus.INTERNAL_SERVER_ERROR);
+        notifyIfServerError(ex, request, HttpStatus.INTERNAL_SERVER_ERROR);
 
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(commonResponse);
     }
 
-    private void sendToDiscord(Exception ex, WebRequest request, HttpStatus status) {
+    private ResponseEntity<CommonResponse> handleSpringStatusException(Exception ex,
+                                                                      WebRequest request,
+                                                                      HttpStatusCode status,
+                                                                      String message) {
+        CommonResponse commonResponse = CommonResponse.error(status.value(), message);
+
+        putErrorMdc(status.value(), ex);
+        logByStatus(status, "Spring MVC exception handled: {}", ex.getMessage(), ex);
+        notifyIfServerError(ex, request, status);
+
+        return ResponseEntity
+                .status(status)
+                .body(commonResponse);
+    }
+
+    private void notifyIfServerError(Exception ex, WebRequest request, HttpStatusCode status) {
+        if (!status.is5xxServerError()) {
+            return;
+        }
+        sendToDiscord(ex, request, status);
+    }
+
+    private void sendToDiscord(Exception ex, WebRequest request, HttpStatusCode status) {
         String path = ((ServletWebRequest) request).getRequest().getRequestURI();
         String errorMessage = ex.getMessage();
         String exceptionType = ex.getClass().getSimpleName();
@@ -83,11 +137,27 @@ public class GlobalExceptionHandler {
         MDC.put("exceptionType", ex.getClass().getSimpleName());
     }
 
-    private void logByStatus(HttpStatus status, String message, String detail, Exception ex) {
+    private void logByStatus(HttpStatusCode status, String message, String detail, Exception ex) {
         if (status.is5xxServerError()) {
             log.error(message, detail, ex);
             return;
         }
         log.warn(message, detail);
+    }
+
+    private String resolveErrorMessage(ErrorResponseException ex) {
+        return resolveErrorMessage((ErrorResponse) ex);
+    }
+
+    private String resolveErrorMessage(ErrorResponse errorResponse) {
+        if (errorResponse.getBody() == null) {
+            return "잘못된 요청입니다.";
+        }
+
+        String detail = errorResponse.getBody().getDetail();
+        if (detail == null || detail.isBlank()) {
+            return "잘못된 요청입니다.";
+        }
+        return detail;
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aisip/OnO/backend/common/exception/GlobalExceptionHandler.java
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
 
         HttpStatusCode status = HttpStatusCode.valueOf(e.getErrorCase().getHttpStatusCode());
         putErrorMdc(e.getErrorCase().getErrorCode(), e);
-        logByStatus(status, "Application exception handled: {}", e.getMessage(), e);
+        logByStatus(status, "Application exception handled", e.getMessage(), e);
         notifyIfServerError(e, request, status);
 
         return ResponseEntity
@@ -51,7 +51,7 @@ public class GlobalExceptionHandler {
         CommonResponse commonResponse = CommonResponse.error(400, message);
 
         putErrorMdc(400, ex);
-        log.warn("Validation exception handled: {}", message);
+        logByStatus(HttpStatus.BAD_REQUEST, "Validation exception handled", message, ex);
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
@@ -89,7 +89,7 @@ public class GlobalExceptionHandler {
         CommonResponse commonResponse = CommonResponse.error(500, "서버 내부 오류가 발생했습니다.");
 
         putErrorMdc(500, ex);
-        log.error("Unhandled exception occurred", ex);
+        logByStatus(HttpStatus.INTERNAL_SERVER_ERROR, "Unhandled exception handled", ex.getMessage(), ex);
         notifyIfServerError(ex, request, HttpStatus.INTERNAL_SERVER_ERROR);
 
         return ResponseEntity
@@ -104,7 +104,7 @@ public class GlobalExceptionHandler {
         CommonResponse commonResponse = CommonResponse.error(status.value(), message);
 
         putErrorMdc(status.value(), ex);
-        logByStatus(status, "Spring MVC exception handled: {}", ex.getMessage(), ex);
+        logByStatus(status, "Spring MVC exception handled", ex.getMessage(), ex);
         notifyIfServerError(ex, request, status);
 
         return ResponseEntity
@@ -137,12 +137,22 @@ public class GlobalExceptionHandler {
         MDC.put("exceptionType", ex.getClass().getSimpleName());
     }
 
-    private void logByStatus(HttpStatusCode status, String message, String detail, Exception ex) {
+    private void logByStatus(HttpStatusCode status, String event, String detail, Exception ex) {
+        String exceptionType = ex.getClass().getSimpleName();
         if (status.is5xxServerError()) {
-            log.error(message, detail, ex);
+            log.error("{} - status: {}, exceptionType: {}, detail: {}",
+                    event,
+                    status.value(),
+                    exceptionType,
+                    detail,
+                    ex);
             return;
         }
-        log.warn(message, detail);
+        log.warn("{} - status: {}, exceptionType: {}, detail: {}",
+                event,
+                status.value(),
+                exceptionType,
+                detail);
     }
 
     private String resolveErrorMessage(ErrorResponseException ex) {

--- a/src/main/java/com/aisip/OnO/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aisip/OnO/backend/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.aisip.OnO.backend.util.webhook.DiscordWebhookNotificationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.*;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -26,6 +27,8 @@ public class GlobalExceptionHandler {
         CommonResponse commonResponse = CommonResponse.error(e.getErrorCase());
 
         HttpStatus status = HttpStatus.valueOf(e.getErrorCase().getHttpStatusCode());
+        putErrorMdc(e.getErrorCase().getErrorCode(), e);
+        logByStatus(status, "Application exception handled: {}", e.getMessage(), e);
         sendToDiscord(e, request, status);
 
         return ResponseEntity
@@ -40,10 +43,25 @@ public class GlobalExceptionHandler {
         String message = bindingResult.getAllErrors().get(0).getDefaultMessage();
         CommonResponse commonResponse = CommonResponse.error(400, message);
 
+        putErrorMdc(400, ex);
+        log.warn("Validation exception handled: {}", message);
         sendToDiscord(ex, request, HttpStatus.BAD_REQUEST);
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
+                .body(commonResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse> handleException(Exception ex, WebRequest request) {
+        CommonResponse commonResponse = CommonResponse.error(500, "서버 내부 오류가 발생했습니다.");
+
+        putErrorMdc(500, ex);
+        log.error("Unhandled exception occurred", ex);
+        sendToDiscord(ex, request, HttpStatus.INTERNAL_SERVER_ERROR);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(commonResponse);
     }
 
@@ -59,5 +77,17 @@ public class GlobalExceptionHandler {
                 exceptionType
         );
     }
-}
 
+    private void putErrorMdc(Integer errorCode, Exception ex) {
+        MDC.put("errorCode", String.valueOf(errorCode));
+        MDC.put("exceptionType", ex.getClass().getSimpleName());
+    }
+
+    private void logByStatus(HttpStatus status, String message, String detail, Exception ex) {
+        if (status.is5xxServerError()) {
+            log.error(message, detail, ex);
+            return;
+        }
+        log.warn(message, detail);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/config/P6SpyExplainAppender.java
+++ b/src/main/java/com/aisip/OnO/backend/config/P6SpyExplainAppender.java
@@ -3,8 +3,6 @@ package com.aisip.OnO.backend.config;
 import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.engine.jdbc.internal.FormatStyle;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -28,10 +26,6 @@ public class P6SpyExplainAppender implements MessageFormattingStrategy {
         return Boolean.parseBoolean(System.getProperty("p6spy.enable.explain", "false"));
     }
 
-    // EXPLAIN을 실행할 쿼리의 최소 실행 시간 (ms)
-    // 0으로 설정하면 모든 SELECT 쿼리에 대해 EXPLAIN 실행
-    private static final long SLOW_QUERY_THRESHOLD_MS = 0;
-
     @Override
     public String formatMessage(int connectionId, String now, long elapsed,
                                  String category, String prepared, String sql, String url) {
@@ -45,17 +39,14 @@ public class P6SpyExplainAppender implements MessageFormattingStrategy {
 
         // 기본 로그 출력
         String formattedSql = formatSql(category, sql);
-        result.append(String.format("[P6Spy] | %s | took %dms | %s | connection %d\n%s\n",
+        result.append(String.format("[P6Spy][SLOW_QUERY] | %s | took %dms | %s | connection %d\n%s\n",
                 now, elapsed, category, connectionId, formattedSql));
 
         // EXPLAIN 실행 조건 체크
         boolean explainEnabled = isExplainEnabled();
         boolean isSelect = sql.trim().toLowerCase(Locale.ROOT).startsWith("select");
-        boolean isSlowQuery = elapsed >= SLOW_QUERY_THRESHOLD_MS;
 
-        // ⭐ category 필터 제거: statement, commit 모두 EXPLAIN 실행
-        // PreparedStatement도 분석하기 위해 category 조건을 완화
-        boolean shouldExplain = explainEnabled && isSelect && isSlowQuery;
+        boolean shouldExplain = explainEnabled && isSelect;
 
         if (shouldExplain) {
             try {
@@ -64,7 +55,7 @@ public class P6SpyExplainAppender implements MessageFormattingStrategy {
                 result.append("╔════════════════════════════════════════════════════════════════════════════════╗\n");
                 result.append("║                         EXPLAIN RESULT (took " + elapsed + "ms)                          ║\n");
                 result.append("╠════════════════════════════════════════════════════════════════════════════════╣\n");
-                result.append("║ Query: ").append(String.format("%-70s", sql.replaceAll("\\s+", " ").trim().substring(0, Math.min(70, sql.length())))).append(" ║\n");
+                result.append("║ Query: ").append(String.format("%-70s", summarizeSql(sql))).append(" ║\n");
                 result.append("╠════════════════════════════════════════════════════════════════════════════════╣\n");
                 result.append(explainResult);
                 result.append("╚════════════════════════════════════════════════════════════════════════════════╝\n");
@@ -86,6 +77,11 @@ public class P6SpyExplainAppender implements MessageFormattingStrategy {
         }
 
         return sql;
+    }
+
+    private String summarizeSql(String sql) {
+        String normalizedSql = sql.replaceAll("\\s+", " ").trim();
+        return normalizedSql.substring(0, Math.min(70, normalizedSql.length()));
     }
 
     private String executeExplain(String sql, String jdbcUrl) throws Exception {

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/FcmNotificationConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/FcmNotificationConsumer.java
@@ -40,15 +40,18 @@ public class FcmNotificationConsumer {
      */
     @RabbitListener(queues = RabbitMQConfig.FCM_NOTIFICATION_QUEUE, concurrency = "5-15")
     public void handleNotificationMessage(FcmNotificationMessage message) {
-        log.info("[FCM Notification Consumer] 메시지 수신 - userId: {}, title: {}, retryCount: {}",
-                message.getUserId(), message.getTitle(), message.getRetryCount());
+        log.info("RabbitMQ message received - queue: {}, operation: {}, userId: {}, messageRetryCount: {}",
+                RabbitMQConfig.FCM_NOTIFICATION_QUEUE, "fcm_notification",
+                message.getUserId(), message.getRetryCount());
 
         try {
             // 사용자의 모든 FCM 토큰 조회
             List<FcmToken> userFcmTokenList = fcmTokenRepository.findAllByUserId(message.getUserId());
 
             if (userFcmTokenList.isEmpty()) {
-                log.warn("[FCM Notification Consumer] FCM 토큰 없음 - userId: {}", message.getUserId());
+                log.warn("RabbitMQ message skipped - queue: {}, operation: {}, outcome: {}, userId: {}, messageRetryCount: {}",
+                        RabbitMQConfig.FCM_NOTIFICATION_QUEUE, "fcm_notification", "token_not_found",
+                        message.getUserId(), message.getRetryCount());
                 return; // 토큰 없으면 스킵 (정상 처리)
             }
 
@@ -61,22 +64,25 @@ public class FcmNotificationConsumer {
                     sendToDevice(fcmToken.getToken(), message);
                     successCount++;
                 } catch (Exception e) {
-                    log.warn("[FCM Notification Consumer] 디바이스 전송 실패 - userId: {}, error: {}",
-                            message.getUserId(), e.getMessage());
+                    log.warn("RabbitMQ device delivery failed - queue: {}, operation: {}, userId: {}, error: {}",
+                            RabbitMQConfig.FCM_NOTIFICATION_QUEUE, "fcm_notification", message.getUserId(), e.getMessage());
                     failCount++;
                 }
             }
-
-            log.info("[FCM Notification Consumer] 전송 완료 - userId: {}, 성공: {}, 실패: {}",
-                    message.getUserId(), successCount, failCount);
 
             // 모든 디바이스 전송 실패 시 예외 발생 (재시도)
             if (successCount == 0 && failCount > 0) {
                 throw new RuntimeException("모든 디바이스 FCM 전송 실패 - userId: " + message.getUserId());
             }
 
+            String outcome = failCount > 0 ? "partial_success" : "success";
+            log.info("RabbitMQ message processed - queue: {}, operation: {}, outcome: {}, userId: {}, successCount: {}, failCount: {}",
+                    RabbitMQConfig.FCM_NOTIFICATION_QUEUE, "fcm_notification", outcome,
+                    message.getUserId(), successCount, failCount);
+
         } catch (Exception e) {
-            log.error("[FCM Notification Consumer] 알림 전송 실패 - userId: {}, retryCount: {}, error: {}",
+            log.error("RabbitMQ message failed - queue: {}, operation: {}, outcome: {}, userId: {}, messageRetryCount: {}, error: {}",
+                    RabbitMQConfig.FCM_NOTIFICATION_QUEUE, "fcm_notification", "failure",
                     message.getUserId(), message.getRetryCount(), e.getMessage());
 
             // 예외를 던지면 RabbitMQ가 자동으로 재시도 or DLQ로 전송
@@ -101,7 +107,8 @@ public class FcmNotificationConsumer {
         try {
             String messageId = firebaseMessaging.send(fcmMessage);
             recordExternalCall("firebase", "send_notification_async", "success", sample);
-            log.debug("[FCM Notification Consumer] FCM 전송 성공 - messageId: {}", messageId);
+            log.debug("External delivery succeeded - dependency: {}, operation: {}, messageId: {}",
+                    "firebase", "send_notification_async", messageId);
         } catch (FirebaseMessagingException e) {
             recordExternalCall("firebase", "send_notification_async", "failure", sample);
             throw e;
@@ -115,17 +122,18 @@ public class FcmNotificationConsumer {
      */
     @RabbitListener(queues = RabbitMQConfig.FCM_NOTIFICATION_DLQ)
     public void handleNotificationDLQ(FcmNotificationMessage message) {
-        log.error("[FCM Notification DLQ] 최종 실패 메시지 - userId: {}, title: {}, retryCount: {}",
-                message.getUserId(), message.getTitle(), message.getRetryCount());
+        log.error("RabbitMQ message moved to DLQ - queue: {}, operation: {}, outcome: {}, userId: {}, messageRetryCount: {}",
+                RabbitMQConfig.FCM_NOTIFICATION_DLQ, "fcm_notification", "dlq",
+                message.getUserId(), message.getRetryCount());
 
         // Discord 알림 전송
         String errorTitle = String.format("🚨 FCM 푸시 알림 최종 실패 (DLQ)");
         String errorDetails = String.format(
-                "**User ID:** %d\n**Title:** %s\n**Body:** %s\n**Retry Count:** %d\n\n" +
+                "**Queue:** %s\n**Operation:** %s\n**User ID:** %d\n**Message Retry Count:** %d\n\n" +
                 "모든 재시도가 실패했습니다. FCM 토큰을 확인하거나 수동으로 알림을 재전송해주세요.",
+                RabbitMQConfig.FCM_NOTIFICATION_DLQ,
+                "fcm_notification",
                 message.getUserId(),
-                message.getTitle(),
-                message.getBody(),
                 message.getRetryCount()
         );
 
@@ -136,9 +144,11 @@ public class FcmNotificationConsumer {
                     "ERROR",
                     errorTitle
             );
-            log.info("[FCM Notification DLQ] Discord 알림 전송 완료");
+            log.info("RabbitMQ DLQ notification sent - queue: {}, operation: {}, userId: {}",
+                    RabbitMQConfig.FCM_NOTIFICATION_DLQ, "fcm_notification", message.getUserId());
         } catch (Exception e) {
-            log.error("[FCM Notification DLQ] Discord 알림 전송 실패: {}", e.getMessage());
+            log.error("RabbitMQ DLQ notification failed - queue: {}, operation: {}, userId: {}, error: {}",
+                    RabbitMQConfig.FCM_NOTIFICATION_DLQ, "fcm_notification", message.getUserId(), e.getMessage());
         }
     }
 

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/FcmNotificationConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/FcmNotificationConsumer.java
@@ -61,8 +61,8 @@ public class FcmNotificationConsumer {
                     sendToDevice(fcmToken.getToken(), message);
                     successCount++;
                 } catch (Exception e) {
-                    log.warn("[FCM Notification Consumer] 디바이스 전송 실패 - userId: {}, token: {}, error: {}",
-                            message.getUserId(), fcmToken.getToken(), e.getMessage());
+                    log.warn("[FCM Notification Consumer] 디바이스 전송 실패 - userId: {}, error: {}",
+                            message.getUserId(), e.getMessage());
                     failCount++;
                 }
             }

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
@@ -32,34 +32,39 @@ public class ProblemAnalysisConsumer {
      */
     @RabbitListener(queues = RabbitMQConfig.GPT_ANALYSIS_QUEUE, concurrency = "1-3")
     public void handleAnalysisMessage(ProblemAnalysisMessage message) {
-        log.info("[GPT Analysis Consumer] 메시지 수신 - problemId: {}, retryCount: {}",
-                message.getProblemId(), message.getRetryCount());
+        log.info("RabbitMQ message received - queue: {}, operation: {}, problemId: {}, messageRetryCount: {}",
+                RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", message.getProblemId(), message.getRetryCount());
 
         try {
             // 실제 GPT 분석 수행
             analysisService.analyzeProblemSync(message.getProblemId());
 
-            log.info("[GPT Analysis Consumer] 분석 성공 - problemId: {}", message.getProblemId());
+            log.info("RabbitMQ message processed - queue: {}, operation: {}, outcome: {}, problemId: {}",
+                    RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", "success", message.getProblemId());
 
         } catch (NonRetryableAnalysisException e) {
-            log.warn("[GPT Analysis Consumer] 비재시도 분석 실패 처리 - problemId: {}, error: {}",
-                    message.getProblemId(), e.getMessage());
+            log.warn("RabbitMQ message skipped - queue: {}, operation: {}, outcome: {}, problemId: {}, messageRetryCount: {}, reason: {}",
+                    RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", "non_retryable_failure",
+                    message.getProblemId(), message.getRetryCount(), e.getMessage());
             // 상태는 Service에서 FAILED로 업데이트됨. 재큐잉 없이 종료(ACK)
             return;
         } catch (ApplicationException e) {
             if (e.getErrorCase() == ProblemErrorCase.PROBLEM_NOT_FOUND) {
-                log.warn("[GPT Analysis Consumer] 문제가 이미 삭제/미존재하여 분석 스킵 - problemId: {}",
-                        message.getProblemId());
+                log.warn("RabbitMQ message skipped - queue: {}, operation: {}, outcome: {}, problemId: {}, messageRetryCount: {}",
+                        RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", "resource_not_found",
+                        message.getProblemId(), message.getRetryCount());
                 return;
             }
 
-            log.error("[GPT Analysis Consumer] 분석 실패 - problemId: {}, retryCount: {}, error: {}",
+            log.error("RabbitMQ message failed - queue: {}, operation: {}, outcome: {}, problemId: {}, messageRetryCount: {}, error: {}",
+                    RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", "failure",
                     message.getProblemId(), message.getRetryCount(), e.getMessage());
 
             // 예외를 던지면 RabbitMQ가 자동으로 재시도 or DLQ로 전송
             throw new RuntimeException("GPT 문제 분석 실패: " + message.getProblemId(), e);
         } catch (Exception e) {
-            log.error("[GPT Analysis Consumer] 분석 실패 - problemId: {}, retryCount: {}, error: {}",
+            log.error("RabbitMQ message failed - queue: {}, operation: {}, outcome: {}, problemId: {}, messageRetryCount: {}, error: {}",
+                    RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", "failure",
                     message.getProblemId(), message.getRetryCount(), e.getMessage());
 
             // 예외를 던지면 RabbitMQ가 자동으로 재시도 or DLQ로 전송
@@ -74,14 +79,17 @@ public class ProblemAnalysisConsumer {
      */
     @RabbitListener(queues = RabbitMQConfig.GPT_ANALYSIS_DLQ)
     public void handleAnalysisDLQ(ProblemAnalysisMessage message) {
-        log.error("[GPT Analysis DLQ] 최종 실패 메시지 - problemId: {}, retryCount: {}",
+        log.error("RabbitMQ message moved to DLQ - queue: {}, operation: {}, outcome: {}, problemId: {}, messageRetryCount: {}",
+                RabbitMQConfig.GPT_ANALYSIS_DLQ, "problem_analysis", "dlq",
                 message.getProblemId(), message.getRetryCount());
 
         // Discord 알림 전송
         String errorTitle = String.format("🚨 GPT 문제 분석 최종 실패 (DLQ)");
         String errorDetails = String.format(
-                "**Problem ID:** %d\n**Retry Count:** %d\n\n" +
+                "**Queue:** %s\n**Operation:** %s\n**Problem ID:** %d\n**Message Retry Count:** %d\n\n" +
                 "모든 재시도가 실패했습니다. 문제를 확인하고 수동으로 재분석을 요청해주세요.",
+                RabbitMQConfig.GPT_ANALYSIS_DLQ,
+                "problem_analysis",
                 message.getProblemId(),
                 message.getRetryCount()
         );
@@ -93,9 +101,11 @@ public class ProblemAnalysisConsumer {
                     "ERROR",
                     errorTitle
             );
-            log.info("[GPT Analysis DLQ] Discord 알림 전송 완료");
+            log.info("RabbitMQ DLQ notification sent - queue: {}, operation: {}, problemId: {}",
+                    RabbitMQConfig.GPT_ANALYSIS_DLQ, "problem_analysis", message.getProblemId());
         } catch (Exception e) {
-            log.error("[GPT Analysis DLQ] Discord 알림 전송 실패: {}", e.getMessage());
+            log.error("RabbitMQ DLQ notification failed - queue: {}, operation: {}, problemId: {}, error: {}",
+                    RabbitMQConfig.GPT_ANALYSIS_DLQ, "problem_analysis", message.getProblemId(), e.getMessage());
         }
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/S3DeleteConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/S3DeleteConsumer.java
@@ -29,22 +29,21 @@ public class S3DeleteConsumer {
      */
     @RabbitListener(queues = RabbitMQConfig.S3_DELETE_QUEUE, concurrency = "3-10")
     public void handleS3DeleteMessage(S3DeleteMessage message) {
-        log.info("[S3 Delete Consumer] 메시지 수신 - imageUrl: {}, problemId: {}, retryCount: {}",
-                message.getImageUrl(), message.getProblemId(), message.getRetryCount());
+        log.info("[S3 Delete Consumer] 메시지 수신 - problemId: {}, retryCount: {}",
+                message.getProblemId(), message.getRetryCount());
 
         try {
             // S3 파일 삭제 실행
             fileUploadService.deleteImageFileFromS3(message.getImageUrl());
 
-            log.info("[S3 Delete Consumer] 삭제 성공 - imageUrl: {}, problemId: {}",
-                    message.getImageUrl(), message.getProblemId());
+            log.info("[S3 Delete Consumer] 삭제 성공 - problemId: {}", message.getProblemId());
 
         } catch (Exception e) {
-            log.error("[S3 Delete Consumer] 삭제 실패 - imageUrl: {}, problemId: {}, retryCount: {}, error: {}",
-                    message.getImageUrl(), message.getProblemId(), message.getRetryCount(), e.getMessage());
+            log.error("[S3 Delete Consumer] 삭제 실패 - problemId: {}, retryCount: {}, error: {}",
+                    message.getProblemId(), message.getRetryCount(), e.getMessage());
 
             // 예외를 던지면 RabbitMQ가 자동으로 재시도 or DLQ로 전송
-            throw new RuntimeException("S3 파일 삭제 실패: " + message.getImageUrl(), e);
+            throw new RuntimeException("S3 파일 삭제 실패 - problemId: " + message.getProblemId(), e);
         }
     }
 
@@ -55,16 +54,18 @@ public class S3DeleteConsumer {
      */
     @RabbitListener(queues = RabbitMQConfig.S3_DELETE_DLQ)
     public void handleS3DeleteDLQ(S3DeleteMessage message) {
-        log.error("[S3 Delete DLQ] 최종 실패 메시지 - imageUrl: {}, problemId: {}, retryCount: {}",
-                message.getImageUrl(), message.getProblemId(), message.getRetryCount());
+        String maskedObjectKey = maskS3ObjectKey(message.getImageUrl());
+
+        log.error("[S3 Delete DLQ] 최종 실패 메시지 - problemId: {}, objectKey: {}, retryCount: {}",
+                message.getProblemId(), maskedObjectKey, message.getRetryCount());
 
         // Discord 알림 전송
         String errorTitle = String.format("🚨 S3 파일 삭제 최종 실패 (DLQ)");
         String errorDetails = String.format(
-                "**Problem ID:** %d\n**Image URL:** %s\n**Retry Count:** %d\n\n" +
+                "**Problem ID:** %d\n**Object Key:** %s\n**Retry Count:** %d\n\n" +
                 "모든 재시도가 실패했습니다. 수동으로 S3에서 파일을 삭제하거나 메시지를 재처리해주세요.",
                 message.getProblemId(),
-                message.getImageUrl(),
+                maskedObjectKey,
                 message.getRetryCount()
         );
 
@@ -79,5 +80,23 @@ public class S3DeleteConsumer {
         } catch (Exception e) {
             log.error("[S3 Delete DLQ] Discord 알림 전송 실패: {}", e.getMessage());
         }
+    }
+
+    private String maskS3ObjectKey(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return "unknown";
+        }
+
+        String splitStr = ".com/";
+        int keyStartIndex = imageUrl.lastIndexOf(splitStr);
+        String objectKey = keyStartIndex >= 0
+                ? imageUrl.substring(keyStartIndex + splitStr.length())
+                : imageUrl;
+
+        if (objectKey.length() <= 16) {
+            return "***";
+        }
+
+        return objectKey.substring(0, 8) + "***" + objectKey.substring(objectKey.length() - 8);
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/S3DeleteConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/S3DeleteConsumer.java
@@ -29,17 +29,19 @@ public class S3DeleteConsumer {
      */
     @RabbitListener(queues = RabbitMQConfig.S3_DELETE_QUEUE, concurrency = "3-10")
     public void handleS3DeleteMessage(S3DeleteMessage message) {
-        log.info("[S3 Delete Consumer] 메시지 수신 - problemId: {}, retryCount: {}",
-                message.getProblemId(), message.getRetryCount());
+        log.info("RabbitMQ message received - queue: {}, operation: {}, problemId: {}, messageRetryCount: {}",
+                RabbitMQConfig.S3_DELETE_QUEUE, "s3_delete", message.getProblemId(), message.getRetryCount());
 
         try {
             // S3 파일 삭제 실행
             fileUploadService.deleteImageFileFromS3(message.getImageUrl());
 
-            log.info("[S3 Delete Consumer] 삭제 성공 - problemId: {}", message.getProblemId());
+            log.info("RabbitMQ message processed - queue: {}, operation: {}, outcome: {}, problemId: {}",
+                    RabbitMQConfig.S3_DELETE_QUEUE, "s3_delete", "success", message.getProblemId());
 
         } catch (Exception e) {
-            log.error("[S3 Delete Consumer] 삭제 실패 - problemId: {}, retryCount: {}, error: {}",
+            log.error("RabbitMQ message failed - queue: {}, operation: {}, outcome: {}, problemId: {}, messageRetryCount: {}, error: {}",
+                    RabbitMQConfig.S3_DELETE_QUEUE, "s3_delete", "failure",
                     message.getProblemId(), message.getRetryCount(), e.getMessage());
 
             // 예외를 던지면 RabbitMQ가 자동으로 재시도 or DLQ로 전송
@@ -56,14 +58,17 @@ public class S3DeleteConsumer {
     public void handleS3DeleteDLQ(S3DeleteMessage message) {
         String maskedObjectKey = maskS3ObjectKey(message.getImageUrl());
 
-        log.error("[S3 Delete DLQ] 최종 실패 메시지 - problemId: {}, objectKey: {}, retryCount: {}",
+        log.error("RabbitMQ message moved to DLQ - queue: {}, operation: {}, outcome: {}, problemId: {}, objectKey: {}, messageRetryCount: {}",
+                RabbitMQConfig.S3_DELETE_DLQ, "s3_delete", "dlq",
                 message.getProblemId(), maskedObjectKey, message.getRetryCount());
 
         // Discord 알림 전송
         String errorTitle = String.format("🚨 S3 파일 삭제 최종 실패 (DLQ)");
         String errorDetails = String.format(
-                "**Problem ID:** %d\n**Object Key:** %s\n**Retry Count:** %d\n\n" +
+                "**Queue:** %s\n**Operation:** %s\n**Problem ID:** %d\n**Object Key:** %s\n**Message Retry Count:** %d\n\n" +
                 "모든 재시도가 실패했습니다. 수동으로 S3에서 파일을 삭제하거나 메시지를 재처리해주세요.",
+                RabbitMQConfig.S3_DELETE_DLQ,
+                "s3_delete",
                 message.getProblemId(),
                 maskedObjectKey,
                 message.getRetryCount()
@@ -76,9 +81,11 @@ public class S3DeleteConsumer {
                     "ERROR",
                     errorTitle
             );
-            log.info("[S3 Delete DLQ] Discord 알림 전송 완료");
+            log.info("RabbitMQ DLQ notification sent - queue: {}, operation: {}, problemId: {}",
+                    RabbitMQConfig.S3_DELETE_DLQ, "s3_delete", message.getProblemId());
         } catch (Exception e) {
-            log.error("[S3 Delete DLQ] Discord 알림 전송 실패: {}", e.getMessage());
+            log.error("RabbitMQ DLQ notification failed - queue: {}, operation: {}, problemId: {}, error: {}",
+                    RabbitMQConfig.S3_DELETE_DLQ, "s3_delete", message.getProblemId(), e.getMessage());
         }
     }
 

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/FcmNotificationProducer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/FcmNotificationProducer.java
@@ -37,10 +37,13 @@ public class FcmNotificationProducer {
                     message
             );
 
-            log.info("[FCM Notification Producer] 메시지 전송 성공 - userId: {}, title: {}", userId, title);
+            log.info("RabbitMQ message sent - exchange: {}, routingKey: {}, operation: {}, userId: {}",
+                    RabbitMQConfig.NOTIFICATION_EXCHANGE, RabbitMQConfig.FCM_NOTIFICATION_ROUTING_KEY,
+                    "fcm_notification", userId);
         } catch (Exception e) {
-            log.error("[FCM Notification Producer] 메시지 전송 실패 - userId: {}, error: {}",
-                    userId, e.getMessage(), e);
+            log.error("RabbitMQ message send failed - exchange: {}, routingKey: {}, operation: {}, userId: {}, error: {}",
+                    RabbitMQConfig.NOTIFICATION_EXCHANGE, RabbitMQConfig.FCM_NOTIFICATION_ROUTING_KEY,
+                    "fcm_notification", userId, e.getMessage(), e);
             // 알림 전송 실패해도 예외를 던지지 않음 (알림은 선택적 기능)
         }
     }

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/ProblemAnalysisProducer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/ProblemAnalysisProducer.java
@@ -32,10 +32,13 @@ public class ProblemAnalysisProducer {
                     message
             );
 
-            log.info("[GPT Analysis Producer] 메시지 전송 성공 - problemId: {}", problemId);
+            log.info("RabbitMQ message sent - exchange: {}, routingKey: {}, operation: {}, problemId: {}",
+                    RabbitMQConfig.ANALYSIS_EXCHANGE, RabbitMQConfig.GPT_ANALYSIS_ROUTING_KEY,
+                    "problem_analysis", problemId);
         } catch (Exception e) {
-            log.error("[GPT Analysis Producer] 메시지 전송 실패 - problemId: {}, error: {}",
-                    problemId, e.getMessage(), e);
+            log.error("RabbitMQ message send failed - exchange: {}, routingKey: {}, operation: {}, problemId: {}, error: {}",
+                    RabbitMQConfig.ANALYSIS_EXCHANGE, RabbitMQConfig.GPT_ANALYSIS_ROUTING_KEY,
+                    "problem_analysis", problemId, e.getMessage(), e);
             // 메시지 전송 실패해도 예외를 던지지 않음 (분석은 선택적 기능)
         }
     }

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/S3DeleteProducer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/S3DeleteProducer.java
@@ -33,10 +33,13 @@ public class S3DeleteProducer {
                     message
             );
 
-            log.info("[S3 Delete Producer] 메시지 전송 성공 - problemId: {}", problemId);
+            log.info("RabbitMQ message sent - exchange: {}, routingKey: {}, operation: {}, problemId: {}",
+                    RabbitMQConfig.FILE_EXCHANGE, RabbitMQConfig.S3_DELETE_ROUTING_KEY,
+                    "s3_delete", problemId);
         } catch (Exception e) {
-            log.error("[S3 Delete Producer] 메시지 전송 실패 - problemId: {}, error: {}",
-                    problemId, e.getMessage(), e);
+            log.error("RabbitMQ message send failed - exchange: {}, routingKey: {}, operation: {}, problemId: {}, error: {}",
+                    RabbitMQConfig.FILE_EXCHANGE, RabbitMQConfig.S3_DELETE_ROUTING_KEY,
+                    "s3_delete", problemId, e.getMessage(), e);
             // 메시지 전송 실패해도 DB 삭제는 완료되므로 예외를 던지지 않음
         }
     }

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/S3DeleteProducer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/S3DeleteProducer.java
@@ -33,10 +33,10 @@ public class S3DeleteProducer {
                     message
             );
 
-            log.info("[S3 Delete Producer] 메시지 전송 성공 - imageUrl: {}, problemId: {}", imageUrl, problemId);
+            log.info("[S3 Delete Producer] 메시지 전송 성공 - problemId: {}", problemId);
         } catch (Exception e) {
-            log.error("[S3 Delete Producer] 메시지 전송 실패 - imageUrl: {}, problemId: {}, error: {}",
-                    imageUrl, problemId, e.getMessage(), e);
+            log.error("[S3 Delete Producer] 메시지 전송 실패 - problemId: {}, error: {}",
+                    problemId, e.getMessage(), e);
             // 메시지 전송 실패해도 DB 삭제는 완료되므로 예외를 던지지 않음
         }
     }

--- a/src/main/java/com/aisip/OnO/backend/folder/exception/FolderErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/exception/FolderErrorCase.java
@@ -8,11 +8,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FolderErrorCase implements ErrorCase {
 
-    FOLDER_NOT_FOUND(400, 5001, "폴더를 찾을 수 없습니다."),
+    FOLDER_NOT_FOUND(404, 5001, "폴더를 찾을 수 없습니다."),
 
-    FOLDER_USER_UNMATCHED(400, 5002, "폴더를 소유한 유저가 아닙니다."),
+    FOLDER_USER_UNMATCHED(403, 5002, "폴더를 소유한 유저가 아닙니다."),
 
-    ROOT_FOLDER_NOT_EXIST(400, 5003, "루트 폴더가 존재하지 않습니다."),
+    ROOT_FOLDER_NOT_EXIST(404, 5003, "루트 폴더가 존재하지 않습니다."),
 
     ROOT_FOLDER_CANNOT_REMOVE(400, 5004, "루트 폴더는 삭제할 수 없습니다.");
 

--- a/src/main/java/com/aisip/OnO/backend/mission/exception/MissionErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/exception/MissionErrorCase.java
@@ -10,7 +10,7 @@ public enum MissionErrorCase implements ErrorCase {
 
     MISSION_TYPE_NOT_FOUND(400, 7001, "잘못된 미션 종류입니다."),
 
-    USER_NOT_FOUND(400, 7002, "해당하는 유저가 존재하지 않습니다.");
+    USER_NOT_FOUND(404, 7002, "해당하는 유저가 존재하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/practicenote/exception/PracticeNoteErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/exception/PracticeNoteErrorCase.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PracticeNoteErrorCase implements ErrorCase {
 
-    PRACTICE_NOTE_NOT_FOUND(400, 6001, "복습 노트를 찾을 수 없습니다.");
+    PRACTICE_NOTE_NOT_FOUND(404, 6001, "복습 노트를 찾을 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/problem/exception/ProblemErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/exception/ProblemErrorCase.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProblemErrorCase implements ErrorCase {
 
-    PROBLEM_NOT_FOUND(400, 4001, "문제를 찾을 수 없습니다."),
+    PROBLEM_NOT_FOUND(404, 4001, "문제를 찾을 수 없습니다."),
 
-    PROBLEM_USER_UNMATCHED(400, 4002, "문제 작성자가 아닙니다."),
+    PROBLEM_USER_UNMATCHED(403, 4002, "문제 작성자가 아닙니다."),
 
     PROBLEM_SOLVE_IMAGE_ALREADY_REGISTERED(400, 4003, "이미 오늘의 복습을 완료한 문제입니다."),
 

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
@@ -190,7 +190,7 @@ public class ProblemAnalysisService {
     @Deprecated
     @Async
     public void analyzeProblemAsync(Long problemId) {
-        log.info("Starting async analysis for problemId: {}, imageUrls: {}", problemId);
+        log.info("Starting async analysis for problemId: {}", problemId);
 
         try {
             // Problem 조회
@@ -252,7 +252,7 @@ public class ProblemAnalysisService {
      */
     public ProblemAnalysisResponseDto testAnalyzeImage(String imageUrl) {
         try {
-            log.info("Testing image analysis for URL: {}", imageUrl);
+            log.info("Testing image analysis");
 
             // AI 분석 실행
             ProblemAnalysisResult result = openAIClient.analyzeImage(imageUrl);

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -291,7 +291,7 @@ public class ProblemService {
                 missionLogService.registerProblemPracticeMission(userId, problemId);
             }
 
-            log.info("Uploaded image to S3: {} for problemId: {}", imageUrl, problemId);
+            log.info("Uploaded image to S3 for problemId: {}, imageType: {}", problemId, imageType);
         }
     }
 
@@ -488,8 +488,8 @@ public class ProblemService {
             try {
                 s3DeleteProducer.sendDeleteMessage(imageData.getImageUrl(), problemId);
             } catch (Exception e) {
-                log.error("S3 삭제 메시지 전송 실패 - problemId: {}, imageUrl: {}, error: {}",
-                        problemId, imageData.getImageUrl(), e.getMessage());
+                log.error("S3 삭제 메시지 전송 실패 - problemId: {}, error: {}",
+                        problemId, e.getMessage());
             }
         });
 

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/exception/ProblemSolveErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/exception/ProblemSolveErrorCase.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProblemSolveErrorCase implements ErrorCase {
 
-    PROBLEM_SOLVE_NOT_FOUND(400, 4021, "복습 기록을 찾을 수 없습니다."),
-    PROBLEM_SOLVE_USER_UNMATCHED(400, 4022, "해당 복습 기록에 대한 권한이 없습니다.");
+    PROBLEM_SOLVE_NOT_FOUND(404, 4021, "복습 기록을 찾을 수 없습니다."),
+    PROBLEM_SOLVE_USER_UNMATCHED(403, 4022, "해당 복습 기록에 대한 권한이 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
@@ -139,7 +139,7 @@ public class ProblemSolveService {
             problemSolve.addImage(problemSolveImageData);
             problemSolveImageDataRepository.save(problemSolveImageData);
 
-            log.info("Uploaded problem solve image to S3: {} for problemSolveId: {}", imageUrl, problemSolveId);
+            log.info("Uploaded problem solve image to S3 for problemSolveId: {}, imageOrder: {}", problemSolveId, i);
         }
     }
 
@@ -191,8 +191,8 @@ public class ProblemSolveService {
             try {
                 s3DeleteProducer.sendDeleteMessage(image.getImageUrl(), problemSolveId);
             } catch (Exception e) {
-                log.error("S3 삭제 메시지 전송 실패 - problemSolveId: {}, imageUrl: {}, error: {}",
-                        problemSolveId, image.getImageUrl(), e.getMessage());
+                log.error("S3 삭제 메시지 전송 실패 - problemSolveId: {}, error: {}",
+                        problemSolveId, e.getMessage());
             }
         });
 
@@ -210,8 +210,8 @@ public class ProblemSolveService {
                 try {
                     s3DeleteProducer.sendDeleteMessage(image.getImageUrl(), record.getId());
                 } catch (Exception e) {
-                    log.error("S3 삭제 메시지 전송 실패 - problemSolveId: {}, imageUrl: {}, error: {}",
-                            record.getId(), image.getImageUrl(), e.getMessage());
+                    log.error("S3 삭제 메시지 전송 실패 - problemSolveId: {}, error: {}",
+                            record.getId(), e.getMessage());
                 }
             });
         });

--- a/src/main/java/com/aisip/OnO/backend/user/exception/UserErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/user/exception/UserErrorCase.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserErrorCase implements ErrorCase {
 
-    USER_NOT_FOUND(400, 3001, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(404, 3001, "사용자를 찾을 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/util/ai/OpenAIClient.java
+++ b/src/main/java/com/aisip/OnO/backend/util/ai/OpenAIClient.java
@@ -88,7 +88,7 @@ public class OpenAIClient {
                     .getMessage()
                     .getContent();
 
-            log.info("Received response from OpenAI: {}", content);
+            log.debug("Received response from OpenAI - contentLength: {}", content == null ? 0 : content.length());
 
             // 6. JSON 응답 파싱
             recordExternalCall("openai", "analyze_images", "success", sample);

--- a/src/main/java/com/aisip/OnO/backend/util/fcm/controller/FcmController.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fcm/controller/FcmController.java
@@ -25,7 +25,8 @@ public class FcmController {
     @PostMapping("/token")
     public CommonResponse<String> registerFcmToken(@RequestBody FcmTokenRequestDto fcmTokenRequestDto) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        log.info("fcm token: {}", fcmTokenRequestDto.token());
+        log.info("FCM token registration requested - userId: {}, tokenLength: {}",
+                userId, fcmTokenRequestDto.token() == null ? 0 : fcmTokenRequestDto.token().length());
 
         fcmService.registerToken(fcmTokenRequestDto, userId);
         return CommonResponse.success("문제가 등록되었습니다.");

--- a/src/main/java/com/aisip/OnO/backend/util/fcm/exception/FcmErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fcm/exception/FcmErrorCase.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FcmErrorCase implements ErrorCase {
 
-    FCM_TOKEN_NOT_FOUND(400, 7001, "Fcm Token을 찾을 수 없습니다."),
+    FCM_TOKEN_NOT_FOUND(404, 8001, "Fcm Token을 찾을 수 없습니다."),
 
-    FCM_SEND_FAILED(400, 7002, "Fcm 메시지 전송에 실패했습니다.");
+    FCM_SEND_FAILED(502, 8002, "Fcm 메시지 전송에 실패했습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/util/fcm/service/FcmService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fcm/service/FcmService.java
@@ -122,7 +122,7 @@ public class FcmService {
                         notificationRequestDto.data()
                 ));
             } catch (ApplicationException e) {
-                log.warn("FCM 전송 실패 (userId: {}, token: {}): {}", userId, fcmToken.getToken(), e.getMessage());
+                log.warn("FCM 전송 실패 (userId: {}): {}", userId, e.getMessage());
             }
         });
     }

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
@@ -45,7 +45,7 @@ public class FileUploadService {
         }
 
         recordExternalCall("s3", "upload", "success", sample);
-        log.info("file url : " + fileUrl + " has upload to S3");
+        log.info("S3 upload completed - fileSize: {}, contentType: {}", file.getSize(), file.getContentType());
         return fileUrl;
     }
 
@@ -54,7 +54,7 @@ public class FileUploadService {
         String splitStr = ".com/";
         String fileName = imageUrl.substring(imageUrl.lastIndexOf(splitStr) + splitStr.length());
 
-        log.info("file url : " + imageUrl + " has removed from S3");
+        log.info("S3 delete requested");
 
         try {
             amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));

--- a/src/main/java/com/aisip/OnO/backend/util/webhook/DiscordWebhookNotificationService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/webhook/DiscordWebhookNotificationService.java
@@ -90,7 +90,7 @@ public class DiscordWebhookNotificationService {
             );
             log.info("Discord webhook 전송 완료: {}", payload.embeds().get(0).title());
         } catch (Exception e) {
-            log.error("Discord webhook 전송 실패: {}", e.getMessage());
+            log.error("Discord webhook 전송 실패: {}", e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/util/webhook/DiscordWebhookNotificationService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/webhook/DiscordWebhookNotificationService.java
@@ -9,8 +9,11 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service
@@ -18,6 +21,8 @@ import java.util.List;
 public class DiscordWebhookNotificationService {
 
     private final RestTemplate restTemplate = new RestTemplate();
+    private final Map<String, Instant> lastSentAtByDedupKey = new ConcurrentHashMap<>();
+    private static final Duration ERROR_NOTIFICATION_DEDUP_WINDOW = Duration.ofMinutes(5);
 
     @Value("${discord.webhook-url}")
     private String webhookUrl;
@@ -27,6 +32,12 @@ public class DiscordWebhookNotificationService {
      */
     public void sendErrorNotification(String path, String errorMessage, String status, String exceptionType) {
         String timestamp = Instant.now().toString();
+        String dedupKey = createDedupKey(path, status, exceptionType);
+
+        if (shouldSuppress(dedupKey)) {
+            log.debug("Discord error notification suppressed - key: {}", dedupKey);
+            return;
+        }
 
         DiscordWebhookPayload.Embed embed = new DiscordWebhookPayload.Embed(
                 "🚨 서버 에러 발생",
@@ -40,7 +51,7 @@ public class DiscordWebhookNotificationService {
                 )
         );
 
-        sendToDiscord(new DiscordWebhookPayload(null, List.of(embed)));
+        sendToDiscord(new DiscordWebhookPayload(null, List.of(embed)), dedupKey);
     }
 
     /**
@@ -64,6 +75,12 @@ public class DiscordWebhookNotificationService {
      */
     public void sendCustomEmbed(String title, String description, List<DiscordWebhookPayload.Embed.Field> fields) {
         String timestamp = Instant.now().toString();
+        String dedupKey = createDedupKey(title, description);
+
+        if (shouldSuppress(dedupKey)) {
+            log.debug("Discord custom notification suppressed - key: {}", dedupKey);
+            return;
+        }
 
         DiscordWebhookPayload.Embed embed = new DiscordWebhookPayload.Embed(
                 title,
@@ -72,13 +89,17 @@ public class DiscordWebhookNotificationService {
                 fields
         );
 
-        sendToDiscord(new DiscordWebhookPayload(null, List.of(embed)));
+        sendToDiscord(new DiscordWebhookPayload(null, List.of(embed)), dedupKey);
     }
 
     /**
      * Discord Webhook으로 메시지 전송 (내부 메서드)
      */
     private void sendToDiscord(DiscordWebhookPayload payload) {
+        sendToDiscord(payload, null);
+    }
+
+    private void sendToDiscord(DiscordWebhookPayload payload, String dedupKey) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
@@ -88,9 +109,40 @@ public class DiscordWebhookNotificationService {
                     new HttpEntity<>(payload, headers),
                     String.class
             );
+            if (dedupKey != null) {
+                lastSentAtByDedupKey.put(dedupKey, Instant.now());
+            }
             log.info("Discord webhook 전송 완료: {}", payload.embeds().get(0).title());
         } catch (Exception e) {
             log.error("Discord webhook 전송 실패: {}", e.getMessage(), e);
         }
+    }
+
+    private boolean shouldSuppress(String dedupKey) {
+        Instant lastSentAt = lastSentAtByDedupKey.get(dedupKey);
+        return lastSentAt != null
+                && Instant.now().isBefore(lastSentAt.plus(ERROR_NOTIFICATION_DEDUP_WINDOW));
+    }
+
+    private String createDedupKey(String path, String status, String exceptionType) {
+        return String.join("|",
+                normalize(path),
+                normalize(status),
+                normalize(exceptionType)
+        );
+    }
+
+    private String createDedupKey(String title, String description) {
+        return String.join("|",
+                normalize(title),
+                normalize(description)
+        );
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return "unknown";
+        }
+        return value.replaceAll("\\s+", " ").trim();
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -39,7 +39,7 @@
     <springProfile name="local">
         <logger name="p6spy" level="INFO"/>
         <logger name="org.hibernate.SQL" level="DEBUG"/>
-        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="DEBUG"/>
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="OFF"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
@@ -48,7 +48,7 @@
     <springProfile name="dev">
         <logger name="p6spy" level="INFO"/>
         <logger name="org.hibernate.SQL" level="INFO"/>
-        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="INFO"/>
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="OFF"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
@@ -57,7 +57,7 @@
     <springProfile name="prod">
         <logger name="p6spy" level="WARN"/>
         <logger name="org.hibernate.SQL" level="WARN"/>
-        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="WARN"/>
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="OFF"/>
         <logger name="org.springframework" level="INFO"/>
         <logger name="org.springframework.amqp" level="WARN"/>
         <logger name="com.zaxxer.hikari" level="WARN"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -38,7 +38,7 @@
 
     <springProfile name="local">
         <logger name="p6spy" level="INFO"/>
-        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
         <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="OFF"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -29,6 +29,7 @@
             <includeMdcKeyName>userId</includeMdcKeyName>
             <includeMdcKeyName>method</includeMdcKeyName>
             <includeMdcKeyName>uri</includeMdcKeyName>
+            <includeMdcKeyName>clientIp</includeMdcKeyName>
             <includeMdcKeyName>status</includeMdcKeyName>
             <includeMdcKeyName>latencyMs</includeMdcKeyName>
             <includeMdcKeyName>errorCode</includeMdcKeyName>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="ono-backend"/>
+    <springProperty scope="context" name="activeProfile" source="spring.profiles.active" defaultValue="local"/>
+
+    <property name="CONSOLE_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS,Asia/Seoul} %highlight(%-5level) [%thread] [%X{traceId:-no-trace}] [%X{userId:-anonymous}] %cyan(%logger{36}) - %msg%n%xEx"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"${appName}","environment":"${activeProfile}"}</customFields>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <level>level</level>
+                <logger>logger</logger>
+                <thread>thread</thread>
+                <message>message</message>
+                <stackTrace>stacktrace</stackTrace>
+            </fieldNames>
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+            <includeMdcKeyName>method</includeMdcKeyName>
+            <includeMdcKeyName>uri</includeMdcKeyName>
+            <includeMdcKeyName>status</includeMdcKeyName>
+            <includeMdcKeyName>latencyMs</includeMdcKeyName>
+            <includeMdcKeyName>errorCode</includeMdcKeyName>
+            <includeMdcKeyName>exceptionType</includeMdcKeyName>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <logger name="p6spy" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="DEBUG"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <logger name="p6spy" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="INFO"/>
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="INFO"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <logger name="p6spy" level="WARN"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="WARN"/>
+        <logger name="org.springframework" level="INFO"/>
+        <logger name="org.springframework.amqp" level="WARN"/>
+        <logger name="com.zaxxer.hikari" level="WARN"/>
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local &amp; !dev &amp; !prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -7,6 +7,6 @@ excludecategories=info,debug,result,resultset,batch
 # Quartz 관련 테이블 제외 (스케줄러 쿼리)
 exclude=QRTZ_TRIGGERS,QRTZ_FIRED_TRIGGERS,QRTZ_JOB_DETAILS,QRTZ_CRON_TRIGGERS,QRTZ_SIMPLE_TRIGGERS,QRTZ_LOCKS,QRTZ_SCHEDULER_STATE
 
-# 실행 시간 필터링 (0으로 설정하면 모든 쿼리 출력)
-# 0 = 모든 쿼리, 1 = 1ms 이상, 100 = 100ms 이상
-executionThreshold=0
+# 실행 시간 필터링
+# 300 = 300ms 이상 걸린 쿼리만 출력
+executionThreshold=300

--- a/src/test/java/com/aisip/OnO/backend/common/exception/ErrorCaseContractTest.java
+++ b/src/test/java/com/aisip/OnO/backend/common/exception/ErrorCaseContractTest.java
@@ -1,0 +1,94 @@
+package com.aisip.OnO.backend.common.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ErrorCaseContractTest {
+
+    private static final String BASE_PACKAGE = "com.aisip.OnO.backend";
+
+    @Test
+    void errorCodesAreUnique() {
+        List<ErrorCase> errorCases = findErrorCases();
+
+        Map<Integer, List<ErrorCase>> casesByCode = errorCases.stream()
+                .collect(Collectors.groupingBy(
+                        ErrorCase::getErrorCode,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
+        Map<Integer, List<String>> duplicatedCodes = casesByCode.entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().stream()
+                                .map(this::formatErrorCase)
+                                .toList(),
+                        (left, right) -> left,
+                        LinkedHashMap::new
+                ));
+
+        assertThat(duplicatedCodes)
+                .as("ErrorCase errorCode must be unique. Duplicates: %s", duplicatedCodes)
+                .isEmpty();
+    }
+
+    @Test
+    void errorCasesHaveValidResponseFields() {
+        List<ErrorCase> errorCases = findErrorCases();
+
+        assertThat(errorCases)
+                .allSatisfy(errorCase -> {
+                    assertThat(errorCase.getHttpStatusCode())
+                            .as("%s httpStatusCode", formatErrorCase(errorCase))
+                            .isBetween(400, 599);
+                    assertThat(errorCase.getErrorCode())
+                            .as("%s errorCode", formatErrorCase(errorCase))
+                            .isPositive();
+                    assertThat(errorCase.getMessage())
+                            .as("%s message", formatErrorCase(errorCase))
+                            .isNotBlank();
+                });
+    }
+
+    private List<ErrorCase> findErrorCases() {
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AssignableTypeFilter(ErrorCase.class));
+
+        return scanner.findCandidateComponents(BASE_PACKAGE).stream()
+                .map(beanDefinition -> loadClass(beanDefinition.getBeanClassName()))
+                .filter(Class::isEnum)
+                .map(Class::getEnumConstants)
+                .map(constants -> Arrays.stream(constants)
+                        .map(ErrorCase.class::cast)
+                        .toList())
+                .flatMap(Collection::stream)
+                .sorted(Comparator.comparing(ErrorCase::getErrorCode))
+                .toList();
+    }
+
+    private Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Failed to load ErrorCase class: " + className, e);
+        }
+    }
+
+    private String formatErrorCase(ErrorCase errorCase) {
+        Enum<?> enumValue = (Enum<?>) errorCase;
+        return enumValue.getDeclaringClass().getSimpleName() + "." + enumValue.name();
+    }
+}


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #193 

## 📝 작업 내용

> 서비스 로그 체계를 정리하고, 운영 환경에서 필요한 에러/장애 정보만 안정적으로 추적할 수 있도록 개선했습니다.

- 환경별 로그 출력 정책 정리
  - local/dev는 사람이 읽기 쉬운 콘솔 로그 유지
  - prod는 JSON 로그 기반으로 구조화
  - Promtail 파이프라인이 JSON 로그의 `level`, `service`, `environment`, `traceId` 등을 파싱하도록 정리

- 요청 단위 추적 로그 개선
  - `X-Request-Id` 기반 `traceId`를 MDC에 저장
  - 요청 응답에도 `X-Request-Id`를 내려 클라이언트와 서버 로그를 연결 가능하게 처리
  - `method`, `uri`, `status`, `latencyMs`, `clientIp`, `userId`를 구조화 로그 필드로 기록
  - 빠른 정상 요청은 `debug`, 느린 요청은 `info`, 4xx는 `warn`, 5xx는 `error`로 분리

- 예외/에러 로그 정리
  - `GlobalExceptionHandler`에서 4xx는 요약 로그, 5xx는 stacktrace 포함 로그로 분리
  - Spring MVC status-bearing 예외가 catch-all에서 500으로 오탐되지 않도록 처리
  - 서비스 AOP에서 HTTP 요청 중 발생한 예외 stacktrace가 중복 출력되지 않도록 조정

- 민감정보 및 로그 노이즈 감소
  - JWT/FCM 토큰, S3 URL, OpenAI 응답 본문 등 민감하거나 과한 정보가 로그에 남지 않도록 정리
  - RabbitMQ/FCM/S3 관련 로그를 운영 대응에 필요한 식별자 중심으로 정리
  - Discord 장애 알림은 동일 유형 알림이 반복 전송되지 않도록 5분 중복 억제 적용

- DB slow query 로그 개선
  - 전체 SQL 로그를 줄이고 slow query 중심으로 확인하도록 조정
  - 운영 환경에서 SQL 원문 대신 fingerprint/hash 중심으로 남겨 민감정보 노출 위험 완화
  - slow query threshold 설정과 P6Spy 출력 기준을 일관되게 정리

- 에러 응답/에러 코드 체계 정리
  - 인증/인가 실패도 `CommonResponse` 형식으로 통일
  - 에러 코드 중복 제거
  - `NOT_FOUND`는 404, 권한 불일치는 403 등 HTTP status 의미에 맞게 정리
  - FCM 에러 코드를 Mission 코드와 겹치지 않도록 8000번대로 분리
  - 전체 `ErrorCase` enum을 검사해 중복 errorCode를 막는 계약 테스트 추가

- 검증
  - `./gradlew compileJava`
  - `./gradlew test --tests com.aisip.OnO.backend.common.exception.ErrorCaseContractTest`
  - `git diff --check`

### 스크린샷 (선택)

- 없음
