### PR TITLE
[Feat] 복습 스케줄 및 알림 기능 개선

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/FcmNotificationConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/FcmNotificationConsumer.java
@@ -8,6 +8,7 @@ import com.aisip.OnO.backend.util.webhook.DiscordWebhookNotificationService;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Notification;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -63,6 +64,15 @@ public class FcmNotificationConsumer {
                 try {
                     sendToDevice(fcmToken.getToken(), message);
                     successCount++;
+                } catch (FirebaseMessagingException e) {
+                    if (isInvalidToken(e)) {
+                        fcmTokenRepository.deleteByToken(fcmToken.getToken());
+                        log.info("만료된 FCM 토큰 삭제 - userId: {}, errorCode: {}", message.getUserId(), e.getMessagingErrorCode());
+                    } else {
+                        log.warn("RabbitMQ device delivery failed - queue: {}, operation: {}, userId: {}, error: {}",
+                                RabbitMQConfig.FCM_NOTIFICATION_QUEUE, "fcm_notification", message.getUserId(), e.getMessage());
+                        failCount++;
+                    }
                 } catch (Exception e) {
                     log.warn("RabbitMQ device delivery failed - queue: {}, operation: {}, userId: {}, error: {}",
                             RabbitMQConfig.FCM_NOTIFICATION_QUEUE, "fcm_notification", message.getUserId(), e.getMessage());
@@ -150,6 +160,12 @@ public class FcmNotificationConsumer {
             log.error("RabbitMQ DLQ notification failed - queue: {}, operation: {}, userId: {}, error: {}",
                     RabbitMQConfig.FCM_NOTIFICATION_DLQ, "fcm_notification", message.getUserId(), e.getMessage());
         }
+    }
+
+    private boolean isInvalidToken(FirebaseMessagingException e) {
+        MessagingErrorCode code = e.getMessagingErrorCode();
+        return code == MessagingErrorCode.UNREGISTERED
+                || code == MessagingErrorCode.INVALID_ARGUMENT;
     }
 
     private void recordExternalCall(String dependency, String operation, String outcome, Timer.Sample sample) {

--- a/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
@@ -4,6 +4,7 @@ import com.aisip.OnO.backend.common.ratelimit.RateLimit;
 import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.problem.dto.ProblemAnalysisResponseDto;
+import com.aisip.OnO.backend.problem.dto.ReviewDueResponseDto;
 import com.aisip.OnO.backend.problem.dto.ProblemDeleteRequestDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2Dto;
@@ -223,6 +224,13 @@ public class ProblemController {
         problemService.deleteProblemImageData(imageUrl);
 
         return CommonResponse.success("문제 이미지 데이터 삭제가 완료되었습니다.");
+    }
+
+    // ✅ 오늘 복습 대상 문제 조회
+    @GetMapping("/review-due")
+    public CommonResponse<ReviewDueResponseDto> getReviewDueProblems() {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return CommonResponse.success(problemService.getReviewDueProblems(userId));
     }
 
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/dto/ProblemResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/dto/ProblemResponseDto.java
@@ -30,6 +30,10 @@ public record ProblemResponseDto (
 
     List<ProblemImageDataResponseDto> imageUrlList,
 
+    Long solveCount,
+
+    LocalDateTime lastSolvedAt,
+
     ProblemAnalysisResponseDto analysis,
 
     List<Long> tagIdList,
@@ -37,6 +41,10 @@ public record ProblemResponseDto (
     List<TagResponseDto> tags
 ) {
     public static ProblemResponseDto from(@NotNull Problem problem) {
+        return from(problem, 0L, null);
+    }
+
+    public static ProblemResponseDto from(@NotNull Problem problem, Long solveCount, LocalDateTime lastSolvedAt) {
 
         List<ProblemImageDataResponseDto> problemImageDataList = Optional.ofNullable(problem.getProblemImageDataList())
                 .orElse(List.of())
@@ -69,6 +77,8 @@ public record ProblemResponseDto (
                 .createdAt(problem.getCreatedAt())
                 .updatedAt(problem.getUpdatedAt())
                 .imageUrlList(problemImageDataList)
+                .solveCount(solveCount)
+                .lastSolvedAt(lastSolvedAt)
                 .analysis(analysisDto)
                 .tagIdList(tagIds)
                 .tags(tags)

--- a/src/main/java/com/aisip/OnO/backend/problem/dto/ReviewDueResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/dto/ReviewDueResponseDto.java
@@ -1,0 +1,35 @@
+package com.aisip.OnO.backend.problem.dto;
+
+import com.aisip.OnO.backend.problem.entity.Problem;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record ReviewDueResponseDto(
+        long dueCount,
+        long overdueCount,
+        List<ReviewDueProblemDto> problems
+) {
+    @Builder
+    public record ReviewDueProblemDto(
+            Long problemId,
+            String memo,
+            String reference,
+            LocalDate nextReviewAt,
+            int reviewInterval,
+            int consecutiveCorrectCount
+    ) {
+        public static ReviewDueProblemDto from(Problem problem) {
+            return ReviewDueProblemDto.builder()
+                    .problemId(problem.getId())
+                    .memo(problem.getMemo())
+                    .reference(problem.getReference())
+                    .nextReviewAt(problem.getNextReviewAt())
+                    .reviewInterval(problem.getReviewInterval())
+                    .consecutiveCorrectCount(problem.getConsecutiveCorrectCount())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/entity/Problem.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/entity/Problem.java
@@ -10,6 +10,7 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,16 @@ public class Problem extends BaseEntity {
     private String reference;
 
     private LocalDateTime solvedAt;
+
+    private LocalDate nextReviewAt;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private int reviewInterval = 1;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private int consecutiveCorrectCount = 0;
 
     @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProblemImageData> problemImageDataList = new ArrayList<>();
@@ -122,5 +133,11 @@ public class Problem extends BaseEntity {
 
     public void updateProblemAnalysis(ProblemAnalysis analysis) {
         this.problemAnalysis = analysis;
+    }
+
+    public void updateReviewSchedule(LocalDate nextReviewAt, int reviewInterval, int consecutiveCorrectCount) {
+        this.nextReviewAt = nextReviewAt;
+        this.reviewInterval = reviewInterval;
+        this.consecutiveCorrectCount = consecutiveCorrectCount;
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/quartz/ReviewDueNotificationJob.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/quartz/ReviewDueNotificationJob.java
@@ -62,7 +62,10 @@ public class ReviewDueNotificationJob extends QuartzJobBean {
         List<Long> notifiedUserIds = new ArrayList<>();
 
         for (User user : users) {
-            // 3일 이상 미접속 유저는 재참여 흐름으로 처리
+            // 알림 수신 거부한 유저 스킵
+            if (!user.isNotificationEnabled()) continue;
+
+            // 7일 이상 미접속 유저는 재참여 흐름으로 처리
             if (user.getLastActiveAt() == null || user.getLastActiveAt().isBefore(reengagementCutoff)) {
                 continue;
             }
@@ -97,6 +100,7 @@ public class ReviewDueNotificationJob extends QuartzJobBean {
         List<Long> notifiedUserIds = new ArrayList<>();
 
         for (User user : inactiveUsers) {
+            if (!user.isNotificationEnabled()) continue;
             fcmService.sendNotificationToAllUserDevice(user.getId(),
                     new NotificationRequestDto("", "오랜만이에요!",
                             "오답노트를 펼칠 시간이에요. 복습하러 돌아와보세요!",
@@ -122,6 +126,7 @@ public class ReviewDueNotificationJob extends QuartzJobBean {
         List<Long> notifiedUserIds = new ArrayList<>();
 
         for (User user : longInactiveUsers) {
+            if (!user.isNotificationEnabled()) continue;
             fcmService.sendNotificationToAllUserDevice(user.getId(),
                     new NotificationRequestDto("", "오답노트가 기다리고 있어요",
                             "한동안 자리를 비우셨네요. 다시 시작하기 딱 좋은 날이에요!",

--- a/src/main/java/com/aisip/OnO/backend/problem/quartz/ReviewDueNotificationJob.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/quartz/ReviewDueNotificationJob.java
@@ -1,0 +1,137 @@
+package com.aisip.OnO.backend.problem.quartz;
+
+import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.problem.repository.ReviewDueSummary;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.fcm.dto.NotificationRequestDto;
+import com.aisip.OnO.backend.util.fcm.service.FcmService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ReviewDueNotificationJob extends QuartzJobBean {
+
+    private static final int REENGAGEMENT_THRESHOLD_DAYS = 7;
+    private static final int REENGAGEMENT_INTERVAL_DAYS = 5;
+    private static final int LONG_INACTIVE_THRESHOLD_DAYS = 30;
+    private static final int LONG_INACTIVE_INTERVAL_DAYS = 30;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FcmService fcmService;
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        ZoneId seoul = ZoneId.of("Asia/Seoul");
+
+        LocalDateTime reengagementCutoff = today.minusDays(REENGAGEMENT_THRESHOLD_DAYS).atStartOfDay(seoul).toLocalDateTime();
+        LocalDateTime longInactiveCutoff = today.minusDays(LONG_INACTIVE_THRESHOLD_DAYS).atStartOfDay(seoul).toLocalDateTime();
+
+        sendReviewNotifications(today, reengagementCutoff);
+        sendReengagementNotifications(today, reengagementCutoff, longInactiveCutoff);
+        sendLongInactiveReengagementNotifications(today, longInactiveCutoff);
+    }
+
+    // 흐름 1: 복습 예정일이 된 문제가 있는 활성 유저에게 복습 알림
+    private void sendReviewNotifications(LocalDate today, LocalDateTime reengagementCutoff) {
+        List<ReviewDueSummary> summaries = problemRepository.findReviewDueSummaryByDate(today);
+        if (summaries.isEmpty()) return;
+
+        Map<Long, Long> dueCountByUserId = summaries.stream()
+                .collect(Collectors.toMap(ReviewDueSummary::getUserId, ReviewDueSummary::getDueCount));
+
+        List<User> users = userRepository.findAllById(new ArrayList<>(dueCountByUserId.keySet()));
+        List<Long> notifiedUserIds = new ArrayList<>();
+
+        for (User user : users) {
+            // 3일 이상 미접속 유저는 재참여 흐름으로 처리
+            if (user.getLastActiveAt() == null || user.getLastActiveAt().isBefore(reengagementCutoff)) {
+                continue;
+            }
+            // 오늘 이미 알림 받은 경우 스킵
+            if (today.equals(user.getLastNotifiedAt())) {
+                continue;
+            }
+
+            long dueCount = dueCountByUserId.get(user.getId());
+            fcmService.sendNotificationToAllUserDevice(user.getId(),
+                    new NotificationRequestDto("", "오늘의 복습 알림",
+                            "오늘 복습할 문제가 " + dueCount + "개 있어요!",
+                            Map.of("type", "review_due")));
+            notifiedUserIds.add(user.getId());
+        }
+
+        if (!notifiedUserIds.isEmpty()) {
+            userRepository.bulkUpdateLastNotifiedAt(notifiedUserIds, today);
+        }
+        log.info("[ReviewDue] 복습 알림 발송: {}명", notifiedUserIds.size());
+    }
+
+    // 흐름 2: 일정 기간 미접속 유저에게 재참여 알림 (due 문제 여부 무관)
+    private void sendReengagementNotifications(LocalDate today, LocalDateTime reengagementCutoff, LocalDateTime inactiveCutoff) {
+        LocalDate notificationCutoff = today.minusDays(REENGAGEMENT_INTERVAL_DAYS);
+
+        List<User> inactiveUsers = userRepository.findUsersForReengagement(
+                reengagementCutoff, inactiveCutoff, notificationCutoff);
+
+        if (inactiveUsers.isEmpty()) return;
+
+        List<Long> notifiedUserIds = new ArrayList<>();
+
+        for (User user : inactiveUsers) {
+            fcmService.sendNotificationToAllUserDevice(user.getId(),
+                    new NotificationRequestDto("", "오랜만이에요!",
+                            "오답노트를 펼칠 시간이에요. 복습하러 돌아와보세요!",
+                            Map.of("type", "reengagement")));
+            notifiedUserIds.add(user.getId());
+        }
+
+        if (!notifiedUserIds.isEmpty()) {
+            userRepository.bulkUpdateLastNotifiedAt(notifiedUserIds, today);
+        }
+        log.info("[ReviewDue] 재참여 알림 발송: {}명", notifiedUserIds.size());
+    }
+
+    // 흐름 3: 30일 초과 미접속 유저에게 월 1회 알림
+    private void sendLongInactiveReengagementNotifications(LocalDate today, LocalDateTime longInactiveCutoff) {
+        LocalDate notificationCutoff = today.minusDays(LONG_INACTIVE_INTERVAL_DAYS);
+
+        List<User> longInactiveUsers = userRepository.findUsersForLongInactiveReengagement(
+                longInactiveCutoff, notificationCutoff);
+
+        if (longInactiveUsers.isEmpty()) return;
+
+        List<Long> notifiedUserIds = new ArrayList<>();
+
+        for (User user : longInactiveUsers) {
+            fcmService.sendNotificationToAllUserDevice(user.getId(),
+                    new NotificationRequestDto("", "오답노트가 기다리고 있어요",
+                            "한동안 자리를 비우셨네요. 다시 시작하기 딱 좋은 날이에요!",
+                            Map.of("type", "reengagement_monthly")));
+            notifiedUserIds.add(user.getId());
+        }
+
+        if (!notifiedUserIds.isEmpty()) {
+            userRepository.bulkUpdateLastNotifiedAt(notifiedUserIds, today);
+        }
+        log.info("[ReviewDue] 장기 미접속 알림 발송: {}명", notifiedUserIds.size());
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/quartz/ReviewDueNotificationScheduler.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/quartz/ReviewDueNotificationScheduler.java
@@ -1,0 +1,53 @@
+package com.aisip.OnO.backend.problem.quartz;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.stereotype.Component;
+
+import java.util.TimeZone;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewDueNotificationScheduler {
+
+    private static final String JOB_NAME = "review-due-notification";
+    private static final String JOB_GROUP = "review";
+    private static final String TRIGGER_NAME = "review-due-trigger";
+    private static final String CRON = "0 0 9 ? * *";
+
+    private final Scheduler scheduler;
+
+    @PostConstruct
+    public void schedule() {
+        try {
+            JobDetail jobDetail = JobBuilder.newJob(ReviewDueNotificationJob.class)
+                    .withIdentity(JOB_NAME, JOB_GROUP)
+                    .storeDurably(true)
+                    .build();
+
+            Trigger trigger = TriggerBuilder.newTrigger()
+                    .withIdentity(TRIGGER_NAME, JOB_GROUP)
+                    .withSchedule(
+                            CronScheduleBuilder.cronSchedule(CRON)
+                                    .inTimeZone(TimeZone.getTimeZone("Asia/Seoul"))
+                    )
+                    .forJob(jobDetail)
+                    .build();
+
+            scheduler.addJob(jobDetail, true);
+
+            if (scheduler.checkExists(trigger.getKey())) {
+                scheduler.rescheduleJob(trigger.getKey(), trigger);
+            } else {
+                scheduler.scheduleJob(trigger);
+            }
+
+            log.info("[ReviewDue] 복습 알림 스케줄 등록 완료 - cron: {} (Asia/Seoul)", CRON);
+        } catch (SchedulerException e) {
+            log.error("[ReviewDue] 복습 알림 스케줄 등록 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemRepository.java
@@ -2,8 +2,19 @@ package com.aisip.OnO.backend.problem.repository;
 
 import com.aisip.OnO.backend.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long>, ProblemRepositoryCustom {
 
     Long countByUserId(Long userId);
+
+    @Query("SELECT p FROM Problem p WHERE p.userId = :userId AND p.nextReviewAt <= :today ORDER BY p.nextReviewAt ASC")
+    List<Problem> findReviewDueProblems(@Param("userId") Long userId, @Param("today") LocalDate today);
+
+    @Query("SELECT p.userId as userId, COUNT(p) as dueCount FROM Problem p WHERE p.nextReviewAt <= :today GROUP BY p.userId")
+    List<ReviewDueSummary> findReviewDueSummaryByDate(@Param("today") LocalDate today);
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/repository/ReviewDueSummary.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/repository/ReviewDueSummary.java
@@ -1,0 +1,6 @@
+package com.aisip.OnO.backend.problem.repository;
+
+public interface ReviewDueSummary {
+    Long getUserId();
+    Long getDueCount();
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -25,6 +25,8 @@ import com.aisip.OnO.backend.problem.dto.ReviewDueResponseDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.practicenote.repository.PracticeNoteRepository;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveSummary;
 import com.aisip.OnO.backend.tag.entity.ProblemTagMapping;
 import com.aisip.OnO.backend.tag.entity.Tag;
 import com.aisip.OnO.backend.tag.exception.TagErrorCase;
@@ -70,6 +72,8 @@ public class ProblemService {
 
     private final PracticeNoteRepository practiceNoteRepository;
 
+    private final ProblemSolveRepository problemSolveRepository;
+
     private final S3DeleteProducer s3DeleteProducer;
 
     private final ProblemAnalysisProducer analysisProducer;
@@ -81,7 +85,7 @@ public class ProblemService {
         Problem problem = problemRepository.findProblemWithImageData(problemId)
                 .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
 
-        return ProblemResponseDto.from(problem);
+        return toProblemResponseDto(problem);
     }
 
     @Transactional(readOnly = true)
@@ -112,27 +116,22 @@ public class ProblemService {
     public List<ProblemResponseDto> findUserProblems(Long userId) {
         log.info("userId: {} find all user problems", userId);
 
-        return problemRepository.findAllByUserId(userId)
-                .stream()
-                .map(ProblemResponseDto::from)
-                .collect(Collectors.toList());
+        return toProblemResponseDtos(problemRepository.findAllByUserId(userId));
     }
 
     @Transactional(readOnly = true)
     public List<ProblemResponseDto> findFolderProblemList(Long folderId) {
-        return problemRepository.findAllByFolderId(folderId)
-                .stream()
-                .map(ProblemResponseDto::from)
-                .collect(Collectors.toList());
+        return toProblemResponseDtos(problemRepository.findAllByFolderId(folderId));
     }
 
     @Transactional(readOnly = true)
     public List<ProblemResponseDto> findAllProblems() {
-        return problemRepository.findAll()
+        List<Problem> problems = problemRepository.findAll()
                 .stream()
                 .sorted((p1, p2) -> p2.getCreatedAt().compareTo(p1.getCreatedAt())) // 최신순 정렬
-                .map(ProblemResponseDto::from)
-                .collect(Collectors.toList());
+                .toList();
+
+        return toProblemResponseDtos(problems);
     }
 
     @Transactional(readOnly = true)
@@ -550,9 +549,7 @@ public class ProblemService {
         List<Problem> content = hasNext ? problems.subList(0, size) : problems;
         Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
 
-        List<ProblemResponseDto> dtoList = content.stream()
-                .map(ProblemResponseDto::from)
-                .collect(Collectors.toList());
+        List<ProblemResponseDto> dtoList = toProblemResponseDtos(content);
 
         log.info("folderId: {} find problems with cursor: {}, size: {}, hasNext: {}", folderId, cursor, size, hasNext);
         return CursorPageResponse.of(dtoList, nextCursor, hasNext, size);
@@ -581,9 +578,7 @@ public class ProblemService {
         List<Problem> content = hasNext ? problems.subList(0, size) : problems;
         Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
 
-        List<ProblemResponseDto> dtoList = content.stream()
-                .map(ProblemResponseDto::from)
-                .collect(Collectors.toList());
+        List<ProblemResponseDto> dtoList = toProblemResponseDtos(content);
 
         log.info("userId: {} find problems by tagId: {} with cursor: {}, size: {}, hasNext: {}",
                 userId, tagId, cursor, size, hasNext);
@@ -609,13 +604,48 @@ public class ProblemService {
         List<Problem> content = hasNext ? problems.subList(0, size) : problems;
         Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
 
-        List<ProblemResponseDto> dtoList = content.stream()
-                .map(ProblemResponseDto::from)
-                .collect(Collectors.toList());
+        List<ProblemResponseDto> dtoList = toProblemResponseDtos(content);
 
         log.info("userId: {} find problems by title query: '{}' with cursor: {}, size: {}, hasNext: {}",
                 userId, query, cursor, size, hasNext);
         return CursorPageResponse.of(dtoList, nextCursor, hasNext, size);
+    }
+
+    private ProblemResponseDto toProblemResponseDto(Problem problem) {
+        Long solveCount = problemSolveRepository.countByProblemId(problem.getId());
+        return ProblemResponseDto.from(
+                problem,
+                solveCount != null ? solveCount : 0L,
+                problemSolveRepository.findLastSolvedAtByProblemId(problem.getId())
+        );
+    }
+
+    private List<ProblemResponseDto> toProblemResponseDtos(List<Problem> problems) {
+        if (problems.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> problemIds = problems.stream()
+                .map(Problem::getId)
+                .toList();
+
+        Map<Long, ProblemSolveSummary> solveSummariesByProblemId = problemSolveRepository.findSolveSummariesByProblemIds(problemIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ProblemSolveSummary::getProblemId,
+                        solveSummary -> solveSummary
+                ));
+
+        return problems.stream()
+                .map(problem -> {
+                    ProblemSolveSummary solveSummary = solveSummariesByProblemId.get(problem.getId());
+                    return ProblemResponseDto.from(
+                            problem,
+                            solveSummary != null ? solveSummary.getSolveCount() : 0L,
+                            solveSummary != null ? solveSummary.getLastSolvedAt() : null
+                    );
+                })
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -21,6 +21,7 @@ import com.aisip.OnO.backend.problem.repository.ProblemAnalysisRepository;
 import com.aisip.OnO.backend.folder.repository.FolderRepository;
 import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
 import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
+import com.aisip.OnO.backend.problem.dto.ReviewDueResponseDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.practicenote.repository.PracticeNoteRepository;
@@ -191,6 +192,7 @@ public class ProblemService {
         problemRepository.save(problem);
         syncProblemTags(problem, userId, problemRegisterDto.tagIds());
 
+        problem.updateReviewSchedule(LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), 1, 0);
         analysisService.createSkippedAnalysis(problem.getId());
         missionLogService.registerProblemWriteMission(userId);
 
@@ -247,6 +249,7 @@ public class ProblemService {
                         problemImageDataRepository.save(imageData);
                     });
         }
+        problem.updateReviewSchedule(LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), 1, 0);
         analysisService.createSkippedAnalysis(problem.getId());
         missionLogService.registerProblemWriteMission(userId);
 
@@ -613,5 +616,25 @@ public class ProblemService {
         log.info("userId: {} find problems by title query: '{}' with cursor: {}, size: {}, hasNext: {}",
                 userId, query, cursor, size, hasNext);
         return CursorPageResponse.of(dtoList, nextCursor, hasNext, size);
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewDueResponseDto getReviewDueProblems(Long userId) {
+        LocalDate today = LocalDate.now(java.time.ZoneId.of("Asia/Seoul"));
+        List<Problem> dueProblems = problemRepository.findReviewDueProblems(userId, today);
+
+        long overdueCount = dueProblems.stream()
+                .filter(p -> p.getNextReviewAt().isBefore(today))
+                .count();
+
+        List<ReviewDueResponseDto.ReviewDueProblemDto> problemDtos = dueProblems.stream()
+                .map(ReviewDueResponseDto.ReviewDueProblemDto::from)
+                .collect(Collectors.toList());
+
+        return ReviewDueResponseDto.builder()
+                .dueCount(dueProblems.size())
+                .overdueCount(overdueCount)
+                .problems(problemDtos)
+                .build();
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ReviewIntervalCalculator.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ReviewIntervalCalculator.java
@@ -1,0 +1,35 @@
+package com.aisip.OnO.backend.problem.service;
+
+import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+public class ReviewIntervalCalculator {
+
+    private static final int MAX_INTERVAL_DAYS = 30;
+    static final int MASTERY_THRESHOLD = 3;
+
+    public record ReviewSchedule(LocalDate nextReviewAt, int reviewInterval, int consecutiveCorrectCount) {
+        public boolean isMastered() {
+            return nextReviewAt == null;
+        }
+    }
+
+    public static ReviewSchedule calculate(AnswerStatus status, int currentInterval, int currentConsecutiveCorrect) {
+        return switch (status) {
+            case CORRECT -> {
+                int newConsecutive = currentConsecutiveCorrect + 1;
+                if (newConsecutive >= MASTERY_THRESHOLD) {
+                    yield new ReviewSchedule(null, currentInterval, newConsecutive);
+                }
+                int newInterval = Math.min(currentInterval * 2, MAX_INTERVAL_DAYS);
+                yield new ReviewSchedule(LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(newInterval), newInterval, newConsecutive);
+            }
+            case WRONG, PARTIAL -> new ReviewSchedule(LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(1), 1, 0);
+            default -> new ReviewSchedule(LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(3), currentInterval, currentConsecutiveCorrect);
+        };
+    }
+
+    private ReviewIntervalCalculator() {}
+}

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +40,15 @@ public interface ProblemSolveRepository extends JpaRepository<ProblemSolve, Long
     @Query("SELECT COUNT(pr) FROM ProblemSolve pr " +
             "WHERE pr.problem.id = :problemId")
     Long countByProblemId(@Param("problemId") Long problemId);
+
+    @Query("SELECT MAX(pr.practicedAt) FROM ProblemSolve pr " +
+            "WHERE pr.problem.id = :problemId")
+    LocalDateTime findLastSolvedAtByProblemId(@Param("problemId") Long problemId);
+
+    @Query("SELECT pr.problem.id as problemId, COUNT(pr) as solveCount, MAX(pr.practicedAt) as lastSolvedAt FROM ProblemSolve pr " +
+            "WHERE pr.problem.id IN :problemIds " +
+            "GROUP BY pr.problem.id")
+    List<ProblemSolveSummary> findSolveSummariesByProblemIds(@Param("problemIds") Collection<Long> problemIds);
 
     void deleteAllByProblemId(Long problemId);
 }

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveSummary.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveSummary.java
@@ -1,0 +1,11 @@
+package com.aisip.OnO.backend.problemsolve.repository;
+
+import java.time.LocalDateTime;
+
+public interface ProblemSolveSummary {
+    Long getProblemId();
+
+    Long getSolveCount();
+
+    LocalDateTime getLastSolvedAt();
+}

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.problemsolve.service;
 
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.mission.service.MissionLogService;
+import com.aisip.OnO.backend.problem.service.ReviewIntervalCalculator;
 import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveRegisterDto;
 import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveResponseDto;
 import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveUpdateDto;
@@ -117,7 +118,16 @@ public class ProblemSolveService {
 
         problemSolveRepository.save(problemSolve);
         missionLogService.registerProblemPracticeMission(userId, problem.getId());
-        log.info("userId: {} created problem solve: {}", userId, problemSolve.getId());
+
+        ReviewIntervalCalculator.ReviewSchedule schedule = ReviewIntervalCalculator.calculate(
+                dto.answerStatus(),
+                problem.getReviewInterval(),
+                problem.getConsecutiveCorrectCount()
+        );
+        problem.updateReviewSchedule(schedule.nextReviewAt(), schedule.reviewInterval(), schedule.consecutiveCorrectCount());
+
+        log.info("userId: {} created problem solve: {}, nextReviewAt: {}, mastered: {}",
+                userId, problemSolve.getId(), schedule.nextReviewAt(), schedule.isMastered());
 
         return problemSolve.getId();
     }

--- a/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
+++ b/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.user.controller;
 
 import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.mission.service.MissionLogService;
+import com.aisip.OnO.backend.user.dto.NotificationSettingsUpdateDto;
 import com.aisip.OnO.backend.user.dto.UserRegisterDto;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.service.UserService;
@@ -34,6 +35,16 @@ public class UserController {
         userService.updateUser(userId, userRegisterDto);
 
         return CommonResponse.success("사용자 정보 수정이 완료되었습니다.");
+    }
+
+    // ✅ 알림 수신 설정
+    @PatchMapping("/notification-settings")
+    public CommonResponse<String> updateNotificationSettings(
+            @RequestBody NotificationSettingsUpdateDto dto) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        userService.updateNotificationSettings(userId, dto.notificationEnabled());
+
+        return CommonResponse.success("알림 설정이 변경되었습니다.");
     }
 
     // ✅ 사용자 계정 삭제

--- a/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
+++ b/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
@@ -22,6 +22,7 @@ public class UserController {
     public CommonResponse<UserResponseDto> getUserInfo() {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         missionLogService.registerLoginMission(userId);
+        userService.touchLastActiveAt(userId);
 
         return CommonResponse.success(userService.findUser(userId));
     }

--- a/src/main/java/com/aisip/OnO/backend/user/dto/NotificationSettingsUpdateDto.java
+++ b/src/main/java/com/aisip/OnO/backend/user/dto/NotificationSettingsUpdateDto.java
@@ -1,0 +1,3 @@
+package com.aisip.OnO.backend.user.dto;
+
+public record NotificationSettingsUpdateDto(boolean notificationEnabled) {}

--- a/src/main/java/com/aisip/OnO/backend/user/entity/User.java
+++ b/src/main/java/com/aisip/OnO/backend/user/entity/User.java
@@ -10,6 +10,9 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,6 +43,10 @@ public class User extends BaseEntity {
 
     private String platform;
 
+    private LocalDateTime lastActiveAt;
+
+    private LocalDate lastNotifiedAt;
+
     @Embedded
     private UserMissionStatus userMissionStatus;
 
@@ -61,6 +68,19 @@ public class User extends BaseEntity {
                         1L, 0L   // 총 학습 레벨 (레벨 1, 포인트 0으로 시작)
                 ))
                 .build();
+    }
+
+    public void touchLastActiveAt() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        // 오늘 이미 갱신한 경우 DB write 생략
+        if (this.lastActiveAt != null && !this.lastActiveAt.toLocalDate().isBefore(today)) {
+            return;
+        }
+        this.lastActiveAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    public void updateLastNotifiedAt(LocalDate date) {
+        this.lastNotifiedAt = date;
     }
 
     public void updateUser(UserRegisterDto userRegisterDto) {

--- a/src/main/java/com/aisip/OnO/backend/user/entity/User.java
+++ b/src/main/java/com/aisip/OnO/backend/user/entity/User.java
@@ -47,6 +47,10 @@ public class User extends BaseEntity {
 
     private LocalDate lastNotifiedAt;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean notificationEnabled = true;
+
     @Embedded
     private UserMissionStatus userMissionStatus;
 
@@ -81,6 +85,10 @@ public class User extends BaseEntity {
 
     public void updateLastNotifiedAt(LocalDate date) {
         this.lastNotifiedAt = date;
+    }
+
+    public void updateNotificationEnabled(boolean enabled) {
+        this.notificationEnabled = enabled;
     }
 
     public void updateUser(UserRegisterDto userRegisterDto) {

--- a/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
@@ -7,6 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -31,5 +35,34 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     List<Object[]> countDailyNewUsers(
             @Param("startDateTime") LocalDateTime startDateTime,
             @Param("endDateTime") LocalDateTime endDateTime
+    );
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE User u SET u.lastNotifiedAt = :date WHERE u.id IN :userIds")
+    void bulkUpdateLastNotifiedAt(@Param("userIds") List<Long> userIds, @Param("date") LocalDate date);
+
+    // 7일 ~ 30일 미접속 유저 (5일 간격)
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.lastActiveAt < :reengagementCutoff
+              AND u.lastActiveAt >= :inactiveCutoff
+              AND (u.lastNotifiedAt IS NULL OR u.lastNotifiedAt < :notificationCutoff)
+            """)
+    List<User> findUsersForReengagement(
+            @Param("reengagementCutoff") LocalDateTime reengagementCutoff,
+            @Param("inactiveCutoff") LocalDateTime inactiveCutoff,
+            @Param("notificationCutoff") LocalDate notificationCutoff
+    );
+
+    // 30일 초과 미접속 유저 (30일 간격)
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.lastActiveAt < :inactiveCutoff
+              AND (u.lastNotifiedAt IS NULL OR u.lastNotifiedAt < :notificationCutoff)
+            """)
+    List<User> findUsersForLongInactiveReengagement(
+            @Param("inactiveCutoff") LocalDateTime inactiveCutoff,
+            @Param("notificationCutoff") LocalDate notificationCutoff
     );
 }

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -121,6 +121,11 @@ public class UserService {
     }
 
     @Transactional
+    public void touchLastActiveAt(Long userId) {
+        findUserEntity(userId).touchLastActiveAt();
+    }
+
+    @Transactional
     public void updateUser(Long userId, UserRegisterDto userRegisterDto) {
 
         User user = findUserEntity(userId);

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -126,6 +126,11 @@ public class UserService {
     }
 
     @Transactional
+    public void updateNotificationSettings(Long userId, boolean notificationEnabled) {
+        findUserEntity(userId).updateNotificationEnabled(notificationEnabled);
+    }
+
+    @Transactional
     public void updateUser(Long userId, UserRegisterDto userRegisterDto) {
 
         User user = findUserEntity(userId);

--- a/src/main/java/com/aisip/OnO/backend/util/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fcm/repository/FcmTokenRepository.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.util.fcm.repository;
 
 import com.aisip.OnO.backend.util.fcm.entity.FcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +16,7 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     Optional<FcmToken> findByToken(String token);
 
     List<FcmToken> findAllByUserId(Long userId);
+
+    @Transactional
+    void deleteByToken(String token);
 }

--- a/src/main/resources/db/migration/V2__add_review_schedule_fields.sql
+++ b/src/main/resources/db/migration/V2__add_review_schedule_fields.sql
@@ -1,0 +1,12 @@
+-- Problem 테이블: 복습 스케줄 필드 추가
+ALTER TABLE problem
+    ADD COLUMN next_review_at     DATE         NULL,
+    ADD COLUMN review_interval    INT          NOT NULL DEFAULT 1,
+    ADD COLUMN consecutive_correct_count INT   NOT NULL DEFAULT 0;
+
+-- User 테이블: 마지막 앱 접속 시각 추가 (알림 대상 필터링용)
+ALTER TABLE user
+    ADD COLUMN last_active_at DATETIME NULL;
+
+-- 복습 대상 조회 성능을 위한 인덱스
+CREATE INDEX idx_problem_review_due ON problem (user_id, next_review_at);

--- a/src/main/resources/db/migration/V3__add_notification_fields_and_backfill.sql
+++ b/src/main/resources/db/migration/V3__add_notification_fields_and_backfill.sql
@@ -1,0 +1,9 @@
+-- User: 알림 스팸 방지용 마지막 알림 발송일
+ALTER TABLE user
+    ADD COLUMN last_notified_at DATE NULL;
+
+-- 기존 유저 last_active_at 백필 (updated_at 기준)
+UPDATE user SET last_active_at = updated_at WHERE last_active_at IS NULL AND deleted_at IS NULL;
+
+-- 스케줄러 전체 날짜 범위 스캔용 인덱스 (next_review_at 선두)
+CREATE INDEX idx_problem_next_review_date ON problem (next_review_at, user_id);

--- a/src/main/resources/db/migration/V4__add_notification_enabled.sql
+++ b/src/main/resources/db/migration/V4__add_notification_enabled.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user
+    ADD COLUMN notification_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
@@ -76,6 +76,8 @@ class ProblemControllerTest {
                     LocalDateTime.now(),
                     LocalDateTime.now(),
                     imageUrlList,
+                    (long) i,
+                    LocalDateTime.now(),
                     null,
                     List.of(),
                     List.of()
@@ -102,6 +104,8 @@ class ProblemControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.problemId").value(1L))
+                .andExpect(jsonPath("$.data.solveCount").value(1L))
+                .andExpect(jsonPath("$.data.lastSolvedAt").exists())
                 .andExpect(jsonPath("$.data.memo").value("memo1"))
                 .andExpect(jsonPath("$.data.reference").value("reference1"))
                 .andExpect(jsonPath("$.data.imageUrlList.size()").value(3))
@@ -120,6 +124,8 @@ class ProblemControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.size()").value(5))
+                .andExpect(jsonPath("$.data[0].solveCount").value(1L))
+                .andExpect(jsonPath("$.data[0].lastSolvedAt").exists())
                 .andExpect(jsonPath("$.data[0].memo").value("memo1"))
                 .andExpect(jsonPath("$.data[0].reference").value("reference1"))
                 .andExpect(jsonPath("$.data[0].imageUrlList.size()").value(3))

--- a/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
@@ -14,6 +14,9 @@ import com.aisip.OnO.backend.problem.entity.ProblemImageData;
 import com.aisip.OnO.backend.problem.entity.ProblemImageType;
 import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
+import com.aisip.OnO.backend.problemsolve.entity.ProblemSolve;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +52,9 @@ class ProblemServiceTest {
 
     @Autowired
     private FolderRepository folderRepository;
+
+    @Autowired
+    private ProblemSolveRepository problemSolveRepository;
 
     @MockBean
     private FileUploadService fileUploadService;
@@ -109,6 +115,7 @@ class ProblemServiceTest {
         problemList.clear();
         folderList.clear();
 
+        problemSolveRepository.deleteAll();
         problemImageDataRepository.deleteAll();
         problemRepository.deleteAll();
         folderRepository.deleteAll();
@@ -120,6 +127,10 @@ class ProblemServiceTest {
         // given
         Problem problem = problemList.get(0);
         Long problemId = problem.getId();
+        LocalDateTime firstSolvedAt = LocalDateTime.now().minusDays(1);
+        LocalDateTime lastSolvedAt = LocalDateTime.now();
+        problemSolveRepository.save(ProblemSolve.create(problem, userId, firstSolvedAt, AnswerStatus.CORRECT, null, null, null));
+        problemSolveRepository.save(ProblemSolve.create(problem, userId, lastSolvedAt, AnswerStatus.WRONG, null, null, null));
 
         // when
         ProblemResponseDto problemResponseDto = problemService.findProblem(problemId);
@@ -129,6 +140,8 @@ class ProblemServiceTest {
         assertThat(problemResponseDto.reference()).isEqualTo(problem.getReference());
         assertThat(problemResponseDto.imageUrlList().size()).isEqualTo(problemImageDataRepository.findAllByProblemId(problemId).size());
         assertThat(problemResponseDto.imageUrlList().size()).isEqualTo(2);
+        assertThat(problemResponseDto.solveCount()).isEqualTo(2L);
+        assertThat(problemResponseDto.lastSolvedAt()).isEqualTo(lastSolvedAt);
     }
 
     @Test
@@ -137,6 +150,9 @@ class ProblemServiceTest {
         //given
 
         //when
+        Problem firstProblem = problemList.get(0);
+        LocalDateTime lastSolvedAt = LocalDateTime.now();
+        problemSolveRepository.save(ProblemSolve.create(firstProblem, userId, lastSolvedAt, AnswerStatus.CORRECT, null, null, null));
         List<ProblemResponseDto> problemResponseDtoList = problemService.findUserProblems(userId);
 
         //then
@@ -149,6 +165,10 @@ class ProblemServiceTest {
             assertThat(problemResponseDtoList.get(i).memo()).isEqualTo(problem.getMemo());
             assertThat(problemResponseDtoList.get(i).reference()).isEqualTo(problem.getReference());
         }
+        assertThat(problemResponseDtoList.get(0).solveCount()).isEqualTo(1L);
+        assertThat(problemResponseDtoList.get(0).lastSolvedAt()).isEqualTo(lastSolvedAt);
+        assertThat(problemResponseDtoList.get(1).solveCount()).isEqualTo(0L);
+        assertThat(problemResponseDtoList.get(1).lastSolvedAt()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### 복습 스케줄링

- 문제 등록 시 최초 복습 예정일을 설정하도록 했습니다.
- 문제 복습 결과(`ProblemSolve.answerStatus`)에 따라 다음 복습일, 복습 간격, 연속 정답 횟수를 갱신하도록 했습니다.
- 오늘 복습할 문제 목록을 조회하는 `/api/problems/review-due` API를 추가했습니다.
- 복습 대상 개수와 지연 복습 개수를 함께 내려주는 `ReviewDueResponseDto`를 추가했습니다.

### 복습/재참여 알림

- Quartz 기반 복습 알림 스케줄러를 추가해 매일 오전 9시(Asia/Seoul)에 알림을 발송하도록 했습니다.
- 복습 예정 문제가 있는 활성 유저에게 오늘의 복습 알림을 발송하도록 했습니다.
- 일정 기간 미접속 유저와 장기 미접속 유저에게 재참여 알림을 발송하도록 했습니다.
- 중복 발송 방지를 위해 유저별 마지막 알림 발송일(`lastNotifiedAt`)을 관리하도록 했습니다.

### 알림 수신 설정

- 유저 알림 수신 여부(`notificationEnabled`) 필드를 추가했습니다.
- `/api/users/notification-settings` API로 알림 수신 여부를 변경할 수 있도록 했습니다.
- 알림 발송 대상 조회 시 수신 동의한 유저만 포함되도록 했습니다.

### FCM 토큰 정리

- FCM 발송 중 토큰 만료/미등록 응답이 발생하면 해당 토큰을 DB에서 삭제하도록 했습니다.
- 유효하지 않은 토큰이 반복 발송 대상에 남아 불필요한 실패를 유발하지 않도록 개선했습니다.

### 오답노트 응답 정보 보강

- 문제 썸네일 응답(`ProblemResponseDto`)에 해당 문제의 풀이 기록 개수(`solveCount`)를 추가했습니다.
- 가장 최근 풀이 일시(`lastSolvedAt`)를 함께 반환하도록 했습니다.
- 목록 조회에서는 `ProblemSolve`를 문제별로 집계해 `solveCount`와 `lastSolvedAt`을 한 번에 조회하도록 했습니다.

### DB 마이그레이션

- 복습 스케줄 필드(`next_review_at`, `review_interval`, `consecutive_correct_count`)와 관련 인덱스를 추가했습니다.
- 알림 발송 제어를 위한 `last_notified_at`, `notification_enabled` 필드를 추가했습니다.
- 복습 알림 조회 성능을 위한 인덱스를 추가했습니다.

### 스크린샷 (선택)

- API/스케줄러 중심 변경으로 스크린샷은 생략합니다.
