### PR TITLE
[Feat] 문제 등록 및 복습 이미지 처리 성능 개선

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/common/config/AsyncConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/common/config/AsyncConfig.java
@@ -1,10 +1,18 @@
 package com.aisip.OnO.backend.common.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 @Configuration
 @EnableAsync
 public class AsyncConfig {
-    // Spring의 @Async 기능을 활성화
+
+    @Bean("s3UploadExecutor")
+    public Executor s3UploadExecutor() {
+        return Executors.newFixedThreadPool(10);
+    }
 }

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryCustom.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryCustom.java
@@ -9,6 +9,8 @@ import java.util.Map;
 public interface MissionLogRepositoryCustom {
     boolean alreadyWriteProblemsTodayMoreThan3(Long userId);
 
+    long countProblemWritesToday(Long userId);
+
     boolean alreadyPracticeProblem(Long problemId);
 
     boolean alreadyPracticeNote(Long practiceNoteId);

--- a/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/repository/MissionLogRepositoryImpl.java
@@ -29,6 +29,11 @@ public class MissionLogRepositoryImpl implements MissionLogRepositoryCustom {
 
     @Override
     public boolean alreadyWriteProblemsTodayMoreThan3(Long userId) {
+        return countProblemWritesToday(userId) >= 3;
+    }
+
+    @Override
+    public long countProblemWritesToday(Long userId) {
         Long count = queryFactory
                 .select(missionLog.count())
                 .from(missionLog)
@@ -38,7 +43,7 @@ public class MissionLogRepositoryImpl implements MissionLogRepositoryCustom {
                 )
                 .fetchOne();
 
-        return count != null && count >= 3;
+        return count != null ? count : 0L;
     }
 
     @Override

--- a/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
+++ b/src/main/java/com/aisip/OnO/backend/mission/service/MissionLogService.java
@@ -103,6 +103,26 @@ public class MissionLogService {
         }
     }
 
+    public void registerProblemWriteMissionBatch(Long userId, int count) {
+        long todayCount = missionLogRepository.countProblemWritesToday(userId);
+        int toCreate = (int) Math.min(count, Math.max(0, 3 - todayCount));
+        if (toCreate == 0) return;
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(MissionErrorCase.USER_NOT_FOUND));
+
+        MissionRegisterDto dto = MissionRegisterDto.builder()
+                .userId(userId)
+                .missionType(MissionType.PROBLEM_WRITE)
+                .build();
+
+        for (int i = 0; i < toCreate; i++) {
+            MissionLog log = MissionLog.from(dto, user);
+            missionLogRepository.save(log);
+            addPointToUser(user, log);
+        }
+    }
+
     public void registerProblemPracticeMission(Long userId, Long problemId) {
         boolean alreadyPracticeProblem = missionLogRepository.alreadyPracticeProblem(problemId);
 

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -332,7 +332,7 @@ public class ProblemService {
         problemAnalysisRepository.saveAll(analyses);
 
         streakCacheService.evict(userId);
-        problems.forEach(problem -> missionLogService.registerProblemWriteMission(userId));
+        missionLogService.registerProblemWriteMissionBatch(userId, problems.size());
 
         List<Long> problemIds = problems.stream()
                 .map(Problem::getId)

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
@@ -24,9 +24,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 @Slf4j
 @Service
@@ -41,6 +46,8 @@ public class ProblemSolveService {
     private final S3DeleteProducer s3DeleteProducer;
     private final ObjectMapper objectMapper;
     private final StreakCacheService streakCacheService;
+    @Qualifier("s3UploadExecutor")
+    private final Executor s3UploadExecutor;
 
     @Transactional(readOnly = true)
     public ProblemSolveResponseDto getProblemSolve(Long problemSolveId, Long userId) {
@@ -144,16 +151,27 @@ public class ProblemSolveService {
             throw new ApplicationException(ProblemSolveErrorCase.PROBLEM_SOLVE_USER_UNMATCHED);
         }
 
-        for (int i = 0; i < images.size(); i++) {
-            MultipartFile imageFile = images.get(i);
-            String imageUrl = fileUploadService.uploadFileToS3(imageFile);
+        // S3 업로드를 병렬로 실행 (트랜잭션과 무관한 네트워크 I/O)
+        List<CompletableFuture<String>> uploadFutures = IntStream.range(0, images.size())
+                .mapToObj(i -> CompletableFuture.supplyAsync(
+                        () -> fileUploadService.uploadFileToS3(images.get(i)),
+                        s3UploadExecutor
+                ))
+                .toList();
 
-            ProblemSolveImageData problemSolveImageData = ProblemSolveImageData.create(imageUrl, i);
-            problemSolve.addImage(problemSolveImageData);
-            problemSolveImageDataRepository.save(problemSolveImageData);
+        List<String> imageUrls = uploadFutures.stream()
+                .map(CompletableFuture::join)
+                .collect(Collectors.toList());
 
-            log.info("Uploaded problem solve image to S3 for problemSolveId: {}, imageOrder: {}", problemSolveId, i);
-        }
+        // DB 저장은 메인 스레드에서 배치로 처리 (트랜잭션 컨텍스트 유지)
+        List<ProblemSolveImageData> imageDataList = IntStream.range(0, imageUrls.size())
+                .mapToObj(i -> ProblemSolveImageData.create(imageUrls.get(i), i))
+                .collect(Collectors.toList());
+
+        imageDataList.forEach(problemSolve::addImage);
+        problemSolveImageDataRepository.saveAll(imageDataList);
+
+        log.info("Uploaded {} images in parallel for problemSolveId: {}", images.size(), problemSolveId);
     }
 
     @Transactional


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### 문제 배치 등록 미션 로그 처리 개선

- 문제 배치 등록 v2에서 문제 개수만큼 `registerProblemWriteMission`을 반복 호출하던 구조를 `registerProblemWriteMissionBatch` 호출 1회로 변경했습니다.
- 오늘 작성한 문제 미션 로그 수를 한 번만 조회하도록 `countProblemWritesToday`를 추가했습니다.
- 하루 문제 작성 미션 보상 최대 3회 제한은 유지하면서, 배치 등록 시 불필요한 미션 로그 조회 N번 호출을 줄였습니다.

### 복습 기록 이미지 업로드 처리 개선

- 복습 기록 이미지 S3 업로드를 고정 스레드 풀 기반으로 병렬 처리하도록 변경했습니다.
- S3 업로드 완료 후 DB 저장은 메인 트랜잭션에서 `saveAll`로 배치 저장하도록 정리했습니다.
- 병렬 업로드용 `s3UploadExecutor` 빈을 추가했습니다.

### 사용자 영향

- 문제를 여러 개 한 번에 등록할 때 미션 로그 처리 쿼리 수가 감소해 응답 지연이 줄어들 수 있습니다.
- 복습 기록에 여러 이미지를 업로드할 때 S3 업로드가 병렬로 수행되어 이미지 업로드 시간이 줄어들 수 있습니다.
- API 응답 필드나 요청 형식은 변경하지 않았습니다.

### 검증 결과

- `./gradlew compileJava` 통과
- `./gradlew test --tests com.aisip.OnO.backend.problem.service.ProblemServiceTest.registerProblemsV2_success --tests com.aisip.OnO.backend.problem.service.ProblemServiceTest.registerProblemsV2_rollbackWhenFolderNotFound` 통과
- `ProblemServiceTest` 전체 실행은 기존 테스트 기대값 문제로 6건 실패
  - 주석 처리된 테스트 호출부의 기대값 검증
  - 기존 삭제 흐름의 S3 삭제 호출 횟수 기대값
  - 목록 조회 순서 기대값
  - 이번 변경 범위와 직접 연결된 실패로 보이지는 않음

### 배포 리스크

- 복습 이미지 업로드 실패 시 `CompletableFuture.join()`이 내부 `ApplicationException`을 `CompletionException`으로 감쌀 수 있어, 기존 파일 업로드 실패 400 응답이 500 응답으로 바뀔 가능성이 있습니다.
- 병렬 업로드 중 일부 파일만 성공한 뒤 실패하면, DB에 연결되지 않은 S3 파일이 남을 수 있습니다.
- `s3UploadExecutor`가 고정 스레드 10개로 동작하므로, 운영 트래픽에서 동시 이미지 업로드 요청이 몰릴 경우 S3 업로드 대기열과 서버 리소스 사용량을 모니터링해야 합니다.

### 롤백 또는 대응 방법

- 복습 이미지 업로드 실패 응답 문제가 확인되면 `CompletionException`의 cause가 `ApplicationException`인 경우 원 예외를 다시 던지도록 보완합니다.
- S3 고아 파일 문제가 확인되면 업로드 성공 URL을 수집하고 실패 시 성공분을 삭제 요청하는 보상 처리 흐름을 추가합니다.
- 업로드 병렬화로 리소스 사용량이 과도하면 executor pool size를 낮추거나 설정값으로 분리합니다.

### 스크린샷 (선택)

- 백엔드 성능 개선 작업으로 해당 없음

## 커밋 범위

- `943081f` `[Perf] 문제 배치 등록 시 미션 로그 N번 호출 -> 배치 처리로 개선`
- `cdb72f3` `[Perf] 복습 기록 이미지 S3 업로드 병렬화 및 배치 저장 적용`
