### PR TITLE
[Fix] 사용자 리소스 소유자 검증 및 문제 등록 folderId null 처리

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminProblemController.java
@@ -70,11 +70,11 @@ public class AdminProblemController {
 
     @GetMapping("/problem/{problemId}")
     public String getProblemDetail(@PathVariable(name = "problemId") Long problemId, Model model) {
-        ProblemResponseDto problem = problemService.findProblem(problemId);
+        ProblemResponseDto problem = problemService.findProblemForAdmin(problemId);
         model.addAttribute("problem", problem);
 
         // 폴더 및 작성자 정보 조회
-        FolderResponseDto folder = folderService.findFolder(problem.folderId());
+        FolderResponseDto folder = folderService.findFolderForAdmin(problem.folderId());
         UserResponseDto user = userService.findUser(folder.userId());
         List<ProblemSolveResponseDto> problemSolves = problemSolveService.getAdminProblemSolvesByProblemId(problemId);
         model.addAttribute("folder", folder);

--- a/src/main/java/com/aisip/OnO/backend/folder/controller/FolderController.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/controller/FolderController.java
@@ -35,7 +35,7 @@ public class FolderController {
     public CommonResponse<FolderResponseDto> getFolder(@PathVariable("folderId") Long folderId) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-        return CommonResponse.success(folderService.findFolder(folderId));
+        return CommonResponse.success(folderService.findFolder(folderId, userId));
     }
 
     // ✅ V2 API: 커서 기반 하위 폴더 조회 (무한 스크롤)
@@ -47,7 +47,7 @@ public class FolderController {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         log.info("userId: {} get subfolders for folderId: {} with cursor: {}, size: {}", userId, folderId, cursor, size);
 
-        return CommonResponse.success(folderService.findSubFoldersWithCursor(folderId, cursor, size));
+        return CommonResponse.success(folderService.findSubFoldersWithCursor(folderId, userId, cursor, size));
     }
 
     // ✅ 모든 폴더 조회
@@ -98,7 +98,8 @@ public class FolderController {
     // ✅ 폴더 삭제 기능
     @DeleteMapping("")
     public CommonResponse<String> deleteFoldersWithProblems(@RequestBody FolderDeleteRequestDto folderDeleteRequestDto) {
-        folderService.deleteFoldersWithProblems(folderDeleteRequestDto.deleteFolderIdList());
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        folderService.deleteFoldersWithProblems(userId, folderDeleteRequestDto.deleteFolderIdList());
         return CommonResponse.success("폴더가 성공적으로 삭제되었습니다.");
     }
 

--- a/src/main/java/com/aisip/OnO/backend/folder/service/FolderService.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/service/FolderService.java
@@ -59,7 +59,7 @@ public class FolderService {
     }
 
     @Transactional(readOnly = true)
-    public FolderResponseDto findFolder(Long folderId) {
+    public FolderResponseDto findFolderForAdmin(Long folderId) {
         Folder folder = folderRepository.findFolderWithDetailsByFolderId(folderId)
                 .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
 
@@ -68,9 +68,24 @@ public class FolderService {
     }
 
     @Transactional(readOnly = true)
-    public Folder findFolderEntity(Long folderId) {
+    public FolderResponseDto findFolder(Long folderId, Long userId) {
+        Folder folder = findFolderWithDetailsOwnedByUser(folderId, userId);
+
+        List<Long> problemIdList = folderRepository.findProblemIdsByFolder(folder.getId());
+        return FolderResponseDto.from(folder, problemIdList);
+    }
+
+    @Transactional(readOnly = true)
+    private Folder findFolderEntity(Long folderId) {
         return folderRepository.findById(folderId)
                 .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Folder findFolderEntity(Long folderId, Long userId) {
+        Folder folder = findFolderEntity(folderId);
+        validateFolderOwner(folder, userId);
+        return folder;
     }
 
     @Transactional(readOnly = true)
@@ -104,7 +119,7 @@ public class FolderService {
 
     public Long createFolder(FolderRegisterDto folderRegisterDto, Long userId) {
         Folder folder = Folder.from(folderRegisterDto, userId);
-        Folder parentFolder = findFolderEntity(folderRegisterDto.parentFolderId());
+        Folder parentFolder = findFolderEntity(folderRegisterDto.parentFolderId(), userId);
 
         folder.updateParentFolder(parentFolder);
         folderRepository.save(folder);
@@ -114,11 +129,11 @@ public class FolderService {
     }
 
     public void updateFolder(FolderRegisterDto folderRegisterDto, Long userId) {
-        Folder folder = findFolderEntity(folderRegisterDto.folderId());
+        Folder folder = findFolderEntity(folderRegisterDto.folderId(), userId);
         folder.updateFolderInfo(folderRegisterDto);
 
         if (folderRegisterDto.parentFolderId() != null && folder.getParentFolder() != null) {
-            Folder newParentFolder = findFolderEntity(folderRegisterDto.parentFolderId());
+            Folder newParentFolder = findFolderEntity(folderRegisterDto.parentFolderId(), userId);
 
             folder.updateParentFolder(newParentFolder);
         }
@@ -126,11 +141,11 @@ public class FolderService {
         log.info("userId : {} update folder id: {}", userId, folder.getId());
     }
 
-    public void deleteFoldersWithProblems(List<Long> folderIds) {
+    public void deleteFoldersWithProblems(Long userId, List<Long> folderIds) {
         // 삭제할 모든 폴더의 ID 조회 (하위 폴더 포함)
-        Set<Long> allFolderIds = getAllFolderIdsIncludingSubFolders(folderIds);
+        Set<Long> allFolderIds = getAllFolderIdsIncludingSubFolders(userId, folderIds);
 
-        problemService.deleteAllByFolderIds(allFolderIds);
+        problemService.deleteAllByFolderIds(userId, allFolderIds);
 
         deleteAllByFolderIds(allFolderIds);
     }
@@ -142,12 +157,11 @@ public class FolderService {
         deleteAllUserFolders(userId);
     }
 
-    public Set<Long> getAllFolderIdsIncludingSubFolders(List<Long> folderIds) {
+    public Set<Long> getAllFolderIdsIncludingSubFolders(Long userId, List<Long> folderIds) {
         Set<Long> allFolderIds = new HashSet<>();
 
         for (Long folderId : folderIds) {
-            Folder folder = folderRepository.findById(folderId)
-                    .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+            Folder folder = findFolderEntity(folderId, userId);
 
             if (folder.getParentFolder() == null) {
                 throw new ApplicationException(FolderErrorCase.ROOT_FOLDER_CANNOT_REMOVE);
@@ -170,7 +184,7 @@ public class FolderService {
         return subFolderIds;
     }
 
-    public void deleteAllByFolderIds(Collection<Long> folderIds) {
+    private void deleteAllByFolderIds(Collection<Long> folderIds) {
         List<Folder> foldersToDelete = folderRepository.findAllById(folderIds);
         folderRepository.deleteAll(foldersToDelete);
     }
@@ -190,7 +204,8 @@ public class FolderService {
      * @return 커서 기반 페이징 응답
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<FolderThumbnailResponseDto> findSubFoldersWithCursor(Long folderId, Long cursor, int size) {
+    public CursorPageResponse<FolderThumbnailResponseDto> findSubFoldersWithCursor(Long folderId, Long userId, Long cursor, int size) {
+        findFolderEntity(folderId, userId);
         List<Folder> folders = folderRepository.findSubFoldersWithCursor(folderId, cursor, size);
 
         boolean hasNext = folders.size() > size;
@@ -203,6 +218,19 @@ public class FolderService {
 
         log.info("folderId: {} find subfolders with cursor: {}, size: {}, hasNext: {}", folderId, cursor, size, hasNext);
         return CursorPageResponse.of(dtoList, nextCursor, hasNext, size);
+    }
+
+    private Folder findFolderWithDetailsOwnedByUser(Long folderId, Long userId) {
+        Folder folder = folderRepository.findFolderWithDetailsByFolderId(folderId)
+                .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+        validateFolderOwner(folder, userId);
+        return folder;
+    }
+
+    private void validateFolderOwner(Folder folder, Long userId) {
+        if (!Objects.equals(folder.getUserId(), userId)) {
+            throw new ApplicationException(FolderErrorCase.FOLDER_USER_UNMATCHED);
+        }
     }
 
     /**

--- a/src/main/java/com/aisip/OnO/backend/practicenote/controller/PracticeNoteController.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/controller/PracticeNoteController.java
@@ -26,7 +26,7 @@ public class PracticeNoteController {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         log.info("userId: {} get problem practice for practice id: {}", userId, practiceId);
 
-        return CommonResponse.success(practiceNoteService.findPracticeNoteDetail(practiceId));
+        return CommonResponse.success(practiceNoteService.findPracticeNoteDetail(practiceId, userId));
     }
 
     // ✅ 사용자의 모든 복습 리스트 썸네일 조회
@@ -94,7 +94,7 @@ public class PracticeNoteController {
     @DeleteMapping("")
     public CommonResponse<String> deletePractices(@RequestBody PracticeNoteDeleteRequestDto practiceNoteDeleteRequestDto) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        practiceNoteService.deletePractices(practiceNoteDeleteRequestDto.deletePracticeIdList());
+        practiceNoteService.deletePractices(userId, practiceNoteDeleteRequestDto.deletePracticeIdList());
 
         return CommonResponse.success("선택한 복습 노트가 삭제되었습니다.");
     }

--- a/src/main/java/com/aisip/OnO/backend/practicenote/exception/PracticeNoteErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/exception/PracticeNoteErrorCase.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PracticeNoteErrorCase implements ErrorCase {
 
-    PRACTICE_NOTE_NOT_FOUND(404, 6001, "복습 노트를 찾을 수 없습니다.");
+    PRACTICE_NOTE_NOT_FOUND(404, 6001, "복습 노트를 찾을 수 없습니다."),
+
+    PRACTICE_NOTE_USER_UNMATCHED(403, 6002, "복습 노트를 소유한 유저가 아닙니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
@@ -33,6 +33,7 @@ import java.time.LocalTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -56,10 +57,13 @@ public class PracticeNoteService {
 
     private final UserRepository userRepository;
 
-    private PracticeNote getPracticeEntity(Long practiceId){
+    private PracticeNote getPracticeEntity(Long practiceId, Long userId){
 
-        return practiceNoteRepository.findById(practiceId)
+        PracticeNote practiceNote = practiceNoteRepository.findById(practiceId)
                 .orElseThrow(() -> new ApplicationException(PracticeNoteErrorCase.PRACTICE_NOTE_NOT_FOUND));
+
+        validatePracticeOwner(practiceNote, userId);
+        return practiceNote;
     }
 
     public Long registerPractice(PracticeNoteRegisterDto practiceNoteRegisterDto, Long userId) {
@@ -69,7 +73,7 @@ public class PracticeNoteService {
 
         if (practiceNoteRegisterDto.problemIdList() != null) {
             practiceNoteRegisterDto.problemIdList().forEach(problemId ->
-                    addProblemToPractice(practiceNote, problemId));
+                    addProblemToPractice(practiceNote, problemId, userId));
         }
 
         if(practiceNoteRegisterDto.practiceNotification() != null) {
@@ -94,10 +98,11 @@ public class PracticeNoteService {
     }
 
     @Transactional(readOnly = true)
-    public PracticeNoteDetailResponseDto findPracticeNoteDetail(Long practiceId){
+    public PracticeNoteDetailResponseDto findPracticeNoteDetail(Long practiceId, Long userId){
         log.info("find practiceId: {}", practiceId);
         PracticeNote practiceNote = practiceNoteRepository.findPracticeNoteWithDetails(practiceId)
                 .orElseThrow(() -> new ApplicationException(PracticeNoteErrorCase.PRACTICE_NOTE_NOT_FOUND));
+        validatePracticeOwner(practiceNote, userId);
 
         List<Long> problemIdList = practiceNoteRepository.findProblemIdListByPracticeNoteId(practiceId);
 
@@ -132,7 +137,7 @@ public class PracticeNoteService {
     }
 
     public void addPracticeNoteCount(Long userId, Long practiceId) {
-        PracticeNote practiceNote = getPracticeEntity(practiceId);
+        PracticeNote practiceNote = getPracticeEntity(practiceId, userId);
         practiceNote.updatePracticeNoteCount();
 
         // 복습노트 사용 미션 등록
@@ -143,7 +148,7 @@ public class PracticeNoteService {
 
     public void updatePracticeInfo(Long userId, PracticeNoteUpdateDto practiceNoteUpdateDto) {
         Long practiceId = practiceNoteUpdateDto.practiceNoteId();
-        PracticeNote practiceNote = getPracticeEntity(practiceId);
+        PracticeNote practiceNote = getPracticeEntity(practiceId, userId);
 
         practiceNote.updateTitle(practiceNoteUpdateDto.practiceTitle());
 
@@ -151,7 +156,7 @@ public class PracticeNoteService {
 
         if (!practiceNoteUpdateDto.addProblemIdList().isEmpty()) {
             practiceNoteUpdateDto.addProblemIdList().forEach(problemId -> {
-                addProblemToPractice(practiceNote, problemId);
+                addProblemToPractice(practiceNote, problemId, userId);
             });
         }
 
@@ -176,7 +181,12 @@ public class PracticeNoteService {
 
     }
 
-    public void deletePractice(Long practiceId) {
+    public void deletePractice(Long practiceId, Long userId) {
+        getPracticeEntity(practiceId, userId);
+        deletePracticeWithoutOwnerCheck(practiceId);
+    }
+
+    private void deletePracticeWithoutOwnerCheck(Long practiceId) {
         List<ProblemPracticeNoteMapping> problemPracticeNoteMappingList = problemPracticeNoteMappingRepository.findAllByPracticeNoteId(practiceId);
         problemPracticeNoteMappingList.forEach(ProblemPracticeNoteMapping::removeMappingFromProblemAndPractice);
 
@@ -184,24 +194,27 @@ public class PracticeNoteService {
         log.info("practiceId: {} has deleted", practiceId);
     }
 
-    public void deletePractices(List<Long> practiceIdList) {
-        practiceIdList.forEach(this::deletePractice);
+    public void deletePractices(Long userId, List<Long> practiceIdList) {
+        practiceIdList.forEach(practiceId -> deletePractice(practiceId, userId));
     }
 
     public void deleteAllPracticesByUser(Long userId) {
         List<Long> practiceIdList = practiceNoteRepository.findAllPracticeIdsByUserId(userId);
 
-        deletePractices(practiceIdList);
+        practiceIdList.forEach(this::deletePracticeWithoutOwnerCheck);
         log.info("userId: {} has delete all practices", userId);
     }
 
-    private void addProblemToPractice(PracticeNote practiceNote, Long problemId) {
+    private void addProblemToPractice(PracticeNote practiceNote, Long problemId, Long userId) {
 
         boolean exists = practiceNoteRepository.checkProblemAlreadyMatchingWithPractice(practiceNote.getId(), problemId);
 
         if (!exists) {
             Problem problem = problemRepository.findById(problemId)
                     .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
+            if (!Objects.equals(problem.getUserId(), userId)) {
+                throw new ApplicationException(ProblemErrorCase.PROBLEM_USER_UNMATCHED);
+            }
 
             ProblemPracticeNoteMapping problemPracticeNoteMapping = ProblemPracticeNoteMapping.from();
             problemPracticeNoteMapping.addMappingToProblemAndPractice(problem, practiceNote);
@@ -219,6 +232,12 @@ public class PracticeNoteService {
 
     public void deleteProblemsFromAllPractice(List<Long> deleteProblemIdList) {
         practiceNoteRepository.deleteProblemsFromAllPractice(deleteProblemIdList);
+    }
+
+    private void validatePracticeOwner(PracticeNote practiceNote, Long userId) {
+        if (!Objects.equals(practiceNote.getUserId(), userId)) {
+            throw new ApplicationException(PracticeNoteErrorCase.PRACTICE_NOTE_USER_UNMATCHED);
+        }
     }
 
     /**

--- a/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
@@ -40,7 +40,7 @@ public class ProblemController {
     @GetMapping("/{problemId}")
     public CommonResponse<ProblemResponseDto> getProblem(@PathVariable("problemId") Long problemId) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        ProblemResponseDto problemResponseDto = problemService.findProblem(problemId);
+        ProblemResponseDto problemResponseDto = problemService.findProblem(problemId, userId);
 
         return CommonResponse.success(problemResponseDto);
     }
@@ -58,7 +58,7 @@ public class ProblemController {
     public CommonResponse<List<ProblemResponseDto>> getProblemsByUserId(@PathVariable("folderId") Long folderId) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-        return CommonResponse.success(problemService.findFolderProblemList(folderId));
+        return CommonResponse.success(problemService.findFolderProblemList(folderId, userId));
     }
 
     // ✅ V2 API: 커서 기반 폴더의 문제 조회 (무한 스크롤)
@@ -70,7 +70,7 @@ public class ProblemController {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         log.info("userId: {} get problems for folderId: {} with cursor: {}, size: {}", userId, folderId, cursor, size);
 
-        return CommonResponse.success(problemService.findProblemsByFolderWithCursor(folderId, cursor, size));
+        return CommonResponse.success(problemService.findProblemsByFolderWithCursor(folderId, userId, cursor, size));
     }
 
     // ✅ V2 API: 커서 기반 태그의 문제 조회 (무한 스크롤)
@@ -119,7 +119,7 @@ public class ProblemController {
     @PostMapping("/{problemId}/analysis")
     public CommonResponse<String> requestProblemAnalysis(@PathVariable("problemId") Long problemId) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        problemService.analysisProblem(problemId);
+        problemService.analysisProblem(problemId, userId);
 
         return CommonResponse.success("문제 분석 요청이 접수되었습니다.");
     }
@@ -153,7 +153,7 @@ public class ProblemController {
     ) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         problemService.uploadProblemImages(problemId, userId, problemImages, problemImageTypes);
-        problemService.analysisProblem(problemId);
+        problemService.analysisProblem(problemId, userId);
 
         return CommonResponse.success("이미지 업로드가 시작되었습니다.");
     }
@@ -164,7 +164,7 @@ public class ProblemController {
             @PathVariable("problemId") Long problemId
     ) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        analysisService.updateToNoImage(problemId);
+        problemService.updateProblemAnalysisToNoImage(problemId, userId);
 
         return CommonResponse.success("이미지 업로드가 시작되었습니다.");
     }
@@ -204,7 +204,8 @@ public class ProblemController {
     public CommonResponse<String> deleteProblems(
             @RequestBody ProblemDeleteRequestDto problemDeleteRequestDto
             ) {
-        problemService.deleteProblemList(problemDeleteRequestDto.deleteProblemIdList());
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        problemService.deleteProblemList(userId, problemDeleteRequestDto.deleteProblemIdList());
         return CommonResponse.success("문제 삭제가 완료되었습니다.");
     }
 
@@ -221,7 +222,7 @@ public class ProblemController {
     @DeleteMapping("/imageData")
     public CommonResponse<String> deleteProblemImageData(@RequestParam("imageUrl") String imageUrl) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        problemService.deleteProblemImageData(imageUrl);
+        problemService.deleteProblemImageData(imageUrl, userId);
 
         return CommonResponse.success("문제 이미지 데이터 삭제가 완료되었습니다.");
     }

--- a/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemImageDataRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/repository/ProblemImageDataRepository.java
@@ -4,10 +4,13 @@ import com.aisip.OnO.backend.problem.entity.ProblemImageData;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProblemImageDataRepository extends JpaRepository<ProblemImageData, Long> {
 
     List<ProblemImageData> findAllByProblemId(Long problemId);
+
+    Optional<ProblemImageData> findByImageUrl(String imageUrl);
 
     void deleteAllByProblemId(Long problemId);
 

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -81,9 +81,16 @@ public class ProblemService {
     private final ProblemTagMappingRepository problemTagMappingRepository;
 
     @Transactional(readOnly = true)
-    public ProblemResponseDto findProblem(Long problemId) {
+    public ProblemResponseDto findProblemForAdmin(Long problemId) {
         Problem problem = problemRepository.findProblemWithImageData(problemId)
                 .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
+
+        return toProblemResponseDto(problem);
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemResponseDto findProblem(Long problemId, Long userId) {
+        Problem problem = findProblemEntityWithImageData(problemId, userId);
 
         return toProblemResponseDto(problem);
     }
@@ -120,7 +127,9 @@ public class ProblemService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProblemResponseDto> findFolderProblemList(Long folderId) {
+    public List<ProblemResponseDto> findFolderProblemList(Long folderId, Long userId) {
+        validateFolderOwner(folderId, userId);
+
         return toProblemResponseDtos(problemRepository.findAllByFolderId(folderId));
     }
 
@@ -185,6 +194,7 @@ public class ProblemService {
 
         Folder folder = folderRepository.findById(problemRegisterDto.folderId())
                 .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+        validateFolderOwner(folder, userId);
 
         Problem problem = Problem.from(problemRegisterDto, userId);
         problem.updateFolder(folder);
@@ -262,6 +272,10 @@ public class ProblemService {
         }
 
         return folderRepository.findById(folderId)
+                .map(folder -> {
+                    validateFolderOwner(folder, userId);
+                    return folder;
+                })
                 .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
     }
 
@@ -313,7 +327,14 @@ public class ProblemService {
      * - 이미지 없음: NOT_STARTED → NO_IMAGE
      */
     @Transactional
-    public void analysisProblem(Long problemId) {
+    public void analysisProblem(Long problemId, Long userId) {
+        findProblemEntity(problemId, userId);
+
+        analysisProblemWithoutOwnerCheck(problemId);
+    }
+
+    @Transactional
+    private void analysisProblemWithoutOwnerCheck(Long problemId) {
         // 이미 분석이 완료된 문제는 재요청하지 않음
         if (problemAnalysisRepository.findByProblemId(problemId)
                 .map(analysis -> analysis.getStatus() == AnalysisStatus.COMPLETED)
@@ -342,6 +363,12 @@ public class ProblemService {
     }
 
     @Transactional
+    public void updateProblemAnalysisToNoImage(Long problemId, Long userId) {
+        findProblemEntity(problemId, userId);
+        analysisService.updateToNoImage(problemId);
+    }
+
+    @Transactional
     public void updateProblemInfo(ProblemRegisterDto problemRegisterDto, Long userId) {
 
         Problem problem = findProblemEntity(problemRegisterDto.problemId(), userId);
@@ -359,6 +386,7 @@ public class ProblemService {
         if (problemRegisterDto.folderId() != null) {
             Folder folder = folderRepository.findById(problemRegisterDto.folderId())
                     .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+            validateFolderOwner(folder, userId);
 
             problem.updateFolder(folder);
 
@@ -472,7 +500,7 @@ public class ProblemService {
      * - PracticeNote 매핑 삭제: 동기 (데이터 정합성)
      */
     @Transactional
-    public void deleteProblem(Long problemId) {
+    private void deleteProblemWithoutOwnerCheck(Long problemId) {
         // 1. 이미지 데이터 조회
         List<ProblemImageData> imageDataList = problemImageDataRepository.findAllByProblemId(problemId);
         // 1-1. 태그 매핑 조회
@@ -508,36 +536,51 @@ public class ProblemService {
     }
 
     @Transactional
-    public void deleteProblemImageData(String imageUrl) {
+    public void deleteProblem(Long problemId, Long userId) {
+        findProblemEntity(problemId, userId);
+        deleteProblemWithoutOwnerCheck(problemId);
+    }
+
+    @Transactional
+    public void deleteProblemImageData(String imageUrl, Long userId) {
+        ProblemImageData imageData = problemImageDataRepository.findByImageUrl(imageUrl)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
+        if (!Objects.equals(imageData.getProblem().getUserId(), userId)) {
+            throw new ApplicationException(ProblemErrorCase.PROBLEM_USER_UNMATCHED);
+        }
+
         fileUploadService.deleteImageFileFromS3(imageUrl);
         problemImageDataRepository.deleteByImageUrl(imageUrl);
     }
 
     @Transactional
-    public void deleteProblemList(List<Long> problemIdList) {
-        problemIdList.forEach(this::deleteProblem);
+    public void deleteProblemList(Long userId, List<Long> problemIdList) {
+        problemIdList.forEach(problemId -> deleteProblem(problemId, userId));
     }
 
     @Transactional
-    public void deleteFolderProblems(Long folderId) {
+    private void deleteFolderProblems(Long folderId) {
         problemRepository.findAllByFolderId(folderId)
                 .forEach(problem -> {
-                    deleteProblem(problem.getId());
+                    deleteProblemWithoutOwnerCheck(problem.getId());
                 });
 
         log.info("problem in folderId: {} has deleted", folderId);
     }
 
     @Transactional
-    public void deleteAllByFolderIds(Collection<Long> folderIds) {
-        folderIds.forEach(this::deleteFolderProblems);
+    public void deleteAllByFolderIds(Long userId, Collection<Long> folderIds) {
+        folderIds.forEach(folderId -> {
+            validateFolderOwner(folderId, userId);
+            deleteFolderProblems(folderId);
+        });
     }
 
     @Transactional
     public void deleteAllUserProblems(Long userId) {
         problemRepository.findAllByUserId(userId)
                 .forEach(problem -> {
-                    deleteProblem(problem.getId());
+                    deleteProblemWithoutOwnerCheck(problem.getId());
                 });
 
         log.info("userId: {} delete all user problems", userId);
@@ -551,7 +594,8 @@ public class ProblemService {
      * @return 커서 기반 페이징 응답
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<ProblemResponseDto> findProblemsByFolderWithCursor(Long folderId, Long cursor, int size) {
+    public CursorPageResponse<ProblemResponseDto> findProblemsByFolderWithCursor(Long folderId, Long userId, Long cursor, int size) {
+        validateFolderOwner(folderId, userId);
         List<Problem> problems = problemRepository.findProblemsByFolderWithCursor(folderId, cursor, size);
 
         boolean hasNext = problems.size() > size;
@@ -655,6 +699,18 @@ public class ProblemService {
                     );
                 })
                 .collect(Collectors.toList());
+    }
+
+    private void validateFolderOwner(Long folderId, Long userId) {
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+        validateFolderOwner(folder, userId);
+    }
+
+    private void validateFolderOwner(Folder folder, Long userId) {
+        if (!Objects.equals(folder.getUserId(), userId)) {
+            throw new ApplicationException(FolderErrorCase.FOLDER_USER_UNMATCHED);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -206,8 +206,7 @@ public class ProblemService {
      */
     @Transactional
     public Long registerProblemV2(ProblemRegisterV2Dto problemRegisterV2Dto, Long userId) {
-        Folder folder = folderRepository.findById(problemRegisterV2Dto.folderId())
-                .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+        Folder folder = resolveRegisterFolder(problemRegisterV2Dto.folderId(), userId);
 
         ProblemRegisterDto baseDto = new ProblemRegisterDto(
                 problemRegisterV2Dto.problemId(),
@@ -254,6 +253,16 @@ public class ProblemService {
 
         log.info("userId: {} register problem(v2) problemId: {}", userId, problem.getId());
         return problem.getId();
+    }
+
+    private Folder resolveRegisterFolder(Long folderId, Long userId) {
+        if (folderId == null) {
+            return folderRepository.findByUserIdAndParentFolderIsNull(userId)
+                    .orElseThrow(() -> new ApplicationException(FolderErrorCase.ROOT_FOLDER_NOT_EXIST));
+        }
+
+        return folderRepository.findById(folderId)
+                .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
     }
 
     /**

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveImageDataRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/repository/ProblemSolveImageDataRepository.java
@@ -4,10 +4,13 @@ import com.aisip.OnO.backend.problemsolve.entity.ProblemSolveImageData;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProblemSolveImageDataRepository extends JpaRepository<ProblemSolveImageData, Long> {
 
     List<ProblemSolveImageData> findAllByProblemSolveId(Long problemSolveId);
+
+    Optional<ProblemSolveImageData> findByImageUrl(String imageUrl);
 
     void deleteByImageUrl(String imageUrl);
 }

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/controller/FileUploadController.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/controller/FileUploadController.java
@@ -4,7 +4,7 @@ import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -42,7 +42,8 @@ public class FileUploadController {
     public CommonResponse<String> deleteImageFile(
             @RequestParam("imageUrl") String imageUrl
     ) {
-        fileUploadService.deleteImageFileFromS3(imageUrl);
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        fileUploadService.deleteUserImageFile(imageUrl, userId);
 
         return CommonResponse.success("이미지 삭제가 완료되었습니다.");
     }

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/exception/FileUploadErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/exception/FileUploadErrorCase.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FileUploadErrorCase implements ErrorCase {
 
-    FILE_UPLOAD_FAILED(400, 2001, "파일 업로드 중 문제가 발생했습니다.");
+    FILE_UPLOAD_FAILED(400, 2001, "파일 업로드 중 문제가 발생했습니다."),
+
+    FILE_NOT_FOUND(404, 2002, "파일을 찾을 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
@@ -1,6 +1,12 @@
 package com.aisip.OnO.backend.util.fileupload.service;
 
 import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.problem.entity.ProblemImageData;
+import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
+import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
+import com.aisip.OnO.backend.problemsolve.entity.ProblemSolveImageData;
+import com.aisip.OnO.backend.problemsolve.exception.ProblemSolveErrorCase;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveImageDataRepository;
 import com.aisip.OnO.backend.util.fileupload.exception.FileUploadErrorCase;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
@@ -8,10 +14,12 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -24,6 +32,9 @@ import java.util.UUID;
 public class FileUploadService {
     private final AmazonS3Client amazonS3Client;
     private final MeterRegistry meterRegistry;
+    private final ProblemImageDataRepository problemImageDataRepository;
+    private final ProblemSolveImageDataRepository problemSolveImageDataRepository;
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
@@ -63,6 +74,36 @@ public class FileUploadService {
             recordExternalCall("s3", "delete", "failure", sample);
             throw e;
         }
+    }
+
+    @Transactional
+    public void deleteUserImageFile(String imageUrl, Long userId) {
+        problemImageDataRepository.findByImageUrl(imageUrl)
+                .ifPresentOrElse(
+                        imageData -> deleteProblemImageData(imageData, imageUrl, userId),
+                        () -> deleteProblemSolveImageData(imageUrl, userId)
+                );
+    }
+
+    private void deleteProblemImageData(ProblemImageData imageData, String imageUrl, Long userId) {
+        if (!Objects.equals(imageData.getProblem().getUserId(), userId)) {
+            throw new ApplicationException(ProblemErrorCase.PROBLEM_USER_UNMATCHED);
+        }
+
+        deleteImageFileFromS3(imageUrl);
+        problemImageDataRepository.deleteByImageUrl(imageUrl);
+    }
+
+    private void deleteProblemSolveImageData(String imageUrl, Long userId) {
+        ProblemSolveImageData imageData = problemSolveImageDataRepository.findByImageUrl(imageUrl)
+                .orElseThrow(() -> new ApplicationException(FileUploadErrorCase.FILE_NOT_FOUND));
+
+        if (!Objects.equals(imageData.getProblemSolve().getUserId(), userId)) {
+            throw new ApplicationException(ProblemSolveErrorCase.PROBLEM_SOLVE_USER_UNMATCHED);
+        }
+
+        deleteImageFileFromS3(imageUrl);
+        problemSolveImageDataRepository.deleteByImageUrl(imageUrl);
     }
 
     private String createFileName(MultipartFile file) {

--- a/src/test/java/com/aisip/OnO/backend/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/folder/service/FolderServiceTest.java
@@ -170,7 +170,7 @@ class FolderServiceTest {
         Long folderId = folderList.get(1).getId();
 
         //when
-        FolderResponseDto folderResponseDto = folderService.findFolder(folderId);
+        FolderResponseDto folderResponseDto = folderService.findFolder(folderId, userId);
 
         //then
         assertThat(folderResponseDto.folderId()).isEqualTo(folderList.get(1).getId());
@@ -183,13 +183,26 @@ class FolderServiceTest {
     }
 
     @Test
+    @DisplayName("다른 유저의 폴더 조회 시 예외")
+    void findFolder_OtherUserFolder() {
+        Folder otherUserFolder = folderRepository.save(Folder.from(
+                new FolderRegisterDto("other folder", null, null),
+                2L
+        ));
+
+        assertThatThrownBy(() -> folderService.findFolder(otherUserFolder.getId(), userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(FolderErrorCase.FOLDER_USER_UNMATCHED.getMessage());
+    }
+
+    @Test
     @DisplayName("folderId를 사용해 특정 폴더 엔티티 조회하기 테스트")
     void findFolderEntity() {
         //given
         Long folderId = folderList.get(0).getId();
 
         //when
-        Folder folder = folderService.findFolderEntity(folderId);
+        Folder folder = folderService.findFolderEntity(folderId, userId);
 
         //then
         assertThat(folder.getId()).isEqualTo(folderList.get(0).getId());
@@ -317,6 +330,24 @@ class FolderServiceTest {
     }
 
     @Test
+    @DisplayName("다른 유저의 부모 폴더에 폴더 생성 시 예외")
+    void createFolder_OtherUserParentFolder() {
+        Folder otherUserParentFolder = folderRepository.save(Folder.from(
+                new FolderRegisterDto("other parent", null, null),
+                2L
+        ));
+        FolderRegisterDto folderRegisterDto = new FolderRegisterDto(
+                "new folder",
+                null,
+                otherUserParentFolder.getId()
+        );
+
+        assertThatThrownBy(() -> folderService.createFolder(folderRegisterDto, userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(FolderErrorCase.FOLDER_USER_UNMATCHED.getMessage());
+    }
+
+    @Test
     @DisplayName("폴더 수정 테스트 - 폴더 이름 수정")
     void updateFolder_FolderName() {
         //given
@@ -396,7 +427,7 @@ class FolderServiceTest {
         doNothing().when(fileUploadService).deleteImageFileFromS3(anyString());
 
         // when & then
-        assertThatThrownBy(() -> folderService.deleteFoldersWithProblems(folderIdList))
+        assertThatThrownBy(() -> folderService.deleteFoldersWithProblems(userId, folderIdList))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessageContaining(FolderErrorCase.ROOT_FOLDER_CANNOT_REMOVE.getMessage());
 
@@ -411,7 +442,7 @@ class FolderServiceTest {
         doNothing().when(fileUploadService).deleteImageFileFromS3(anyString());
 
         // when
-        folderService.deleteFoldersWithProblems(folderIdList);
+        folderService.deleteFoldersWithProblems(userId, folderIdList);
 
         // then
         assertThat(folderRepository.findAllByUserId(userId).size()).isEqualTo(1);
@@ -425,7 +456,7 @@ class FolderServiceTest {
         doNothing().when(fileUploadService).deleteImageFileFromS3(anyString());
 
         // when
-        folderService.deleteFoldersWithProblems(folderIdList);
+        folderService.deleteFoldersWithProblems(userId, folderIdList);
 
         // then
         assertThat(folderRepository.findAllByUserId(userId).size()).isEqualTo(3);

--- a/src/test/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteServiceTest.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.practicenote.service;
 
+import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.folder.dto.FolderRegisterDto;
 import com.aisip.OnO.backend.folder.entity.Folder;
 import com.aisip.OnO.backend.folder.repository.FolderRepository;
@@ -10,6 +11,7 @@ import com.aisip.OnO.backend.practicenote.dto.PracticeNoteUpdateDto;
 import com.aisip.OnO.backend.practicenote.dto.PracticeNotificationRegisterDto;
 import com.aisip.OnO.backend.practicenote.entity.PracticeNote;
 import com.aisip.OnO.backend.practicenote.entity.ProblemPracticeNoteMapping;
+import com.aisip.OnO.backend.practicenote.exception.PracticeNoteErrorCase;
 import com.aisip.OnO.backend.practicenote.repository.PracticeNoteRepository;
 import com.aisip.OnO.backend.practicenote.repository.ProblemPracticeNoteMappingRepository;
 import com.aisip.OnO.backend.problem.dto.ProblemImageDataRegisterDto;
@@ -17,6 +19,7 @@ import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.entity.ProblemImageData;
 import com.aisip.OnO.backend.problem.entity.ProblemImageType;
+import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
 import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -33,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -187,7 +191,7 @@ class PracticeNoteServiceTest {
         Long practiceNoteId = practiceNote.getId();
 
         //when
-        PracticeNoteDetailResponseDto practiceNoteDetailResponseDto = practiceNoteService.findPracticeNoteDetail(practiceNoteId);
+        PracticeNoteDetailResponseDto practiceNoteDetailResponseDto = practiceNoteService.findPracticeNoteDetail(practiceNoteId, userId);
 
         //then
         assertThat(practiceNote.getId()).isEqualTo(practiceNoteDetailResponseDto.practiceNoteId());
@@ -196,6 +200,19 @@ class PracticeNoteServiceTest {
             //System.out.println("===== imageDataSize: " + practiceNoteDetailResponseDto.problemResponseDtoList().get(i).imageUrlList().size() + "=====");
             assertThat(problemList.get(i).getId()).isEqualTo(practiceNoteDetailResponseDto.problemIdList().get(i));
         }
+    }
+
+    @Test
+    @DisplayName("다른 유저의 복습 노트 상세 조회 시 예외")
+    void findPracticeNoteDetail_OtherUserPractice() {
+        PracticeNote otherUserPractice = practiceNoteRepository.save(PracticeNote.from(
+                new PracticeNoteRegisterDto(null, "other practice", List.of(), null),
+                2L
+        ));
+
+        assertThatThrownBy(() -> practiceNoteService.findPracticeNoteDetail(otherUserPractice.getId(), userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(PracticeNoteErrorCase.PRACTICE_NOTE_USER_UNMATCHED.getMessage());
     }
 
     @Test
@@ -227,6 +244,28 @@ class PracticeNoteServiceTest {
         practiceNoteService.registerPractice(practiceNoteRegisterDto, userId);
 
         assertThat(practiceNoteRepository.findAll().size()).isEqualTo(practiceNoteList.size() + 1);
+    }
+
+    @Test
+    @DisplayName("다른 유저의 문제를 복습 노트에 추가하면 예외")
+    void registerPractice_OtherUserProblem() {
+        Problem otherUserProblem = Problem.from(
+                new ProblemRegisterDto(null, "memo", "reference", null, LocalDateTime.now()),
+                2L
+        );
+        otherUserProblem.updateFolder(problemList.get(0).getFolder());
+        problemRepository.save(otherUserProblem);
+
+        PracticeNoteRegisterDto practiceNoteRegisterDto = new PracticeNoteRegisterDto(
+                null,
+                "new practice",
+                List.of(otherUserProblem.getId()),
+                null
+        );
+
+        assertThatThrownBy(() -> practiceNoteService.registerPractice(practiceNoteRegisterDto, userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(ProblemErrorCase.PROBLEM_USER_UNMATCHED.getMessage());
     }
 
     @Test
@@ -279,7 +318,7 @@ class PracticeNoteServiceTest {
         Long practiceNoteId = practiceNoteList.get(0).getId();
 
         // when
-        practiceNoteService.deletePractice(practiceNoteId);
+        practiceNoteService.deletePractice(practiceNoteId, userId);
 
         // then
         Optional<PracticeNote> optionalPracticeNote = practiceNoteRepository.findById(practiceNoteId);
@@ -296,7 +335,7 @@ class PracticeNoteServiceTest {
         List<Long> practiceIdList = List.of(practiceNoteList.get(0).getId(), practiceNoteList.get(1).getId());
 
         // when
-        practiceNoteService.deletePractices(practiceIdList);
+        practiceNoteService.deletePractices(userId, practiceIdList);
 
         // then
         for (int i = 0; i < 2; i++) {

--- a/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
@@ -97,7 +97,7 @@ class ProblemControllerTest {
     void getProblem() throws Exception {
         //given
         Long problemId = 1L;
-        given(problemService.findProblem(problemId)).willReturn(problemResponseDtoList.get(0));
+        given(problemService.findProblem(problemId, 1L)).willReturn(problemResponseDtoList.get(0));
 
         // When & Then
         mockMvc.perform(get("/api/problems/" + problemId)
@@ -152,7 +152,7 @@ class ProblemControllerTest {
     @WithMockCustomUser()
     void getFolderProblems() throws Exception {
         //given
-        given(problemService.findFolderProblemList(1L)).willReturn(problemResponseDtoList);
+        given(problemService.findFolderProblemList(1L, 1L)).willReturn(problemResponseDtoList);
 
         // When & Then
         mockMvc.perform(get("/api/problems/folder/1")
@@ -203,7 +203,7 @@ class ProblemControllerTest {
                 .andExpect(status().isOk());
 
         verify(problemService, times(1)).uploadProblemImages(eq(1L), eq(1L), any(), any());
-        verify(problemService, times(1)).analysisProblem(eq(1L));
+        verify(problemService, times(1)).analysisProblem(eq(1L), eq(1L));
     }
 
     @Test
@@ -264,6 +264,6 @@ class ProblemControllerTest {
                         .param("imageUrl", imageUrl))
                 .andExpect(status().isOk());
 
-        Mockito.verify(problemService, Mockito.times(1)).deleteProblemImageData(imageUrl);
+        Mockito.verify(problemService, Mockito.times(1)).deleteProblemImageData(imageUrl, 1L);
     }
 }

--- a/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
@@ -13,6 +13,7 @@ import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.entity.ProblemImageData;
 import com.aisip.OnO.backend.problem.entity.ProblemImageType;
+import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
 import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
@@ -140,7 +141,7 @@ class ProblemServiceTest {
         problemSolveRepository.save(ProblemSolve.create(problem, userId, lastSolvedAt, AnswerStatus.WRONG, null, null, null));
 
         // when
-        ProblemResponseDto problemResponseDto = problemService.findProblem(problemId);
+        ProblemResponseDto problemResponseDto = problemService.findProblem(problemId, userId);
 
         // then
         assertThat(problemResponseDto.memo()).isEqualTo(problem.getMemo());
@@ -149,6 +150,16 @@ class ProblemServiceTest {
         assertThat(problemResponseDto.imageUrlList().size()).isEqualTo(2);
         assertThat(problemResponseDto.solveCount()).isEqualTo(2L);
         assertThat(problemResponseDto.lastSolvedAt()).isEqualTo(lastSolvedAt);
+    }
+
+    @Test
+    @DisplayName("다른 유저의 문제 조회 시 예외")
+    void findProblem_OtherUserProblem() {
+        Problem otherUserProblem = createOtherUserProblem();
+
+        assertThatThrownBy(() -> problemService.findProblem(otherUserProblem.getId(), userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(ProblemErrorCase.PROBLEM_USER_UNMATCHED.getMessage());
     }
 
     @Test
@@ -186,7 +197,7 @@ class ProblemServiceTest {
         Long folderId = folder.getId();
 
         //when
-        List<ProblemResponseDto> problemResponseDtoList = problemService.findFolderProblemList(folderId);
+        List<ProblemResponseDto> problemResponseDtoList = problemService.findFolderProblemList(folderId, userId);
 
         //then
         assertThat(problemResponseDtoList.size()).isEqualTo(problemRepository.findAllByFolderId(folderId).size());
@@ -202,6 +213,19 @@ class ProblemServiceTest {
         assertThat(problemResponseDtoList.get(0)).isNotNull();
         assertThat(problemResponseDtoList.size()).isEqualTo(3);
         assertThat(problemResponseDtoList.get(0).imageUrlList().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("다른 유저의 폴더 문제 목록 조회 시 예외")
+    void findFolderProblemList_OtherUserFolder() {
+        Folder otherUserFolder = folderRepository.save(Folder.from(
+                new FolderRegisterDto("other folder", null, null),
+                2L
+        ));
+
+        assertThatThrownBy(() -> problemService.findFolderProblemList(otherUserFolder.getId(), userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(FolderErrorCase.FOLDER_USER_UNMATCHED.getMessage());
     }
 
     @Test
@@ -269,6 +293,22 @@ class ProblemServiceTest {
         assertThatThrownBy(() -> problemService.registerProblem(dto, userId))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessageContaining(FolderErrorCase.FOLDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("문제 등록하기 - 다른 유저 폴더 예외")
+    void registerProblem_otherUserFolder() {
+        Folder otherUserFolder = folderRepository.save(Folder.from(
+                new FolderRegisterDto("other folder", null, null),
+                2L
+        ));
+        ProblemRegisterDto dto = new ProblemRegisterDto(
+                null, "memo", "reference", otherUserFolder.getId(), LocalDateTime.now()
+        );
+
+        assertThatThrownBy(() -> problemService.registerProblem(dto, userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(FolderErrorCase.FOLDER_USER_UNMATCHED.getMessage());
     }
 
     @Test
@@ -428,7 +468,7 @@ class ProblemServiceTest {
 
         // When
         doNothing().when(fileUploadService).deleteImageFileFromS3(anyString());
-        problemService.deleteProblem(problemId);
+        problemService.deleteProblem(problemId, userId);
 
         // Then
         verify(fileUploadService, times(2)).deleteImageFileFromS3(anyString());
@@ -462,7 +502,7 @@ class ProblemServiceTest {
 
         // when
         doNothing().when(fileUploadService).deleteImageFileFromS3(anyString());
-        problemService.deleteProblemList(problemIdList);
+        problemService.deleteProblemList(userId, problemIdList);
 
         // then
         verify(fileUploadService, times(2 * problemIdList.size())).deleteImageFileFromS3(anyString());
@@ -477,7 +517,7 @@ class ProblemServiceTest {
 
         // when
         int problemCount = problemRepository.findAllByFolderId(folderIdList.get(0)).size();
-        problemService.deleteAllByFolderIds(folderIdList);
+        problemService.deleteAllByFolderIds(userId, folderIdList);
 
         // then
         verify(fileUploadService, times(2 * problemCount)).deleteImageFileFromS3(anyString());
@@ -495,7 +535,7 @@ class ProblemServiceTest {
             String imageUrl = problem.getProblemImageDataList().get(0).getImageUrl();
 
             // when
-            problemService.deleteProblemImageData(imageUrl);
+            problemService.deleteProblemImageData(imageUrl, userId);
 
             // then
             verify(fileUploadService, times(1)).deleteImageFileFromS3(anyString());
@@ -507,5 +547,35 @@ class ProblemServiceTest {
                 assertThat(problem.getProblemImageDataList().size()).isEqualTo(1);
             }
         }
+    }
+
+    @Test
+    @DisplayName("다른 유저의 문제 이미지 삭제 시 예외")
+    void deleteProblemImageData_OtherUserProblem() {
+        Problem otherUserProblem = createOtherUserProblem();
+        ProblemImageData imageData = ProblemImageData.from(new ProblemImageDataRegisterDto(
+                otherUserProblem.getId(),
+                "other-user-url",
+                ProblemImageType.PROBLEM_IMAGE
+        ));
+        imageData.updateProblem(otherUserProblem);
+        problemImageDataRepository.save(imageData);
+
+        assertThatThrownBy(() -> problemService.deleteProblemImageData("other-user-url", userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(ProblemErrorCase.PROBLEM_USER_UNMATCHED.getMessage());
+    }
+
+    private Problem createOtherUserProblem() {
+        Folder otherUserFolder = folderRepository.save(Folder.from(
+                new FolderRegisterDto("other folder", null, null),
+                2L
+        ));
+        Problem otherUserProblem = Problem.from(
+                new ProblemRegisterDto(null, "memo", "reference", otherUserFolder.getId(), LocalDateTime.now()),
+                2L
+        );
+        otherUserProblem.updateFolder(otherUserFolder);
+        return problemRepository.save(otherUserProblem);
     }
 }

--- a/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
@@ -8,6 +8,7 @@ import com.aisip.OnO.backend.folder.exception.FolderErrorCase;
 import com.aisip.OnO.backend.folder.repository.FolderRepository;
 import com.aisip.OnO.backend.problem.dto.ProblemImageDataRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2Dto;
 import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.entity.ProblemImageData;
@@ -17,6 +18,9 @@ import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
 import com.aisip.OnO.backend.problemsolve.entity.ProblemSolve;
 import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
+import com.aisip.OnO.backend.user.dto.UserRegisterDto;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,6 +59,9 @@ class ProblemServiceTest {
 
     @Autowired
     private ProblemSolveRepository problemSolveRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @MockBean
     private FileUploadService fileUploadService;
@@ -262,6 +269,41 @@ class ProblemServiceTest {
         assertThatThrownBy(() -> problemService.registerProblem(dto, userId))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessageContaining(FolderErrorCase.FOLDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("문제 등록 v2 - folderId가 없으면 루트 폴더에 등록")
+    void registerProblemV2_nullFolderIdUsesRootFolder() {
+        // Given
+        User user = userRepository.save(User.from(new UserRegisterDto(
+                "root-user@example.com",
+                "root-user",
+                "root-user-" + System.nanoTime(),
+                "MEMBER",
+                null
+        )));
+        Long rootUserId = user.getId();
+        Folder rootFolder = folderRepository.save(Folder.from(
+                new FolderRegisterDto("root", null, null),
+                rootUserId
+        ));
+        ProblemRegisterV2Dto dto = new ProblemRegisterV2Dto(
+                null,
+                "memo",
+                "reference",
+                null,
+                LocalDateTime.now(),
+                List.of("https://example.com/problem.png"),
+                List.of("https://example.com/answer.png"),
+                null
+        );
+
+        // When
+        Long problemId = problemService.registerProblemV2(dto, rootUserId);
+
+        // Then
+        Problem problem = problemRepository.findById(problemId).orElseThrow();
+        assertThat(problem.getFolder().getId()).isEqualTo(rootFolder.getId());
     }
 
     @Test


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

> 최근 2개 커밋 기준 PR 작업 내용입니다.

- 문제 등록 v2에서 `folderId`가 `null`로 전달될 때 사용자의 루트 폴더에 문제를 등록하도록 처리했습니다.
- 폴더, 문제, 복습 노트, 이미지 삭제 등 사용자 리소스 접근 경로에 소유자 검증을 추가했습니다.
- 관리자용 폴더 조회와 일반 사용자 폴더 조회를 분리해 사용자 API에서는 본인 소유 폴더만 접근하도록 변경했습니다.
- 문제 조회, 폴더별 문제 조회, 문제 삭제, 문제 이미지 삭제, 복습 노트 상세 조회/수정/삭제, 폴더 생성/수정/삭제 시 다른 사용자의 리소스 접근을 차단하도록 서비스와 컨트롤러 호출 흐름을 정리했습니다.
- 파일 업로드 이미지 삭제 시 문제 이미지와 풀이 이미지 각각의 소유자를 확인한 뒤 S3 파일 및 이미지 데이터를 삭제하도록 변경했습니다.
- 다른 사용자의 폴더, 문제, 복습 노트, 이미지에 접근하는 경우 예외가 발생하는지 검증하는 테스트를 추가했습니다.
- `folderId` 없이 문제 등록 v2를 호출하면 루트 폴더에 등록되는지 검증하는 테스트를 추가했습니다.

### 스크린샷 (선택)

- 없음
