### PR TITLE
[Feat] Flyway 도입 및 기존 스키마 baseline 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,10 @@ application-dev.yml
 application-prod.yml
 FirebaseAdminKey.json
 
-**/db/migration/
+**/db/migration/*
+!**/db/migration/
+!**/db/migration/README.md
+!**/db/migration/V*.sql
 
 ### Environment variables
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ monitoring/README.md
 
 ### Local agent guidance
 /AGENTS.md
+.claude.md

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 	// Hibernate Core

--- a/src/main/java/com/aisip/OnO/backend/config/FlywayConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/config/FlywayConfig.java
@@ -1,0 +1,29 @@
+package com.aisip.OnO.backend.config;
+
+import org.flywaydb.core.api.MigrationVersion;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+    @Bean
+    public FlywayConfigurationCustomizer flywayConfigurationCustomizer(
+            @Value("${spring.flyway.baseline-on-migrate:true}") boolean baselineOnMigrate,
+            @Value("${spring.flyway.baseline-version:1}") String baselineVersion,
+            @Value("${spring.flyway.baseline-description:Existing schema before Flyway adoption}") String baselineDescription,
+            @Value("${spring.flyway.validate-on-migrate:true}") boolean validateOnMigrate,
+            @Value("${spring.flyway.clean-disabled:true}") boolean cleanDisabled,
+            @Value("${spring.flyway.connect-retries:10}") int connectRetries
+    ) {
+        return configuration -> configuration
+                .baselineOnMigrate(baselineOnMigrate)
+                .baselineVersion(MigrationVersion.fromVersion(baselineVersion))
+                .baselineDescription(baselineDescription)
+                .validateOnMigrate(validateOnMigrate)
+                .cleanDisabled(cleanDisabled)
+                .connectRetries(connectRetries);
+    }
+}

--- a/src/main/resources/db/migration/README.md
+++ b/src/main/resources/db/migration/README.md
@@ -1,0 +1,11 @@
+# Flyway migrations
+
+Flyway is enabled for `local`, `dev`, and `prod`.
+
+The current production-compatible schema is treated as version `1`:
+
+- Existing non-empty databases are baselined automatically through `baseline-on-migrate`.
+- `V1__baseline_existing_schema.sql` is intentionally a no-op marker.
+- New schema changes must start at `V2__*.sql`.
+
+The older `.sql` files in this directory do not follow Flyway naming and are kept as historical/manual scripts. Do not rename them into `V*__*.sql` unless they are reviewed as production-safe, idempotent migrations.

--- a/src/main/resources/db/migration/V1__baseline_existing_schema.sql
+++ b/src/main/resources/db/migration/V1__baseline_existing_schema.sql
@@ -1,0 +1,3 @@
+-- Flyway adoption baseline.
+-- Existing dev/prod schemas are recorded at version 1 by baseline-on-migrate.
+-- Add new schema changes as V2__*.sql and later migrations.


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #191 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- Flyway 의존성(`flyway-core`, `flyway-mysql`)을 추가했습니다.
- 기존 dev/prod DB가 이미 테이블을 가진 상태에서도 첫 배포가 실패하지 않도록 Flyway baseline 설정을 추가했습니다.
- `V1__baseline_existing_schema.sql`을 no-op 기준점으로 추가해 기존 운영 스키마를 version 1로 관리하도록 했습니다.
- 이후 실제 스키마 변경은 `V2__*.sql`부터 작성하도록 migration README를 추가했습니다.
- `.gitignore`에서 Flyway 표준 마이그레이션 파일(`V*.sql`)과 README만 추적되도록 조정했습니다.

### 스크린샷 (선택)

없음

### 검증

- `./gradlew compileJava` 성공
- `./gradlew assemble -x test` 성공
- `./gradlew test`는 기존 테스트 환경의 datasource 설정 누락으로 context load 실패가 발생했고, 이후 AMQP/Quartz 스레드 OOM이 반복되어 중단했습니다.
