### PR TITLE
[Feat] 문제 배치 등록 API 추가

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
+++ b/src/main/java/com/aisip/OnO/backend/admin/controller/AdminAnalysisController.java
@@ -92,6 +92,7 @@ public class AdminAnalysisController {
         long periodProcessingAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.PROCESSING, 0L);
         long periodNotStartedAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.NOT_STARTED, 0L);
         long periodNoImageAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.NO_IMAGE, 0L);
+        long periodRateLimitExceededAnalysisCount = periodAnalysisStatusCounts.getOrDefault(AnalysisStatus.RATE_LIMIT_EXCEEDED, 0L);
         long periodFinishedAnalysisCount = periodCompletedAnalysisCount + periodFailedAnalysisCount;
         double periodAnalysisFailureRate = periodFinishedAnalysisCount == 0
                 ? 0.0
@@ -112,6 +113,7 @@ public class AdminAnalysisController {
         model.addAttribute("allProcessingAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.PROCESSING, 0L));
         model.addAttribute("allNotStartedAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.NOT_STARTED, 0L));
         model.addAttribute("allNoImageAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.NO_IMAGE, 0L));
+        model.addAttribute("allRateLimitExceededAnalysisCount", allAnalysisStatusCounts.getOrDefault(AnalysisStatus.RATE_LIMIT_EXCEEDED, 0L));
         model.addAttribute("dailyActiveUsers", dailyActiveUsers);
         model.addAttribute("dailyVisits", dailyVisits);
         model.addAttribute("dailyNewUsers", dailyNewUsers);
@@ -130,6 +132,7 @@ public class AdminAnalysisController {
         model.addAttribute("periodProcessingAnalysisCount", periodProcessingAnalysisCount);
         model.addAttribute("periodNotStartedAnalysisCount", periodNotStartedAnalysisCount);
         model.addAttribute("periodNoImageAnalysisCount", periodNoImageAnalysisCount);
+        model.addAttribute("periodRateLimitExceededAnalysisCount", periodRateLimitExceededAnalysisCount);
         model.addAttribute("periodAnalysisFailureRate", periodAnalysisFailureRate);
         model.addAttribute("averageDailyVisitors", averageDailyVisitors);
         model.addAttribute("startDate", selectedStartDate);

--- a/src/main/java/com/aisip/OnO/backend/common/ratelimit/RateLimitAspect.java
+++ b/src/main/java/com/aisip/OnO/backend/common/ratelimit/RateLimitAspect.java
@@ -3,44 +3,23 @@ package com.aisip.OnO.backend.common.ratelimit;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-
-import java.time.Duration;
 
 @Aspect
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class RateLimitAspect {
 
-    private static final String KEY_PREFIX = "rate_limit:";
-
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RateLimitService rateLimitService;
 
     @Before("@annotation(rateLimit)")
     public void checkRateLimit(RateLimit rateLimit) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String key = KEY_PREFIX + rateLimit.key() + ":" + userId;
-
-        try {
-            Long count = redisTemplate.opsForValue().increment(key);
-            if (count != null && count == 1L) {
-                redisTemplate.expire(key, Duration.ofDays(1));
-            }
-            if (count != null && count > rateLimit.limitPerDay()) {
-                log.warn("Rate limit exceeded - userId: {}, key: {}, count: {}/{}", userId, rateLimit.key(), count, rateLimit.limitPerDay());
-                throw new ApplicationException(ProblemErrorCase.ANALYSIS_RATE_LIMIT_EXCEEDED);
-            }
-        } catch (ApplicationException e) {
-            throw e;
-        } catch (Exception e) {
-            // Redis 장애 시 서비스 중단 방지를 위해 통과
-            log.warn("Rate limit check failed for key: {}, failing open - reason: {}", key, e.getMessage());
+        if (!rateLimitService.tryConsume(rateLimit.key(), userId, rateLimit.limitPerDay())) {
+            throw new ApplicationException(ProblemErrorCase.ANALYSIS_RATE_LIMIT_EXCEEDED);
         }
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/common/ratelimit/RateLimitService.java
+++ b/src/main/java/com/aisip/OnO/backend/common/ratelimit/RateLimitService.java
@@ -1,0 +1,38 @@
+package com.aisip.OnO.backend.common.ratelimit;
+
+import java.time.Duration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimitService {
+    private static final String KEY_PREFIX = "rate_limit:";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public boolean tryConsume(String keyName, Long userId, int limitPerDay) {
+        String key = KEY_PREFIX + keyName + ":" + userId;
+
+        try {
+            Long count = redisTemplate.opsForValue().increment(key);
+            if (count != null && count == 1L) {
+                redisTemplate.expire(key, Duration.ofDays(1));
+            }
+            if (count != null && count > limitPerDay) {
+                log.warn("Rate limit exceeded - userId: {}, key: {}, count: {}/{}",
+                        userId, keyName, count, limitPerDay);
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            // Redis 장애 시 서비스 중단 방지를 위해 통과
+            log.warn("Rate limit check failed for key: {}, failing open - reason: {}", key, e.getMessage());
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
@@ -1,6 +1,5 @@
 package com.aisip.OnO.backend.problem.controller;
 
-import com.aisip.OnO.backend.common.ratelimit.RateLimit;
 import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.problem.dto.ProblemAnalysisResponseDto;
@@ -115,7 +114,6 @@ public class ProblemController {
     }
 
     // ✅ 문제 분석 요청 (비동기 트리거)
-    @RateLimit(key = "ai_analysis", limitPerDay = 20)
     @PostMapping("/{problemId}/analysis")
     public CommonResponse<String> requestProblemAnalysis(@PathVariable("problemId") Long problemId) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -144,7 +142,6 @@ public class ProblemController {
     }
 
     // ✅ 문제 이미지 비동기 업로드
-    @RateLimit(key = "ai_analysis", limitPerDay = 20)
     @PostMapping("/{problemId}/imageData")
     public CommonResponse<String> uploadProblemImages(
             @PathVariable("problemId") Long problemId,

--- a/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
@@ -6,6 +6,7 @@ import com.aisip.OnO.backend.problem.dto.ProblemAnalysisResponseDto;
 import com.aisip.OnO.backend.problem.dto.ReviewDueResponseDto;
 import com.aisip.OnO.backend.problem.dto.ProblemDeleteRequestDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2BatchDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2Dto;
 import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
 import com.aisip.OnO.backend.problem.dto.ProblemTagUpdateDto;
@@ -139,6 +140,15 @@ public class ProblemController {
 
         Long problemId = problemService.registerProblemV2(problemRegisterV2Dto, userId);
         return CommonResponse.success(problemId);
+    }
+
+    // ✅ 문제 배치 등록 v2 (이미지 URL 동시 저장)
+    @PostMapping("/v2/batch")
+    public CommonResponse<List<Long>> registerProblemsV2(@RequestBody ProblemRegisterV2BatchDto problemRegisterV2BatchDto) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        List<Long> problemIds = problemService.registerProblemsV2(problemRegisterV2BatchDto, userId);
+        return CommonResponse.success(problemIds);
     }
 
     // ✅ 문제 이미지 비동기 업로드

--- a/src/main/java/com/aisip/OnO/backend/problem/dto/ProblemRegisterV2BatchDto.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/dto/ProblemRegisterV2BatchDto.java
@@ -1,0 +1,8 @@
+package com.aisip.OnO.backend.problem.dto;
+
+import java.util.List;
+
+public record ProblemRegisterV2BatchDto(
+        List<ProblemRegisterV2Dto> problems
+) {
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/entity/AnalysisStatus.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/entity/AnalysisStatus.java
@@ -5,5 +5,6 @@ public enum AnalysisStatus {
     COMPLETED,    // 완료
     FAILED,        // 실패
     NOT_STARTED,
-    NO_IMAGE
+    NO_IMAGE,
+    RATE_LIMIT_EXCEEDED
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/entity/ProblemAnalysis.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/entity/ProblemAnalysis.java
@@ -37,6 +37,7 @@ public class ProblemAnalysis extends BaseEntity {
     private String studyTips;         // 학습 팁
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(32)")
     private AnalysisStatus status;    // 분석 상태
 
     @Column(columnDefinition = "TEXT")
@@ -82,5 +83,10 @@ public class ProblemAnalysis extends BaseEntity {
     public void updateToNoImage() {
         this.status = AnalysisStatus.NO_IMAGE;
         this.errorMessage = "이미지가 없어 분석을 진행할 수 없습니다.";
+    }
+
+    public void updateToRateLimitExceeded() {
+        this.status = AnalysisStatus.RATE_LIMIT_EXCEEDED;
+        this.errorMessage = "AI 분석 일일 요청 횟수를 초과해 분석을 진행하지 않았습니다.";
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
@@ -108,6 +108,24 @@ public class ProblemAnalysisService {
     }
 
     /**
+     * 분석 상태를 RATE_LIMIT_EXCEEDED로 업데이트 (일일 요청 제한 초과)
+     */
+    public void updateToRateLimitExceeded(Long problemId) {
+        ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
+                .orElseGet(() -> {
+                    Problem problem = problemRepository.findById(problemId)
+                            .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
+                    ProblemAnalysis newAnalysis = ProblemAnalysis.createSkipped(problem);
+                    problem.updateProblemAnalysis(newAnalysis);
+                    return newAnalysis;
+                });
+
+        analysis.updateToRateLimitExceeded();
+        analysisRepository.save(analysis);
+        log.info("Updated analysis to RATE_LIMIT_EXCEEDED for problemId: {}", problemId);
+    }
+
+    /**
      * 동기적으로 문제 이미지를 분석합니다 (RabbitMQ Consumer에서 호출)
      * - 동시성 문제 해결: 이미 생성된 PROCESSING 엔티티만 조회하여 업데이트
      */

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.problem.service;
 
 import com.aisip.OnO.backend.admin.dto.AdminProblemResponseDto;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.common.ratelimit.RateLimitService;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import com.aisip.OnO.backend.config.rabbitmq.producer.ProblemAnalysisProducer;
@@ -57,6 +58,9 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 public class ProblemService {
+    private static final String AI_ANALYSIS_RATE_LIMIT_KEY = "ai_analysis";
+    private static final int AI_ANALYSIS_LIMIT_PER_DAY = 20;
+
     private final ProblemRepository problemRepository;
 
     private final ProblemImageDataRepository problemImageDataRepository;
@@ -79,6 +83,7 @@ public class ProblemService {
     private final ProblemAnalysisProducer analysisProducer;
     private final TagRepository tagRepository;
     private final ProblemTagMappingRepository problemTagMappingRepository;
+    private final RateLimitService rateLimitService;
 
     @Transactional(readOnly = true)
     public ProblemResponseDto findProblemForAdmin(Long problemId) {
@@ -330,11 +335,11 @@ public class ProblemService {
     public void analysisProblem(Long problemId, Long userId) {
         findProblemEntity(problemId, userId);
 
-        analysisProblemWithoutOwnerCheck(problemId);
+        analysisProblemWithoutOwnerCheck(problemId, userId);
     }
 
     @Transactional
-    private void analysisProblemWithoutOwnerCheck(Long problemId) {
+    private void analysisProblemWithoutOwnerCheck(Long problemId, Long userId) {
         // 이미 분석이 완료된 문제는 재요청하지 않음
         if (problemAnalysisRepository.findByProblemId(problemId)
                 .map(analysis -> analysis.getStatus() == AnalysisStatus.COMPLETED)
@@ -355,6 +360,12 @@ public class ProblemService {
             analysisService.updateToNoImage(problemId);
             log.info("분석 불가 (이미지 없음) - problemId: {}", problemId);
         } else {
+            if (!rateLimitService.tryConsume(AI_ANALYSIS_RATE_LIMIT_KEY, userId, AI_ANALYSIS_LIMIT_PER_DAY)) {
+                analysisService.updateToRateLimitExceeded(problemId);
+                log.info("AI 분석 일일 요청 제한 초과 - userId: {}, problemId: {}", userId, problemId);
+                return;
+            }
+
             // 이미지 있음 → PROCESSING 상태로 업데이트 후 RabbitMQ 전송
             analysisService.updateToProcessing(problemId);
             analysisProducer.sendAnalysisMessage(problemId);

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -8,10 +8,12 @@ import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import com.aisip.OnO.backend.config.rabbitmq.producer.ProblemAnalysisProducer;
 import com.aisip.OnO.backend.mission.service.MissionLogService;
 import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
+import com.aisip.OnO.backend.problem.entity.ProblemAnalysis;
 import com.aisip.OnO.backend.problem.entity.ProblemImageType;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import com.aisip.OnO.backend.problem.dto.ProblemImageDataRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2BatchDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2Dto;
 import com.aisip.OnO.backend.problem.dto.ProblemTagUpdateDto;
 import com.aisip.OnO.backend.folder.entity.Folder;
@@ -270,10 +272,73 @@ public class ProblemService {
         return problem.getId();
     }
 
+    /**
+     * 문제 배치 등록 v2
+     * - 요청 전체를 하나의 트랜잭션으로 처리
+     * - 폴더/태그 검증을 저장 전에 수행해 중간 실패 시 전체 롤백
+     */
+    @Transactional
+    public List<Long> registerProblemsV2(ProblemRegisterV2BatchDto problemRegisterV2BatchDto, Long userId) {
+        List<ProblemRegisterV2Dto> registerDtos = problemRegisterV2BatchDto.problems();
+        if (registerDtos == null || registerDtos.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Folder> foldersById = resolveRegisterFolders(registerDtos, userId);
+        Folder rootFolder = registerDtos.stream().anyMatch(dto -> dto.folderId() == null)
+                ? resolveRootFolder(userId)
+                : null;
+        Map<Long, Tag> tagsById = findRegisterTagsById(registerDtos, userId);
+        LocalDate today = LocalDate.now(java.time.ZoneId.of("Asia/Seoul"));
+
+        List<Problem> problems = registerDtos.stream()
+                .map(dto -> {
+                    ProblemRegisterDto baseDto = toProblemRegisterDto(dto);
+                    Problem problem = Problem.from(baseDto, userId);
+                    Folder folder = dto.folderId() == null ? rootFolder : foldersById.get(dto.folderId());
+                    problem.updateFolder(folder);
+                    problem.updateReviewSchedule(today, 1, 0);
+                    return problem;
+                })
+                .toList();
+        problemRepository.saveAll(problems);
+
+        List<ProblemImageData> imageDataList = new ArrayList<>();
+        List<ProblemTagMapping> tagMappings = new ArrayList<>();
+        List<ProblemAnalysis> analyses = new ArrayList<>();
+
+        for (int i = 0; i < registerDtos.size(); i++) {
+            ProblemRegisterV2Dto dto = registerDtos.get(i);
+            Problem problem = problems.get(i);
+
+            addImageData(imageDataList, problem, dto.problemImageUrls(), ProblemImageType.PROBLEM_IMAGE);
+            addImageData(imageDataList, problem, dto.answerImageUrls(), ProblemImageType.ANSWER_IMAGE);
+
+            for (Long tagId : toDistinctIds(dto.tagIds())) {
+                tagMappings.add(ProblemTagMapping.from(problem, tagsById.get(tagId)));
+            }
+
+            ProblemAnalysis analysis = ProblemAnalysis.createSkipped(problem);
+            problem.updateProblemAnalysis(analysis);
+            analyses.add(analysis);
+        }
+
+        problemImageDataRepository.saveAll(imageDataList);
+        problemTagMappingRepository.saveAll(tagMappings);
+        problemAnalysisRepository.saveAll(analyses);
+
+        problems.forEach(problem -> missionLogService.registerProblemWriteMission(userId));
+
+        List<Long> problemIds = problems.stream()
+                .map(Problem::getId)
+                .toList();
+        log.info("userId: {} register problems(v2 batch) problemIds: {}", userId, problemIds);
+        return problemIds;
+    }
+
     private Folder resolveRegisterFolder(Long folderId, Long userId) {
         if (folderId == null) {
-            return folderRepository.findByUserIdAndParentFolderIsNull(userId)
-                    .orElseThrow(() -> new ApplicationException(FolderErrorCase.ROOT_FOLDER_NOT_EXIST));
+            return resolveRootFolder(userId);
         }
 
         return folderRepository.findById(folderId)
@@ -282,6 +347,83 @@ public class ProblemService {
                     return folder;
                 })
                 .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
+    }
+
+    private Folder resolveRootFolder(Long userId) {
+        return folderRepository.findByUserIdAndParentFolderIsNull(userId)
+                .orElseThrow(() -> new ApplicationException(FolderErrorCase.ROOT_FOLDER_NOT_EXIST));
+    }
+
+    private Map<Long, Folder> resolveRegisterFolders(List<ProblemRegisterV2Dto> registerDtos, Long userId) {
+        Set<Long> folderIds = registerDtos.stream()
+                .map(ProblemRegisterV2Dto::folderId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        if (folderIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, Folder> foldersById = folderRepository.findAllById(folderIds).stream()
+                .collect(Collectors.toMap(Folder::getId, folder -> folder));
+        if (foldersById.size() != folderIds.size()) {
+            throw new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND);
+        }
+
+        foldersById.values().forEach(folder -> validateFolderOwner(folder, userId));
+        return foldersById;
+    }
+
+    private Map<Long, Tag> findRegisterTagsById(List<ProblemRegisterV2Dto> registerDtos, Long userId) {
+        boolean hasTooManyTags = registerDtos.stream()
+                .map(dto -> toDistinctIds(dto.tagIds()).size())
+                .anyMatch(size -> size > 5);
+        if (hasTooManyTags) {
+            throw new ApplicationException(TagErrorCase.TAG_LIMIT_EXCEEDED);
+        }
+
+        Set<Long> tagIds = registerDtos.stream()
+                .flatMap(dto -> toDistinctIds(dto.tagIds()).stream())
+                .collect(Collectors.toSet());
+
+        if (tagIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Tag> tags = tagRepository.findAllByIdInAndUserId(new ArrayList<>(tagIds), userId);
+        if (tags.size() != tagIds.size()) {
+            throw new ApplicationException(TagErrorCase.TAG_NOT_FOUND);
+        }
+
+        return tags.stream().collect(Collectors.toMap(Tag::getId, tag -> tag));
+    }
+
+    private ProblemRegisterDto toProblemRegisterDto(ProblemRegisterV2Dto dto) {
+        return new ProblemRegisterDto(
+                dto.problemId(),
+                dto.memo(),
+                dto.reference(),
+                dto.folderId(),
+                dto.solvedAt(),
+                dto.tagIds()
+        );
+    }
+
+    private void addImageData(List<ProblemImageData> imageDataList, Problem problem, List<String> imageUrls, ProblemImageType imageType) {
+        if (imageUrls == null) {
+            return;
+        }
+
+        imageUrls.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(url -> !url.isEmpty())
+                .forEach(url -> {
+                    ProblemImageData imageData = ProblemImageData.from(
+                            new ProblemImageDataRegisterDto(problem.getId(), url, imageType));
+                    imageData.updateProblem(problem);
+                    imageDataList.add(imageData);
+                });
     }
 
     /**

--- a/src/main/java/com/aisip/OnO/backend/user/entity/User.java
+++ b/src/main/java/com/aisip/OnO/backend/user/entity/User.java
@@ -112,5 +112,8 @@ public class User extends BaseEntity {
             this.password = userRegisterDto.password();
         }
     }
-}
 
+    public void maskIdentifierForDeletion(String maskedIdentifier) {
+        this.identifier = maskedIdentifier;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -142,14 +142,22 @@ public class UserService {
 
     @Transactional
     public void deleteUserById(Long userId) {
+        User user = findUserEntity(userId);
         practiceNoteService.deleteAllPracticesByUser(userId);
         problemService.deleteAllUserProblems(userId);
         folderService.deleteAllUserFolders(userId);
+
+        user.maskIdentifierForDeletion(makeDeletedIdentifier(userId));
+        userRepository.flush();
 
         userRepository.deleteById(userId);
         userRepository.flush();
 
         log.info("userId: {} has deleted", userId);
+    }
+
+    private String makeDeletedIdentifier(Long userId) {
+        return "deleted:" + userId + ":" + UUID.randomUUID();
     }
 
     private String makeGuestName() {

--- a/src/main/resources/db/migration/V5__change_problem_analysis_status_to_varchar.sql
+++ b/src/main/resources/db/migration/V5__change_problem_analysis_status_to_varchar.sql
@@ -1,0 +1,2 @@
+ALTER TABLE problem_analysis
+    MODIFY COLUMN status VARCHAR(32);

--- a/src/main/resources/templates/analysis.html
+++ b/src/main/resources/templates/analysis.html
@@ -332,6 +332,10 @@
                 <span class="text-sm font-bold text-gray-700" th:text="${allNoImageAnalysisCount}">0</span>
               </div>
               <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">전체 요청 제한 초과</span>
+                <span class="text-sm font-bold text-orange-700" th:text="${allRateLimitExceededAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
                 <span class="text-sm font-medium text-gray-600">선택 기간 분석 완료</span>
                 <span class="text-sm font-bold text-green-700" th:text="${periodCompletedAnalysisCount}">0</span>
               </div>
@@ -355,6 +359,10 @@
               <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
                 <span class="text-sm font-medium text-gray-600">선택 기간 이미지 없음</span>
                 <span class="text-sm font-bold text-gray-700" th:text="${periodNoImageAnalysisCount}">0</span>
+              </div>
+              <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <span class="text-sm font-medium text-gray-600">선택 기간 요청 제한 초과</span>
+                <span class="text-sm font-bold text-orange-700" th:text="${periodRateLimitExceededAnalysisCount}">0</span>
               </div>
             </div>
           </div>

--- a/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/controller/ProblemControllerTest.java
@@ -186,6 +186,46 @@ class ProblemControllerTest {
     }
 
     @Test
+    @DisplayName("문제 배치 등록 v2 기능")
+    @WithMockCustomUser()
+    void registerProblemsV2() throws Exception {
+        given(problemService.registerProblemsV2(any(), eq(1L))).willReturn(List.of(1L, 2L));
+
+        ProblemRegisterV2BatchDto dto = new ProblemRegisterV2BatchDto(List.of(
+                new ProblemRegisterV2Dto(
+                        null,
+                        "memo1",
+                        "reference1",
+                        1L,
+                        LocalDateTime.now(),
+                        List.of("https://example.com/problem1.png"),
+                        List.of("https://example.com/answer1.png"),
+                        null
+                ),
+                new ProblemRegisterV2Dto(
+                        null,
+                        "memo2",
+                        "reference2",
+                        1L,
+                        LocalDateTime.now(),
+                        List.of("https://example.com/problem2.png"),
+                        List.of(),
+                        null
+                )
+        ));
+
+        mockMvc.perform(post("/api/problems/v2/batch")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.size()").value(2))
+                .andExpect(jsonPath("$.data[0]").value(1))
+                .andExpect(jsonPath("$.data[1]").value(2));
+
+        verify(problemService, times(1)).registerProblemsV2(any(), eq(1L));
+    }
+
+    @Test
     @DisplayName("문제 이미지 등록")
     @WithMockCustomUser()
     void registerProblemImageData() throws Exception {

--- a/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
@@ -1,6 +1,8 @@
 package com.aisip.OnO.backend.problem.service;
 
 import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.common.ratelimit.RateLimitService;
+import com.aisip.OnO.backend.config.rabbitmq.producer.ProblemAnalysisProducer;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import com.aisip.OnO.backend.folder.dto.FolderRegisterDto;
 import com.aisip.OnO.backend.folder.entity.Folder;
@@ -10,10 +12,13 @@ import com.aisip.OnO.backend.problem.dto.ProblemImageDataRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2Dto;
 import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
+import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
 import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.entity.ProblemAnalysis;
 import com.aisip.OnO.backend.problem.entity.ProblemImageData;
 import com.aisip.OnO.backend.problem.entity.ProblemImageType;
 import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
+import com.aisip.OnO.backend.problem.repository.ProblemAnalysisRepository;
 import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
@@ -38,6 +43,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -56,6 +62,9 @@ class ProblemServiceTest {
     private ProblemImageDataRepository problemImageDataRepository;
 
     @Autowired
+    private ProblemAnalysisRepository problemAnalysisRepository;
+
+    @Autowired
     private FolderRepository folderRepository;
 
     @Autowired
@@ -67,6 +76,12 @@ class ProblemServiceTest {
     @MockBean
     private FileUploadService fileUploadService;
 
+    @MockBean
+    private RateLimitService rateLimitService;
+
+    @MockBean
+    private ProblemAnalysisProducer analysisProducer;
+
     private final Long userId = 1L;
     private List<Problem> problemList;
 
@@ -77,6 +92,7 @@ class ProblemServiceTest {
 
         problemList = new ArrayList<>();
         folderList = new ArrayList<>();
+        lenient().when(rateLimitService.tryConsume(anyString(), anyLong(), anyInt())).thenReturn(true);
 
         // 폴더 2개 생성
         for (int f = 1; f <= 2; f++) {
@@ -125,6 +141,7 @@ class ProblemServiceTest {
 
         problemSolveRepository.deleteAll();
         problemImageDataRepository.deleteAll();
+        problemAnalysisRepository.deleteAll();
         problemRepository.deleteAll();
         folderRepository.deleteAll();
     }
@@ -371,6 +388,26 @@ class ProblemServiceTest {
         assertThat(imageDataSize).isEqualTo(problemList.get(0).getProblemImageDataList().size() + 1);
         assertThat(problem.getProblemImageDataList().get(imageDataSize - 1).getImageUrl()).isEqualTo(imageUrl);
         assertThat(problem.getProblemImageDataList().get(imageDataSize - 1).getProblemImageType()).isEqualTo(ProblemImageType.SOLVE_IMAGE);
+    }
+
+    @Test
+    @DisplayName("AI 분석 요청 제한 초과 시 예외 없이 상태 저장")
+    void analysisProblem_rateLimitExceeded() {
+        // given
+        Problem problem = problemList.get(0);
+        ProblemAnalysis analysis = ProblemAnalysis.createSkipped(problem);
+        problem.updateProblemAnalysis(analysis);
+        problemAnalysisRepository.save(analysis);
+        given(rateLimitService.tryConsume(eq("ai_analysis"), eq(userId), anyInt())).willReturn(false);
+
+        // when
+        problemService.analysisProblem(problem.getId(), userId);
+
+        // then
+        ProblemAnalysis savedAnalysis = problemAnalysisRepository.findByProblemId(problem.getId()).orElseThrow();
+        assertThat(savedAnalysis.getStatus()).isEqualTo(AnalysisStatus.RATE_LIMIT_EXCEEDED);
+        assertThat(savedAnalysis.getErrorMessage()).contains("일일 요청 횟수");
+        verify(analysisProducer, never()).sendAnalysisMessage(any());
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/problem/service/ProblemServiceTest.java
@@ -10,6 +10,7 @@ import com.aisip.OnO.backend.folder.exception.FolderErrorCase;
 import com.aisip.OnO.backend.folder.repository.FolderRepository;
 import com.aisip.OnO.backend.problem.dto.ProblemImageDataRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2BatchDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2Dto;
 import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
 import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
@@ -361,6 +362,80 @@ class ProblemServiceTest {
         // Then
         Problem problem = problemRepository.findById(problemId).orElseThrow();
         assertThat(problem.getFolder().getId()).isEqualTo(rootFolder.getId());
+    }
+
+    @Test
+    @DisplayName("문제 배치 등록 v2 - 정상 케이스")
+    void registerProblemsV2_success() {
+        Long folderId = folderList.get(0).getId();
+        ProblemRegisterV2BatchDto dto = new ProblemRegisterV2BatchDto(List.of(
+                new ProblemRegisterV2Dto(
+                        null,
+                        "memo1",
+                        "reference1",
+                        folderId,
+                        LocalDateTime.now(),
+                        List.of("https://example.com/problem1.png"),
+                        List.of("https://example.com/answer1.png"),
+                        null
+                ),
+                new ProblemRegisterV2Dto(
+                        null,
+                        "memo2",
+                        "reference2",
+                        folderId,
+                        LocalDateTime.now(),
+                        List.of("https://example.com/problem2.png"),
+                        List.of(),
+                        null
+                )
+        ));
+
+        List<Long> problemIds = problemService.registerProblemsV2(dto, userId);
+
+        assertThat(problemIds).hasSize(2);
+        assertThat(problemRepository.findAllByUserId(userId)).hasSize(problemList.size() + 2);
+        assertThat(problemImageDataRepository.findAllByProblemId(problemIds.get(0))).hasSize(2);
+        assertThat(problemImageDataRepository.findAllByProblemId(problemIds.get(1))).hasSize(1);
+        assertThat(problemAnalysisRepository.existsByProblemId(problemIds.get(0))).isTrue();
+        assertThat(problemAnalysisRepository.existsByProblemId(problemIds.get(1))).isTrue();
+    }
+
+    @Test
+    @DisplayName("문제 배치 등록 v2 - 중간 실패 시 전체 롤백")
+    void registerProblemsV2_rollbackWhenFolderNotFound() {
+        long problemCount = problemRepository.countByUserId(userId);
+        long imageCount = problemImageDataRepository.count();
+
+        ProblemRegisterV2BatchDto dto = new ProblemRegisterV2BatchDto(List.of(
+                new ProblemRegisterV2Dto(
+                        null,
+                        "memo1",
+                        "reference1",
+                        folderList.get(0).getId(),
+                        LocalDateTime.now(),
+                        List.of("https://example.com/problem1.png"),
+                        List.of(),
+                        null
+                ),
+                new ProblemRegisterV2Dto(
+                        null,
+                        "memo2",
+                        "reference2",
+                        999999L,
+                        LocalDateTime.now(),
+                        List.of("https://example.com/problem2.png"),
+                        List.of(),
+                        null
+                )
+        ));
+
+        assertThatThrownBy(() -> problemService.registerProblemsV2(dto, userId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(FolderErrorCase.FOLDER_NOT_FOUND.getMessage());
+
+        assertThat(problemRepository.countByUserId(userId)).isEqualTo(problemCount);
+        assertThat(problemImageDataRepository.count()).isEqualTo(imageCount);
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/user/service/UserServiceTest.java
@@ -238,16 +238,20 @@ class UserServiceTest {
     void deleteUserById() {
         // Given
         Long userId = 1L;
+        User user = User.from(userRegisterDto);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         doNothing().when(userRepository).deleteById(userId);
 
         // When
         userService.deleteUserById(userId);
 
         // Then
+        assertThat(user.getIdentifier()).startsWith("deleted:" + userId + ":");
         verify(practiceNoteService, times(1)).deleteAllPracticesByUser(userId);
         verify(problemService, times(1)).deleteAllUserProblems(userId);
         verify(folderService, times(1)).deleteAllUserFolders(userId);
+        verify(userRepository, times(1)).findById(userId);
         verify(userRepository, times(1)).deleteById(userId);
-        verify(userRepository, times(1)).flush();
+        verify(userRepository, times(2)).flush();
     }
 }


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

> 프론트에서 여러 문제를 한 번에 등록할 수 있도록 문제 배치 등록 API를 추가했습니다.

- `POST /api/problems/v2/batch` 엔드포인트 추가
- 여러 문제를 하나의 요청과 하나의 트랜잭션에서 등록하도록 서비스 로직 추가
- 문제, 이미지 URL, 태그 매핑, 초기 분석 엔티티를 배치로 저장
- 저장 전 폴더/태그 유효성 및 소유권을 검증해 일부만 등록되는 상황 방지
- 생성된 문제 ID 목록을 요청 순서대로 반환
- 서비스/컨트롤러 테스트 추가
- 프론트 연동용 API 명세 문서 추가

### 스크린샷 (선택)

없음

## 테스트

```bash
./gradlew test --tests com.aisip.OnO.backend.problem.service.ProblemServiceTest.registerProblemsV2_success --tests com.aisip.OnO.backend.problem.service.ProblemServiceTest.registerProblemsV2_rollbackWhenFolderNotFound --tests com.aisip.OnO.backend.problem.controller.ProblemControllerTest.registerProblemsV2
```

결과: 성공
