### PR TITLE
[Feat] 소셜 스터디룸 백엔드 구현

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/auth/config/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/folders/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
                                 .requestMatchers("/api/fileUpload/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
                                 .requestMatchers("/api/practiceNotes/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
-                                .requestMatchers("/api/study-room/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
+                                .requestMatchers("/api/study-room/**", "/api/study-rooms/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
                                 .anyRequest().authenticated()
                 )
                 .formLogin(formLogin -> formLogin

--- a/src/main/java/com/aisip/OnO/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/auth/config/SecurityConfig.java
@@ -106,6 +106,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/folders/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
                                 .requestMatchers("/api/fileUpload/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
                                 .requestMatchers("/api/practiceNotes/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
+                                .requestMatchers("/api/study-room/**").hasAnyRole("GUEST", "MEMBER", "ADMIN")
                                 .anyRequest().authenticated()
                 )
                 .formLogin(formLogin -> formLogin

--- a/src/main/java/com/aisip/OnO/backend/common/emoji/CustomEmojiErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/common/emoji/CustomEmojiErrorCase.java
@@ -1,0 +1,16 @@
+package com.aisip.OnO.backend.common.emoji;
+
+import com.aisip.OnO.backend.common.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CustomEmojiErrorCase implements ErrorCase {
+
+    INVALID_EMOJI_KEY(400, 11001, "지원하지 않는 이모지입니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/aisip/OnO/backend/common/emoji/CustomEmojiValidator.java
+++ b/src/main/java/com/aisip/OnO/backend/common/emoji/CustomEmojiValidator.java
@@ -1,0 +1,98 @@
+package com.aisip.OnO.backend.common.emoji;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class CustomEmojiValidator {
+
+    private static final Set<String> ALLOWED_KEYS = Set.of(
+            "angry_with_flames",
+            "crying_in_rain",
+            "confused_question",
+            "cool_sunglasses",
+            "happy_tears",
+            "excited_happy",
+            "lol_laughing_tears",
+            "cheek_to_cheek",
+            "dizzy_spiral_eyes2",
+            "stressed_bomb",
+            "shy_clasped_hands",
+            "shy_wink_heart",
+            "in_love_heart",
+            "scared_dread",
+            "star_eyes_excited",
+            "frustrated_studying",
+            "holding_pen",
+            "reading_with_glasses",
+            "reading_tablet",
+            "studying_together",
+            "studying_with_lamp",
+            "idea_lightbulb",
+            "got_100_score",
+            "success_checkmark",
+            "writing_wink",
+            "working_laptop",
+            "birthday_cake",
+            "celebrating_confetti",
+            "cheering_megaphone",
+            "excited_with_gift",
+            "fired_up_sparkle_eyes",
+            "superhero_cape",
+            "gold_medal",
+            "holding_flower",
+            "holding_heart",
+            "lifting_weights",
+            "party_celebration",
+            "praying_grateful",
+            "sprout_growth",
+            "trophy_celebration",
+            "thumbs_up_happy",
+            "thumbs_up_wink",
+            "thank_you_sign",
+            "winking_fist",
+            "hi_greeting",
+            "waving_hello",
+            "cheers_beer",
+            "cuddle_love",
+            "texting_heart",
+            "puzzle_teamwork",
+            "peeking_wall",
+            "blue_hoodie",
+            "sleeping_blanket",
+            "cozy_blanket",
+            "cooking_chef",
+            "drinking_coffee",
+            "sleeping_with_star",
+            "eating_ice_cream",
+            "eating_skewer",
+            "playing_game_controller",
+            "hiking_backpack",
+            "listening_headphones",
+            "morning_coffee",
+            "shopping_bags",
+            "singing_happy",
+            "taking_bath",
+            "taking_photo",
+            "umbrella_rain",
+            "wearing_scarf"
+    );
+
+    public void validate(String emojiKey) {
+        if (!isAllowed(emojiKey)) {
+            throw new ApplicationException(CustomEmojiErrorCase.INVALID_EMOJI_KEY);
+        }
+    }
+
+    public void validateNullable(String emojiKey) {
+        if (emojiKey != null) {
+            validate(emojiKey);
+        }
+    }
+
+    public boolean isAllowed(String emojiKey) {
+        return emojiKey != null && ALLOWED_KEYS.contains(emojiKey);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/RabbitMQConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/RabbitMQConfig.java
@@ -6,6 +6,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -61,10 +62,12 @@ public class RabbitMQConfig {
      */
     @Bean
     public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
-            ConnectionFactory connectionFactory) {
+            ConnectionFactory connectionFactory,
+            @Value("${spring.rabbitmq.listener.simple.auto-startup:true}") boolean autoStartup) {
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setMessageConverter(messageConverter());
+        factory.setAutoStartup(autoStartup);
         factory.setConcurrentConsumers(3); // 동시 처리 스레드 수
         factory.setMaxConcurrentConsumers(10); // 최대 동시 처리 스레드 수
         factory.setPrefetchCount(1); // 한 번에 가져올 메시지 수

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/controller/LearningCalendarController.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/controller/LearningCalendarController.java
@@ -1,12 +1,16 @@
 package com.aisip.OnO.backend.learningcalendar.controller;
 
 import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarMoodRequestDto;
+import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarMoodResponseDto;
 import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarResponseDto;
 import com.aisip.OnO.backend.learningcalendar.service.LearningCalendarService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +31,12 @@ public class LearningCalendarController {
         validateYearMonth(year, month);
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return CommonResponse.success(learningCalendarService.getLearningCalendar(userId, year, month));
+    }
+
+    @PatchMapping("/mood")
+    public CommonResponse<LearningCalendarMoodResponseDto> updateMood(@RequestBody LearningCalendarMoodRequestDto request) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return CommonResponse.success(learningCalendarService.updateMood(userId, request));
     }
 
     private void validateYearMonth(int year, int month) {

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/dto/LearningCalendarMoodRequestDto.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/dto/LearningCalendarMoodRequestDto.java
@@ -1,0 +1,9 @@
+package com.aisip.OnO.backend.learningcalendar.dto;
+
+import java.time.LocalDate;
+
+public record LearningCalendarMoodRequestDto(
+        LocalDate date,
+        String emojiKey
+) {
+}

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/dto/LearningCalendarMoodResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/dto/LearningCalendarMoodResponseDto.java
@@ -1,0 +1,9 @@
+package com.aisip.OnO.backend.learningcalendar.dto;
+
+import java.time.LocalDate;
+
+public record LearningCalendarMoodResponseDto(
+        LocalDate date,
+        String emojiKey
+) {
+}

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/dto/LearningCalendarResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/dto/LearningCalendarResponseDto.java
@@ -22,7 +22,8 @@ public record LearningCalendarResponseDto(
             int reviewCount,
             int noteWriteCount,
             int studyMinutes,
-            List<String> reviewedItems
+            List<String> reviewedItems,
+            String moodEmojiKey
     ) {
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/entity/LearningCalendarMood.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/entity/LearningCalendarMood.java
@@ -1,0 +1,52 @@
+package com.aisip.OnO.backend.learningcalendar.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "learning_calendar_mood",
+        uniqueConstraints = @UniqueConstraint(name = "uk_learning_calendar_mood_user_date", columnNames = {"user_id", "study_date"}))
+public class LearningCalendarMood extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "study_date", nullable = false)
+    private LocalDate studyDate;
+
+    @Column(name = "emoji_key", nullable = false, length = 80)
+    private String emojiKey;
+
+    public static LearningCalendarMood create(Long userId, LocalDate studyDate, String emojiKey) {
+        return LearningCalendarMood.builder()
+                .userId(userId)
+                .studyDate(studyDate)
+                .emojiKey(emojiKey)
+                .build();
+    }
+
+    public void updateEmojiKey(String emojiKey) {
+        this.emojiKey = emojiKey;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/exception/LearningCalendarErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/exception/LearningCalendarErrorCase.java
@@ -1,0 +1,17 @@
+package com.aisip.OnO.backend.learningcalendar.exception;
+
+import com.aisip.OnO.backend.common.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LearningCalendarErrorCase implements ErrorCase {
+
+    CALENDAR_RECORD_NOT_FOUND(404, 12001, "해당 날짜 학습 기록이 없습니다."),
+    INVALID_DATE_FORMAT(400, 12002, "날짜 형식이 올바르지 않습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/repository/LearningCalendarMoodRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/repository/LearningCalendarMoodRepository.java
@@ -1,0 +1,15 @@
+package com.aisip.OnO.backend.learningcalendar.repository;
+
+import com.aisip.OnO.backend.learningcalendar.entity.LearningCalendarMood;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface LearningCalendarMoodRepository extends JpaRepository<LearningCalendarMood, Long> {
+
+    Optional<LearningCalendarMood> findByUserIdAndStudyDate(Long userId, LocalDate studyDate);
+
+    List<LearningCalendarMood> findAllByUserIdAndStudyDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/repository/LearningCalendarQueryRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/repository/LearningCalendarQueryRepository.java
@@ -128,6 +128,27 @@ public class LearningCalendarQueryRepository {
                 .toList();
     }
 
+    public boolean existsStudyRecord(Long userId, LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(23, 59, 59);
+        Integer reviewExists = queryFactory
+                .selectOne()
+                .from(problemSolve)
+                .where(problemSolve.userId.eq(userId)
+                        .and(problemSolve.practicedAt.between(start, end)))
+                .fetchFirst();
+        if (reviewExists != null) {
+            return true;
+        }
+        Integer noteWriteExists = queryFactory
+                .selectOne()
+                .from(problem)
+                .where(problem.userId.eq(userId)
+                        .and(problem.createdAt.between(start, end)))
+                .fetchFirst();
+        return noteWriteExists != null;
+    }
+
     private int secondsToMinutes(Integer seconds) {
         return seconds == null ? 0 : seconds / 60;
     }

--- a/src/main/java/com/aisip/OnO/backend/learningcalendar/service/LearningCalendarService.java
+++ b/src/main/java/com/aisip/OnO/backend/learningcalendar/service/LearningCalendarService.java
@@ -1,6 +1,13 @@
 package com.aisip.OnO.backend.learningcalendar.service;
 
+import com.aisip.OnO.backend.common.emoji.CustomEmojiValidator;
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarMoodRequestDto;
+import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarMoodResponseDto;
 import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarResponseDto;
+import com.aisip.OnO.backend.learningcalendar.entity.LearningCalendarMood;
+import com.aisip.OnO.backend.learningcalendar.exception.LearningCalendarErrorCase;
+import com.aisip.OnO.backend.learningcalendar.repository.LearningCalendarMoodRepository;
 import com.aisip.OnO.backend.learningcalendar.repository.LearningCalendarQueryRepository;
 import com.aisip.OnO.backend.util.redis.StreakCacheService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +31,8 @@ public class LearningCalendarService {
 
     private final LearningCalendarQueryRepository calendarRepository;
     private final StreakCacheService streakCacheService;
+    private final LearningCalendarMoodRepository moodRepository;
+    private final CustomEmojiValidator customEmojiValidator;
 
     public LearningCalendarResponseDto getLearningCalendar(Long userId, int year, int month) {
         return getLearningCalendar(userId, year, month, LocalDate.now());
@@ -45,13 +54,17 @@ public class LearningCalendarService {
         Map<LocalDate, List<String>> reviewedItems = toReviewedItemsMap(
                 calendarRepository.findReviewItems(userId, start, end)
         );
+        Map<LocalDate, String> moodEmojiKeys = moodRepository.findAllByUserIdAndStudyDateBetween(userId, startDate, endDate)
+                .stream()
+                .collect(Collectors.toMap(LearningCalendarMood::getStudyDate, LearningCalendarMood::getEmojiKey));
 
         List<LearningCalendarResponseDto.DailyStudyRecord> records = startDate.datesUntil(endDate.plusDays(1))
                 .map(date -> buildDailyRecord(
                         date,
                         reviewStats.get(date),
                         noteWriteStats.get(date),
-                        reviewedItems.getOrDefault(date, List.of())
+                        reviewedItems.getOrDefault(date, List.of()),
+                        moodEmojiKeys.get(date)
                 ))
                 .toList();
 
@@ -71,11 +84,27 @@ public class LearningCalendarService {
                 .build();
     }
 
+    @Transactional
+    public LearningCalendarMoodResponseDto updateMood(Long userId, LearningCalendarMoodRequestDto request) {
+        if (request == null || request.date() == null) {
+            throw new ApplicationException(LearningCalendarErrorCase.INVALID_DATE_FORMAT);
+        }
+        customEmojiValidator.validate(request.emojiKey());
+        if (!calendarRepository.existsStudyRecord(userId, request.date())) {
+            throw new ApplicationException(LearningCalendarErrorCase.CALENDAR_RECORD_NOT_FOUND);
+        }
+        LearningCalendarMood mood = moodRepository.findByUserIdAndStudyDate(userId, request.date())
+                .orElseGet(() -> moodRepository.save(LearningCalendarMood.create(userId, request.date(), request.emojiKey())));
+        mood.updateEmojiKey(request.emojiKey());
+        return new LearningCalendarMoodResponseDto(mood.getStudyDate(), mood.getEmojiKey());
+    }
+
     private LearningCalendarResponseDto.DailyStudyRecord buildDailyRecord(
             LocalDate date,
             LearningCalendarQueryRepository.DailyReviewStat reviewStat,
             LearningCalendarQueryRepository.DailyNoteWriteStat noteWriteStat,
-            List<String> reviewedItems
+            List<String> reviewedItems,
+            String moodEmojiKey
     ) {
         int reviewCount = reviewStat == null ? 0 : toInt(reviewStat.reviewCount());
         int noteWriteCount = noteWriteStat == null ? 0 : toInt(noteWriteStat.noteWriteCount());
@@ -88,6 +117,7 @@ public class LearningCalendarService {
                 .noteWriteCount(noteWriteCount)
                 .studyMinutes(studyMinutes)
                 .reviewedItems(reviewedItems)
+                .moodEmojiKey(moodEmojiKey)
                 .build();
     }
 

--- a/src/main/java/com/aisip/OnO/backend/practicenote/controller/PracticeNoteController.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/controller/PracticeNoteController.java
@@ -73,9 +73,10 @@ public class PracticeNoteController {
 
     // ✅ 복습 완료 횟수 증가
     @PatchMapping("/{practiceId}/complete")
-    public CommonResponse<String> addPracticeCount(@PathVariable("practiceId") Long practiceId) {
+    public CommonResponse<String> addPracticeCount(@PathVariable("practiceId") Long practiceId,
+                                                   @RequestBody(required = false) PracticeNoteCompleteRequestDto request) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        practiceNoteService.addPracticeNoteCount(userId, practiceId);
+        practiceNoteService.addPracticeNoteCount(userId, practiceId, request);
 
         log.info("userId: {} completed problem practice with practiceNoteId: {}", userId, practiceId);
         return CommonResponse.success("복습을 완료했습니다.");

--- a/src/main/java/com/aisip/OnO/backend/practicenote/dto/PracticeNoteCompleteRequestDto.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/dto/PracticeNoteCompleteRequestDto.java
@@ -1,0 +1,6 @@
+package com.aisip.OnO.backend.practicenote.dto;
+
+public record PracticeNoteCompleteRequestDto(
+        String moodEmojiKey
+) {
+}

--- a/src/main/java/com/aisip/OnO/backend/practicenote/dto/PracticeNoteDetailResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/dto/PracticeNoteDetailResponseDto.java
@@ -21,6 +21,8 @@ public record PracticeNoteDetailResponseDto(
 
         LocalDateTime lastSolvedAt,
 
+        String lastSessionMoodEmojiKey,
+
         LocalDateTime createdAt,
 
         LocalDateTime updatedAt
@@ -41,6 +43,7 @@ public record PracticeNoteDetailResponseDto(
                 .problemIdList(problemIdList)
                 .practiceNotification(notificationDto)
                 .lastSolvedAt(practiceNote.getLastSolvedAt())
+                .lastSessionMoodEmojiKey(practiceNote.getLastSessionMoodEmojiKey())
                 .createdAt(practiceNote.getCreatedAt())
                 .updatedAt(practiceNote.getUpdatedAt())
                 .build();

--- a/src/main/java/com/aisip/OnO/backend/practicenote/dto/PracticeNoteThumbnailResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/dto/PracticeNoteThumbnailResponseDto.java
@@ -15,7 +15,9 @@ public record PracticeNoteThumbnailResponseDto(
 
         Long practiceCount,
 
-        LocalDateTime lastSolvedAt
+        LocalDateTime lastSolvedAt,
+
+        String lastSessionMoodEmojiKey
 ) {
     public static PracticeNoteThumbnailResponseDto from(@NotNull PracticeNote practiceNote) {
         return PracticeNoteThumbnailResponseDto.builder()
@@ -23,6 +25,7 @@ public record PracticeNoteThumbnailResponseDto(
                 .practiceTitle(practiceNote.getTitle())
                 .practiceCount(practiceNote.getPracticeCount())
                 .lastSolvedAt(practiceNote.getLastSolvedAt())
+                .lastSessionMoodEmojiKey(practiceNote.getLastSessionMoodEmojiKey())
                 .build();
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/practicenote/entity/PracticeNote.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/entity/PracticeNote.java
@@ -35,6 +35,9 @@ public class PracticeNote extends BaseEntity {
 
     private LocalDateTime lastSolvedAt;
 
+    @Column(length = 80)
+    private String lastSessionMoodEmojiKey;
+
     @Embedded
     private PracticeNotification practiceNotification;
 
@@ -61,6 +64,11 @@ public class PracticeNote extends BaseEntity {
     public void updatePracticeNoteCount() {
         this.practiceCount += 1;
         this.lastSolvedAt = LocalDateTime.now();
+    }
+
+    public void updatePracticeNoteCount(String moodEmojiKey) {
+        updatePracticeNoteCount();
+        this.lastSessionMoodEmojiKey = moodEmojiKey;
     }
 
     public void updateNotification(PracticeNotification practiceNotification) {

--- a/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
+++ b/src/main/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteService.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.practicenote.service;
 
 import com.aisip.OnO.backend.admin.dto.AdminPracticeNoteResponseDto;
+import com.aisip.OnO.backend.common.emoji.CustomEmojiValidator;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.mission.service.MissionLogService;
@@ -56,6 +57,8 @@ public class PracticeNoteService {
     private final MissionLogService missionLogService;
 
     private final UserRepository userRepository;
+
+    private final CustomEmojiValidator customEmojiValidator;
 
     private PracticeNote getPracticeEntity(Long practiceId, Long userId){
 
@@ -137,8 +140,14 @@ public class PracticeNoteService {
     }
 
     public void addPracticeNoteCount(Long userId, Long practiceId) {
+        addPracticeNoteCount(userId, practiceId, null);
+    }
+
+    public void addPracticeNoteCount(Long userId, Long practiceId, PracticeNoteCompleteRequestDto request) {
         PracticeNote practiceNote = getPracticeEntity(practiceId, userId);
-        practiceNote.updatePracticeNoteCount();
+        String moodEmojiKey = request == null ? null : request.moodEmojiKey();
+        customEmojiValidator.validateNullable(moodEmojiKey);
+        practiceNote.updatePracticeNoteCount(moodEmojiKey);
 
         // 복습노트 사용 미션 등록
         missionLogService.registerNotePracticeMission(userId, practiceId);

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -30,6 +30,8 @@ import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.practicenote.repository.PracticeNoteRepository;
 import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
 import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveSummary;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+import com.aisip.OnO.backend.studyroom.event.StudyRoomActivityEvent;
 import com.aisip.OnO.backend.tag.entity.ProblemTagMapping;
 import com.aisip.OnO.backend.tag.entity.Tag;
 import com.aisip.OnO.backend.tag.exception.TagErrorCase;
@@ -38,6 +40,7 @@ import com.aisip.OnO.backend.tag.repository.TagRepository;
 import com.aisip.OnO.backend.util.redis.StreakCacheService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
@@ -88,6 +91,7 @@ public class ProblemService {
     private final ProblemTagMappingRepository problemTagMappingRepository;
     private final RateLimitService rateLimitService;
     private final StreakCacheService streakCacheService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public ProblemResponseDto findProblemForAdmin(Long problemId) {
@@ -214,6 +218,8 @@ public class ProblemService {
         analysisService.createSkippedAnalysis(problem.getId());
         streakCacheService.evict(userId);
         missionLogService.registerProblemWriteMission(userId);
+        eventPublisher.publishEvent(new StudyRoomActivityEvent(
+                userId, StudyRoomFeedEventType.PROBLEM_REGISTERED, Map.of("count", 1)));
 
         log.info("userId: {} register problemId: {}", userId, problem.getId());
 
@@ -271,6 +277,8 @@ public class ProblemService {
         analysisService.createSkippedAnalysis(problem.getId());
         streakCacheService.evict(userId);
         missionLogService.registerProblemWriteMission(userId);
+        eventPublisher.publishEvent(new StudyRoomActivityEvent(
+                userId, StudyRoomFeedEventType.PROBLEM_REGISTERED, Map.of("count", 1)));
 
         log.info("userId: {} register problem(v2) problemId: {}", userId, problem.getId());
         return problem.getId();
@@ -333,6 +341,8 @@ public class ProblemService {
 
         streakCacheService.evict(userId);
         missionLogService.registerProblemWriteMissionBatch(userId, problems.size());
+        eventPublisher.publishEvent(new StudyRoomActivityEvent(
+                userId, StudyRoomFeedEventType.PROBLEM_REGISTERED, Map.of("count", problems.size())));
 
         List<Long> problemIds = problems.stream()
                 .map(Problem::getId)

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
@@ -15,6 +15,8 @@ import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+import com.aisip.OnO.backend.studyroom.event.StudyRoomActivityEvent;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
@@ -46,6 +49,7 @@ public class ProblemSolveService {
     private final S3DeleteProducer s3DeleteProducer;
     private final ObjectMapper objectMapper;
     private final StreakCacheService streakCacheService;
+    private final ApplicationEventPublisher eventPublisher;
     @Qualifier("s3UploadExecutor")
     private final Executor s3UploadExecutor;
 
@@ -135,6 +139,8 @@ public class ProblemSolveService {
                 problem.getConsecutiveCorrectCount()
         );
         problem.updateReviewSchedule(schedule.nextReviewAt(), schedule.reviewInterval(), schedule.consecutiveCorrectCount());
+        eventPublisher.publishEvent(new StudyRoomActivityEvent(
+                userId, StudyRoomFeedEventType.PRACTICE_COMPLETED, java.util.Map.of()));
 
         log.info("userId: {} created problem solve: {}, nextReviewAt: {}, mastered: {}",
                 userId, problemSolve.getId(), schedule.nextReviewAt(), schedule.isMastered());

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomChallengeController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomChallengeController.java
@@ -18,19 +18,20 @@ public class StudyRoomChallengeController {
     private final StudyRoomChallengeService challengeService;
 
     @GetMapping
-    public CommonResponse<List<ChallengeResponse>> getChallenges(@PathVariable Long roomId) {
+    public CommonResponse<List<ChallengeResponse>> getChallenges(@PathVariable("roomId") Long roomId) {
         return CommonResponse.success(challengeService.getChallenges(roomId, currentUserId()));
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommonResponse<ChallengeResponse> createChallenge(@PathVariable Long roomId,
+    public CommonResponse<ChallengeResponse> createChallenge(@PathVariable("roomId") Long roomId,
                                                              @RequestBody ChallengeCreateRequest request) {
         return CommonResponse.success(challengeService.createChallenge(roomId, currentUserId(), request));
     }
 
     @DeleteMapping("/{challengeId}")
-    public CommonResponse<String> deleteChallenge(@PathVariable Long roomId, @PathVariable Long challengeId) {
+    public CommonResponse<String> deleteChallenge(@PathVariable("roomId") Long roomId,
+                                                  @PathVariable("challengeId") Long challengeId) {
         challengeService.deleteChallenge(roomId, challengeId, currentUserId());
         return CommonResponse.success("챌린지 삭제가 완료되었습니다.");
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomChallengeController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomChallengeController.java
@@ -1,0 +1,41 @@
+package com.aisip.OnO.backend.studyroom.controller;
+
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomChallengeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-room/{roomId}/challenges")
+public class StudyRoomChallengeController {
+
+    private final StudyRoomChallengeService challengeService;
+
+    @GetMapping
+    public CommonResponse<List<ChallengeResponse>> getChallenges(@PathVariable Long roomId) {
+        return CommonResponse.success(challengeService.getChallenges(roomId, currentUserId()));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<ChallengeResponse> createChallenge(@PathVariable Long roomId,
+                                                             @RequestBody ChallengeCreateRequest request) {
+        return CommonResponse.success(challengeService.createChallenge(roomId, currentUserId(), request));
+    }
+
+    @DeleteMapping("/{challengeId}")
+    public CommonResponse<String> deleteChallenge(@PathVariable Long roomId, @PathVariable Long challengeId) {
+        challengeService.deleteChallenge(roomId, challengeId, currentUserId());
+        return CommonResponse.success("챌린지 삭제가 완료되었습니다.");
+    }
+
+    private Long currentUserId() {
+        return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
@@ -6,8 +6,10 @@ import com.aisip.OnO.backend.studyroom.service.StudyRoomInviteService;
 import com.aisip.OnO.backend.studyroom.service.StudyRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -68,6 +70,12 @@ public class StudyRoomController {
     public CommonResponse<GoalUpdateResponse> updateGoal(@PathVariable("roomId") Long roomId,
                                                          @RequestBody StudyRoomGoalUpdateRequest request) {
         return CommonResponse.success(studyRoomService.updateGoal(roomId, currentUserId(), request));
+    }
+
+    @PatchMapping(value = "/{roomId}/thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public CommonResponse<StudyRoomThumbnailUpdateResponse> updateThumbnail(@PathVariable("roomId") Long roomId,
+                                                                           @RequestParam("thumbnail") MultipartFile thumbnail) {
+        return CommonResponse.success(studyRoomService.updateThumbnail(roomId, currentUserId(), thumbnail));
     }
 
     private Long currentUserId() {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/study-room")
+@RequestMapping({"/api/study-room", "/api/study-rooms"})
 public class StudyRoomController {
 
     private final StudyRoomService studyRoomService;
@@ -37,10 +37,17 @@ public class StudyRoomController {
         return CommonResponse.success(studyRoomService.getRoom(roomId, currentUserId()));
     }
 
-    @PatchMapping("/{roomId}")
+    @PatchMapping(value = "/{roomId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public CommonResponse<StudyRoomDetailResponse> updateRoom(@PathVariable("roomId") Long roomId,
                                                               @RequestBody StudyRoomUpdateRequest request) {
         return CommonResponse.success(studyRoomService.updateRoom(roomId, currentUserId(), request));
+    }
+
+    @PatchMapping(value = "/{roomId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public CommonResponse<StudyRoomDetailResponse> updateRoomMultipart(@PathVariable("roomId") Long roomId,
+                                                                       @RequestParam(value = "name", required = false) String name,
+                                                                       @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage) {
+        return CommonResponse.success(studyRoomService.updateRoom(roomId, currentUserId(), name, thumbnailImage));
     }
 
     @DeleteMapping("/{roomId}")

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
@@ -37,6 +37,12 @@ public class StudyRoomController {
         return CommonResponse.success(studyRoomService.getRoom(roomId, currentUserId()));
     }
 
+    @PatchMapping("/{roomId}")
+    public CommonResponse<StudyRoomDetailResponse> updateRoom(@PathVariable("roomId") Long roomId,
+                                                              @RequestBody StudyRoomUpdateRequest request) {
+        return CommonResponse.success(studyRoomService.updateRoom(roomId, currentUserId(), request));
+    }
+
     @DeleteMapping("/{roomId}")
     public CommonResponse<String> deleteRoom(@PathVariable("roomId") Long roomId) {
         studyRoomService.deleteRoom(roomId, currentUserId());

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
@@ -1,0 +1,75 @@
+package com.aisip.OnO.backend.studyroom.controller;
+
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomInviteService;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-room")
+public class StudyRoomController {
+
+    private final StudyRoomService studyRoomService;
+    private final StudyRoomInviteService inviteService;
+
+    @GetMapping
+    public CommonResponse<List<StudyRoomListResponse>> getMyRooms() {
+        return CommonResponse.success(studyRoomService.getMyRooms(currentUserId()));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<StudyRoomDetailResponse> createRoom(@RequestBody StudyRoomCreateRequest request) {
+        return CommonResponse.success(studyRoomService.createRoom(request, currentUserId()));
+    }
+
+    @GetMapping("/{roomId}")
+    public CommonResponse<StudyRoomDetailResponse> getRoom(@PathVariable Long roomId) {
+        return CommonResponse.success(studyRoomService.getRoom(roomId, currentUserId()));
+    }
+
+    @DeleteMapping("/{roomId}")
+    public CommonResponse<String> deleteRoom(@PathVariable Long roomId) {
+        studyRoomService.deleteRoom(roomId, currentUserId());
+        return CommonResponse.success("스터디룸 삭제가 완료되었습니다.");
+    }
+
+    @PostMapping("/{roomId}/invite")
+    public CommonResponse<InviteCodeResponse> issueInviteCode(@PathVariable Long roomId) {
+        return CommonResponse.success(inviteService.issueInviteCode(roomId, currentUserId()));
+    }
+
+    @PostMapping("/join")
+    public CommonResponse<StudyRoomDetailResponse> join(@RequestBody StudyRoomJoinRequest request) {
+        return CommonResponse.success(inviteService.join(request, currentUserId()));
+    }
+
+    @DeleteMapping("/{roomId}/leave")
+    public CommonResponse<String> leaveRoom(@PathVariable Long roomId) {
+        studyRoomService.leaveRoom(roomId, currentUserId());
+        return CommonResponse.success("스터디룸 탈퇴가 완료되었습니다.");
+    }
+
+    @DeleteMapping("/{roomId}/members/{memberId}")
+    public CommonResponse<String> kickMember(@PathVariable Long roomId, @PathVariable Long memberId) {
+        studyRoomService.kickMember(roomId, memberId, currentUserId());
+        return CommonResponse.success("스터디룸 멤버 강퇴가 완료되었습니다.");
+    }
+
+    @PutMapping("/{roomId}/members/me/goal")
+    public CommonResponse<GoalUpdateResponse> updateGoal(@PathVariable Long roomId,
+                                                         @RequestBody StudyRoomGoalUpdateRequest request) {
+        return CommonResponse.success(studyRoomService.updateGoal(roomId, currentUserId(), request));
+    }
+
+    private Long currentUserId() {
+        return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
@@ -31,18 +31,18 @@ public class StudyRoomController {
     }
 
     @GetMapping("/{roomId}")
-    public CommonResponse<StudyRoomDetailResponse> getRoom(@PathVariable Long roomId) {
+    public CommonResponse<StudyRoomDetailResponse> getRoom(@PathVariable("roomId") Long roomId) {
         return CommonResponse.success(studyRoomService.getRoom(roomId, currentUserId()));
     }
 
     @DeleteMapping("/{roomId}")
-    public CommonResponse<String> deleteRoom(@PathVariable Long roomId) {
+    public CommonResponse<String> deleteRoom(@PathVariable("roomId") Long roomId) {
         studyRoomService.deleteRoom(roomId, currentUserId());
         return CommonResponse.success("스터디룸 삭제가 완료되었습니다.");
     }
 
     @PostMapping("/{roomId}/invite")
-    public CommonResponse<InviteCodeResponse> issueInviteCode(@PathVariable Long roomId) {
+    public CommonResponse<InviteCodeResponse> issueInviteCode(@PathVariable("roomId") Long roomId) {
         return CommonResponse.success(inviteService.issueInviteCode(roomId, currentUserId()));
     }
 
@@ -52,19 +52,20 @@ public class StudyRoomController {
     }
 
     @DeleteMapping("/{roomId}/leave")
-    public CommonResponse<String> leaveRoom(@PathVariable Long roomId) {
+    public CommonResponse<String> leaveRoom(@PathVariable("roomId") Long roomId) {
         studyRoomService.leaveRoom(roomId, currentUserId());
         return CommonResponse.success("스터디룸 탈퇴가 완료되었습니다.");
     }
 
     @DeleteMapping("/{roomId}/members/{memberId}")
-    public CommonResponse<String> kickMember(@PathVariable Long roomId, @PathVariable Long memberId) {
+    public CommonResponse<String> kickMember(@PathVariable("roomId") Long roomId,
+                                             @PathVariable("memberId") Long memberId) {
         studyRoomService.kickMember(roomId, memberId, currentUserId());
         return CommonResponse.success("스터디룸 멤버 강퇴가 완료되었습니다.");
     }
 
     @PutMapping("/{roomId}/members/me/goal")
-    public CommonResponse<GoalUpdateResponse> updateGoal(@PathVariable Long roomId,
+    public CommonResponse<GoalUpdateResponse> updateGoal(@PathVariable("roomId") Long roomId,
                                                          @RequestBody StudyRoomGoalUpdateRequest request) {
         return CommonResponse.success(studyRoomService.updateGoal(roomId, currentUserId(), request));
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomFeedController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomFeedController.java
@@ -1,0 +1,35 @@
+package com.aisip.OnO.backend.studyroom.controller;
+
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.common.response.CursorPageResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomFeedService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-room/{roomId}/feed")
+public class StudyRoomFeedController {
+
+    private final StudyRoomFeedService feedService;
+
+    @GetMapping
+    public CommonResponse<CursorPageResponse<FeedItemResponse>> getFeed(@PathVariable Long roomId,
+                                                                        @RequestParam(value = "cursor", required = false) Long cursor,
+                                                                        @RequestParam(defaultValue = "30") int size) {
+        return CommonResponse.success(feedService.getFeed(roomId, currentUserId(), cursor, size));
+    }
+
+    @PostMapping("/{feedId}/reactions")
+    public CommonResponse<FeedReactionToggleResponse> toggleReaction(@PathVariable Long roomId,
+                                                                     @PathVariable Long feedId,
+                                                                     @RequestBody ReactionToggleRequest request) {
+        return CommonResponse.success(feedService.toggleReaction(roomId, feedId, currentUserId(), request));
+    }
+
+    private Long currentUserId() {
+        return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomFeedController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomFeedController.java
@@ -16,15 +16,15 @@ public class StudyRoomFeedController {
     private final StudyRoomFeedService feedService;
 
     @GetMapping
-    public CommonResponse<CursorPageResponse<FeedItemResponse>> getFeed(@PathVariable Long roomId,
+    public CommonResponse<CursorPageResponse<FeedItemResponse>> getFeed(@PathVariable("roomId") Long roomId,
                                                                         @RequestParam(value = "cursor", required = false) Long cursor,
-                                                                        @RequestParam(defaultValue = "30") int size) {
+                                                                        @RequestParam(value = "size", defaultValue = "30") int size) {
         return CommonResponse.success(feedService.getFeed(roomId, currentUserId(), cursor, size));
     }
 
     @PostMapping("/{feedId}/reactions")
-    public CommonResponse<FeedReactionToggleResponse> toggleReaction(@PathVariable Long roomId,
-                                                                     @PathVariable Long feedId,
+    public CommonResponse<FeedReactionToggleResponse> toggleReaction(@PathVariable("roomId") Long roomId,
+                                                                     @PathVariable("feedId") Long feedId,
                                                                      @RequestBody ReactionToggleRequest request) {
         return CommonResponse.success(feedService.toggleReaction(roomId, feedId, currentUserId(), request));
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
@@ -3,6 +3,7 @@ package com.aisip.OnO.backend.studyroom.controller;
 import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomSharedProblemCommentService;
 import com.aisip.OnO.backend.studyroom.service.StudyRoomSharedProblemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,10 +12,11 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/study-room/{roomId}/shared-problems")
+@RequestMapping({"/api/study-room/{roomId}/shared-problems", "/api/study-rooms/{roomId}/shared-problems"})
 public class StudyRoomSharedProblemController {
 
     private final StudyRoomSharedProblemService sharedProblemService;
+    private final StudyRoomSharedProblemCommentService commentService;
 
     @GetMapping
     public CommonResponse<CursorPageResponse<SharedProblemResponse>> getSharedProblems(@PathVariable("roomId") Long roomId,
@@ -35,6 +37,38 @@ public class StudyRoomSharedProblemController {
                                                                               @PathVariable("sharedProblemId") Long sharedProblemId,
                                                                               @RequestBody ReactionToggleRequest request) {
         return CommonResponse.success(sharedProblemService.toggleReaction(roomId, sharedProblemId, currentUserId(), request));
+    }
+
+    @GetMapping("/{sharedProblemId}/comments")
+    public CommonResponse<CursorPageResponse<SharedProblemCommentResponse>> getComments(@PathVariable("roomId") Long roomId,
+                                                                                        @PathVariable("sharedProblemId") Long sharedProblemId,
+                                                                                        @RequestParam(value = "cursor", required = false) Long cursor,
+                                                                                        @RequestParam(value = "size", defaultValue = "20") int size) {
+        return CommonResponse.success(commentService.getComments(roomId, sharedProblemId, currentUserId(), cursor, size));
+    }
+
+    @PostMapping("/{sharedProblemId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<SharedProblemCommentResponse> createComment(@PathVariable("roomId") Long roomId,
+                                                                      @PathVariable("sharedProblemId") Long sharedProblemId,
+                                                                      @RequestBody SharedProblemCommentRequest request) {
+        return CommonResponse.success(commentService.createComment(roomId, sharedProblemId, currentUserId(), request));
+    }
+
+    @PatchMapping("/{sharedProblemId}/comments/{commentId}")
+    public CommonResponse<SharedProblemCommentResponse> updateComment(@PathVariable("roomId") Long roomId,
+                                                                      @PathVariable("sharedProblemId") Long sharedProblemId,
+                                                                      @PathVariable("commentId") Long commentId,
+                                                                      @RequestBody SharedProblemCommentRequest request) {
+        return CommonResponse.success(commentService.updateComment(roomId, sharedProblemId, commentId, currentUserId(), request));
+    }
+
+    @DeleteMapping("/{sharedProblemId}/comments/{commentId}")
+    public CommonResponse<String> deleteComment(@PathVariable("roomId") Long roomId,
+                                                @PathVariable("sharedProblemId") Long sharedProblemId,
+                                                @PathVariable("commentId") Long commentId) {
+        commentService.deleteComment(roomId, sharedProblemId, commentId, currentUserId());
+        return CommonResponse.success("공유 문제 댓글 삭제가 완료되었습니다.");
     }
 
     @DeleteMapping("/{sharedProblemId}")

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
@@ -63,6 +63,14 @@ public class StudyRoomSharedProblemController {
         return CommonResponse.success(commentService.updateComment(roomId, sharedProblemId, commentId, currentUserId(), request));
     }
 
+    @PostMapping("/{sharedProblemId}/comments/{commentId}/reactions")
+    public CommonResponse<SharedProblemCommentReactionToggleResponse> toggleCommentReaction(@PathVariable("roomId") Long roomId,
+                                                                                            @PathVariable("sharedProblemId") Long sharedProblemId,
+                                                                                            @PathVariable("commentId") Long commentId,
+                                                                                            @RequestBody ReactionToggleRequest request) {
+        return CommonResponse.success(commentService.toggleReaction(roomId, sharedProblemId, commentId, currentUserId(), request));
+    }
+
     @DeleteMapping("/{sharedProblemId}/comments/{commentId}")
     public CommonResponse<String> deleteComment(@PathVariable("roomId") Long roomId,
                                                 @PathVariable("sharedProblemId") Long sharedProblemId,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
@@ -1,0 +1,49 @@
+package com.aisip.OnO.backend.studyroom.controller;
+
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.common.response.CursorPageResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomSharedProblemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-room/{roomId}/shared-problems")
+public class StudyRoomSharedProblemController {
+
+    private final StudyRoomSharedProblemService sharedProblemService;
+
+    @GetMapping
+    public CommonResponse<CursorPageResponse<SharedProblemResponse>> getSharedProblems(@PathVariable Long roomId,
+                                                                                       @RequestParam(value = "cursor", required = false) Long cursor,
+                                                                                       @RequestParam(defaultValue = "20") int size) {
+        return CommonResponse.success(sharedProblemService.getSharedProblems(roomId, currentUserId(), cursor, size));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<SharedProblemResponse> shareProblem(@PathVariable Long roomId,
+                                                              @RequestBody SharedProblemCreateRequest request) {
+        return CommonResponse.success(sharedProblemService.shareProblem(roomId, currentUserId(), request));
+    }
+
+    @PostMapping("/{sharedProblemId}/reactions")
+    public CommonResponse<SharedProblemReactionToggleResponse> toggleReaction(@PathVariable Long roomId,
+                                                                              @PathVariable Long sharedProblemId,
+                                                                              @RequestBody ReactionToggleRequest request) {
+        return CommonResponse.success(sharedProblemService.toggleReaction(roomId, sharedProblemId, currentUserId(), request));
+    }
+
+    @DeleteMapping("/{sharedProblemId}")
+    public CommonResponse<String> deleteSharedProblem(@PathVariable Long roomId, @PathVariable Long sharedProblemId) {
+        sharedProblemService.deleteSharedProblem(roomId, sharedProblemId, currentUserId());
+        return CommonResponse.success("공유 문제 삭제가 완료되었습니다.");
+    }
+
+    private Long currentUserId() {
+        return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomSharedProblemController.java
@@ -17,28 +17,29 @@ public class StudyRoomSharedProblemController {
     private final StudyRoomSharedProblemService sharedProblemService;
 
     @GetMapping
-    public CommonResponse<CursorPageResponse<SharedProblemResponse>> getSharedProblems(@PathVariable Long roomId,
+    public CommonResponse<CursorPageResponse<SharedProblemResponse>> getSharedProblems(@PathVariable("roomId") Long roomId,
                                                                                        @RequestParam(value = "cursor", required = false) Long cursor,
-                                                                                       @RequestParam(defaultValue = "20") int size) {
+                                                                                       @RequestParam(value = "size", defaultValue = "20") int size) {
         return CommonResponse.success(sharedProblemService.getSharedProblems(roomId, currentUserId(), cursor, size));
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommonResponse<SharedProblemResponse> shareProblem(@PathVariable Long roomId,
+    public CommonResponse<SharedProblemResponse> shareProblem(@PathVariable("roomId") Long roomId,
                                                               @RequestBody SharedProblemCreateRequest request) {
         return CommonResponse.success(sharedProblemService.shareProblem(roomId, currentUserId(), request));
     }
 
     @PostMapping("/{sharedProblemId}/reactions")
-    public CommonResponse<SharedProblemReactionToggleResponse> toggleReaction(@PathVariable Long roomId,
-                                                                              @PathVariable Long sharedProblemId,
+    public CommonResponse<SharedProblemReactionToggleResponse> toggleReaction(@PathVariable("roomId") Long roomId,
+                                                                              @PathVariable("sharedProblemId") Long sharedProblemId,
                                                                               @RequestBody ReactionToggleRequest request) {
         return CommonResponse.success(sharedProblemService.toggleReaction(roomId, sharedProblemId, currentUserId(), request));
     }
 
     @DeleteMapping("/{sharedProblemId}")
-    public CommonResponse<String> deleteSharedProblem(@PathVariable Long roomId, @PathVariable Long sharedProblemId) {
+    public CommonResponse<String> deleteSharedProblem(@PathVariable("roomId") Long roomId,
+                                                      @PathVariable("sharedProblemId") Long sharedProblemId) {
         sharedProblemService.deleteSharedProblem(roomId, sharedProblemId, currentUserId());
         return CommonResponse.success("공유 문제 삭제가 완료되었습니다.");
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomWeeklyReportController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomWeeklyReportController.java
@@ -1,0 +1,33 @@
+package com.aisip.OnO.backend.studyroom.controller;
+
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomWeeklyReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-room/{roomId}/weekly-reports")
+public class StudyRoomWeeklyReportController {
+
+    private final StudyRoomWeeklyReportService reportService;
+
+    @GetMapping
+    public CommonResponse<List<WeeklyReportResponse>> getReports(@PathVariable Long roomId,
+                                                                 @RequestParam(defaultValue = "4") int limit) {
+        return CommonResponse.success(reportService.getReports(roomId, currentUserId(), limit));
+    }
+
+    @PatchMapping("/{reportId}/read")
+    public CommonResponse<WeeklyReportReadResponse> markRead(@PathVariable Long roomId, @PathVariable Long reportId) {
+        return CommonResponse.success(reportService.markRead(roomId, reportId, currentUserId()));
+    }
+
+    private Long currentUserId() {
+        return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomWeeklyReportController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomWeeklyReportController.java
@@ -17,13 +17,14 @@ public class StudyRoomWeeklyReportController {
     private final StudyRoomWeeklyReportService reportService;
 
     @GetMapping
-    public CommonResponse<List<WeeklyReportResponse>> getReports(@PathVariable Long roomId,
-                                                                 @RequestParam(defaultValue = "4") int limit) {
+    public CommonResponse<List<WeeklyReportResponse>> getReports(@PathVariable("roomId") Long roomId,
+                                                                 @RequestParam(value = "limit", defaultValue = "4") int limit) {
         return CommonResponse.success(reportService.getReports(roomId, currentUserId(), limit));
     }
 
     @PatchMapping("/{reportId}/read")
-    public CommonResponse<WeeklyReportReadResponse> markRead(@PathVariable Long roomId, @PathVariable Long reportId) {
+    public CommonResponse<WeeklyReportReadResponse> markRead(@PathVariable("roomId") Long roomId,
+                                                             @PathVariable("reportId") Long reportId) {
         return CommonResponse.success(reportService.markRead(roomId, reportId, currentUserId()));
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudySessionController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudySessionController.java
@@ -16,18 +16,19 @@ public class StudySessionController {
     private final StudySessionService sessionService;
 
     @GetMapping("/active")
-    public CommonResponse<ActiveStudySessionsResponse> getActiveSessions(@PathVariable Long roomId) {
+    public CommonResponse<ActiveStudySessionsResponse> getActiveSessions(@PathVariable("roomId") Long roomId) {
         return CommonResponse.success(sessionService.getActiveSessions(roomId, currentUserId()));
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommonResponse<StudySessionStartResponse> start(@PathVariable Long roomId) {
+    public CommonResponse<StudySessionStartResponse> start(@PathVariable("roomId") Long roomId) {
         return CommonResponse.success(sessionService.start(roomId, currentUserId()));
     }
 
     @PatchMapping("/{sessionId}/end")
-    public CommonResponse<StudySessionEndResponse> end(@PathVariable Long roomId, @PathVariable Long sessionId) {
+    public CommonResponse<StudySessionEndResponse> end(@PathVariable("roomId") Long roomId,
+                                                       @PathVariable("sessionId") Long sessionId) {
         return CommonResponse.success(sessionService.end(roomId, sessionId, currentUserId()));
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudySessionController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudySessionController.java
@@ -1,0 +1,37 @@
+package com.aisip.OnO.backend.studyroom.controller;
+
+import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.service.StudySessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-room/{roomId}/sessions")
+public class StudySessionController {
+
+    private final StudySessionService sessionService;
+
+    @GetMapping("/active")
+    public CommonResponse<ActiveStudySessionsResponse> getActiveSessions(@PathVariable Long roomId) {
+        return CommonResponse.success(sessionService.getActiveSessions(roomId, currentUserId()));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<StudySessionStartResponse> start(@PathVariable Long roomId) {
+        return CommonResponse.success(sessionService.start(roomId, currentUserId()));
+    }
+
+    @PatchMapping("/{sessionId}/end")
+    public CommonResponse<StudySessionEndResponse> end(@PathVariable Long roomId, @PathVariable Long sessionId) {
+        return CommonResponse.success(sessionService.end(roomId, sessionId, currentUserId()));
+    }
+
+    private Long currentUserId() {
+        return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -1,0 +1,105 @@
+package com.aisip.OnO.backend.studyroom.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public final class StudyRoomDtos {
+
+    private StudyRoomDtos() {
+    }
+
+    public record StudyRoomCreateRequest(String name) {
+    }
+
+    public record StudyRoomJoinRequest(String code) {
+    }
+
+    public record StudyRoomGoalUpdateRequest(Integer weeklyGoal) {
+    }
+
+    public record ReactionToggleRequest(String emoji) {
+    }
+
+    public record ChallengeCreateRequest(String title, String type, String metric, Integer targetValue,
+                                         LocalDateTime startAt, LocalDateTime endAt) {
+    }
+
+    public record SharedProblemCreateRequest(Long problemId, String comment) {
+    }
+
+    public record StudyRoomListResponse(Long roomId, String name, Long hostUserId, int memberCount,
+                                        String thumbnailUrl, boolean hasUnreadReport) {
+    }
+
+    public record StudyRoomDetailResponse(Long roomId, String name, Long hostUserId, String thumbnailUrl,
+                                          int memberCount, List<StudyRoomMemberResponse> members) {
+    }
+
+    public record StudyRoomMemberResponse(Long userId, String name, Long totalStudyLevel, int currentStreak,
+                                          int weeklyProblemCount, int weeklyPracticeCount,
+                                          Integer weeklyGoal, Integer goalProgress) {
+    }
+
+    public record InviteCodeResponse(String code, LocalDateTime expiredAt) {
+    }
+
+    public record GoalUpdateResponse(Integer weeklyGoal, Integer goalProgress) {
+    }
+
+    public record PageResponse<T>(List<T> content, int page, int size, long totalElements, boolean hasNext) {
+    }
+
+    public record ReactionResponse(String emoji, long count, boolean reactedByMe) {
+    }
+
+    public record FeedItemResponse(Long feedId, Long userId, String userName, String eventType,
+                                   Map<String, Object> metadata, LocalDateTime createdAt,
+                                   List<ReactionResponse> reactions) {
+    }
+
+    public record FeedReactionToggleResponse(Long feedId, List<ReactionResponse> reactions) {
+    }
+
+    public record ChallengeResponse(Long challengeId, String title, String type, String metric, Integer targetValue,
+                                    LocalDateTime startAt, LocalDateTime endAt, String status,
+                                    List<ChallengeMemberProgressResponse> memberProgress,
+                                    Integer groupCurrent) {
+    }
+
+    public record ChallengeMemberProgressResponse(Long userId, String name, int current, boolean cleared) {
+    }
+
+    public record ActiveStudySessionsResponse(List<ActiveStudySessionResponse> activeSessions) {
+    }
+
+    public record ActiveStudySessionResponse(Long userId, String name, LocalDateTime startedAt) {
+    }
+
+    public record StudySessionStartResponse(Long sessionId, LocalDateTime startedAt) {
+    }
+
+    public record StudySessionEndResponse(Long sessionId, LocalDateTime startedAt, LocalDateTime endedAt,
+                                          Integer durationMinutes) {
+    }
+
+    public record SharedProblemResponse(Long sharedProblemId, Long sharedByUserId, String sharedByName,
+                                        Long problemId, String problemImageUrl, String reference,
+                                        String comment, LocalDateTime sharedAt,
+                                        List<ReactionResponse> reactions) {
+    }
+
+    public record SharedProblemReactionToggleResponse(Long sharedProblemId, List<ReactionResponse> reactions) {
+    }
+
+    public record WeeklyReportResponse(Long reportId, LocalDate weekStart, LocalDate weekEnd,
+                                       String topMemberName, Integer topMemberProblemCount,
+                                       String longestStreakName, Integer longestStreakDays,
+                                       Integer totalProblems, Integer challengesCompleted,
+                                       String cheerMessage, boolean isRead) {
+    }
+
+    public record WeeklyReportReadResponse(Long reportId, boolean isRead) {
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -32,6 +32,9 @@ public final class StudyRoomDtos {
     public record SharedProblemCreateRequest(Long problemId, String comment) {
     }
 
+    public record SharedProblemCommentRequest(String content) {
+    }
+
     public record StudyRoomListResponse(Long roomId, String name, Long hostUserId, int memberCount,
                                         String thumbnailUrl, boolean hasUnreadReport,
                                         int todayPracticeMemberCount, int todayPracticeCount) {
@@ -99,6 +102,11 @@ public final class StudyRoomDtos {
     }
 
     public record SharedProblemReactionToggleResponse(Long sharedProblemId, List<ReactionResponse> reactions) {
+    }
+
+    public record SharedProblemCommentResponse(Long commentId, String content, Long authorId, String authorName,
+                                               String authorProfileImageUrl, LocalDateTime createdAt,
+                                               LocalDateTime updatedAt, boolean isEdited, boolean isMine) {
     }
 
     public record WeeklyReportResponse(Long reportId, LocalDate weekStart, LocalDate weekEnd,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -44,7 +44,8 @@ public final class StudyRoomDtos {
                                           int memberCount, List<StudyRoomMemberResponse> members) {
     }
 
-    public record StudyRoomMemberResponse(Long userId, String name, Long totalStudyLevel, int currentStreak,
+    public record StudyRoomMemberResponse(Long userId, String name, String profileImageUrl,
+                                          Long totalStudyLevel, int currentStreak,
                                           int weeklyProblemCount, int weeklyPracticeCount,
                                           Integer weeklyGoal, Integer goalProgress,
                                           int todayPracticeCount, boolean practicedToday) {
@@ -65,7 +66,7 @@ public final class StudyRoomDtos {
     public record ReactionResponse(String emoji, long count, boolean reactedByMe) {
     }
 
-    public record FeedItemResponse(Long feedId, Long userId, String userName, String eventType,
+    public record FeedItemResponse(Long feedId, Long userId, String userName, String userProfileImageUrl, String eventType,
                                    Map<String, Object> metadata, LocalDateTime createdAt,
                                    List<ReactionResponse> reactions) {
     }
@@ -96,18 +97,22 @@ public final class StudyRoomDtos {
     }
 
     public record SharedProblemResponse(Long sharedProblemId, Long sharedByUserId, String sharedByName,
-                                        Long problemId, String problemImageUrl, String reference,
-                                        String comment, LocalDateTime sharedAt,
+                                        String sharedByProfileImageUrl,
+                                        Long problemId, String problemImageUrl, List<String> problemImageUrls, String reference,
+                                        String comment, long commentCount, LocalDateTime sharedAt,
                                         List<ReactionResponse> reactions) {
     }
 
     public record SharedProblemReactionToggleResponse(Long sharedProblemId, List<ReactionResponse> reactions) {
     }
 
+    public record SharedProblemCommentReactionToggleResponse(Long commentId, List<ReactionResponse> reactions) {
+    }
+
     public record SharedProblemCommentResponse(Long commentId, String content, Long authorId, String authorName,
                                                String authorProfileImageUrl, LocalDateTime createdAt,
                                                LocalDateTime updatedAt, boolean isEdited, boolean isMine,
-                                               boolean canDelete) {
+                                               boolean canDelete, List<ReactionResponse> reactions) {
     }
 
     public record WeeklyReportResponse(Long reportId, LocalDate weekStart, LocalDate weekEnd,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -22,15 +22,16 @@ public final class StudyRoomDtos {
     public record ReactionToggleRequest(String emoji) {
     }
 
-    public record ChallengeCreateRequest(String title, String type, String metric, Integer targetValue,
-                                         LocalDateTime startAt, LocalDateTime endAt) {
+    public record ChallengeCreateRequest(String title, String type, String metric, String period,
+                                         Integer targetValue, LocalDateTime startAt, LocalDateTime endAt) {
     }
 
     public record SharedProblemCreateRequest(Long problemId, String comment) {
     }
 
     public record StudyRoomListResponse(Long roomId, String name, Long hostUserId, int memberCount,
-                                        String thumbnailUrl, boolean hasUnreadReport) {
+                                        String thumbnailUrl, boolean hasUnreadReport,
+                                        int todayPracticeMemberCount, int todayPracticeCount) {
     }
 
     public record StudyRoomDetailResponse(Long roomId, String name, Long hostUserId, String thumbnailUrl,
@@ -39,7 +40,8 @@ public final class StudyRoomDtos {
 
     public record StudyRoomMemberResponse(Long userId, String name, Long totalStudyLevel, int currentStreak,
                                           int weeklyProblemCount, int weeklyPracticeCount,
-                                          Integer weeklyGoal, Integer goalProgress) {
+                                          Integer weeklyGoal, Integer goalProgress,
+                                          int todayPracticeCount) {
     }
 
     public record InviteCodeResponse(String code, LocalDateTime expiredAt) {
@@ -62,8 +64,8 @@ public final class StudyRoomDtos {
     public record FeedReactionToggleResponse(Long feedId, List<ReactionResponse> reactions) {
     }
 
-    public record ChallengeResponse(Long challengeId, String title, String type, String metric, Integer targetValue,
-                                    LocalDateTime startAt, LocalDateTime endAt, String status,
+    public record ChallengeResponse(Long challengeId, String title, String type, String metric, String period,
+                                    Integer targetValue, LocalDateTime startAt, LocalDateTime endAt, String status,
                                     List<ChallengeMemberProgressResponse> memberProgress,
                                     Integer groupCurrent) {
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -26,7 +26,8 @@ public final class StudyRoomDtos {
     }
 
     public record ChallengeCreateRequest(String title, String type, String metric, String period,
-                                         Integer targetValue, LocalDateTime startAt, LocalDateTime endAt) {
+                                         Integer periodDays, Integer targetValue,
+                                         LocalDateTime startAt, LocalDateTime endAt) {
     }
 
     public record SharedProblemCreateRequest(Long problemId, String comment) {
@@ -75,7 +76,8 @@ public final class StudyRoomDtos {
     }
 
     public record ChallengeResponse(Long challengeId, String title, String type, String metric, String period,
-                                    Integer targetValue, LocalDateTime startAt, LocalDateTime endAt, String status,
+                                    Integer periodDays, Integer targetValue,
+                                    LocalDateTime startAt, LocalDateTime endAt, String status,
                                     List<ChallengeMemberProgressResponse> memberProgress,
                                     Integer groupCurrent) {
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -106,7 +106,8 @@ public final class StudyRoomDtos {
 
     public record SharedProblemCommentResponse(Long commentId, String content, Long authorId, String authorName,
                                                String authorProfileImageUrl, LocalDateTime createdAt,
-                                               LocalDateTime updatedAt, boolean isEdited, boolean isMine) {
+                                               LocalDateTime updatedAt, boolean isEdited, boolean isMine,
+                                               boolean canDelete) {
     }
 
     public record WeeklyReportResponse(Long reportId, LocalDate weekStart, LocalDate weekEnd,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -44,6 +44,9 @@ public final class StudyRoomDtos {
                                           int todayPracticeCount) {
     }
 
+    public record StudyRoomThumbnailUpdateResponse(String thumbnailUrl) {
+    }
+
     public record InviteCodeResponse(String code, LocalDateTime expiredAt) {
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -13,6 +13,9 @@ public final class StudyRoomDtos {
     public record StudyRoomCreateRequest(String name) {
     }
 
+    public record StudyRoomUpdateRequest(String name) {
+    }
+
     public record StudyRoomJoinRequest(String code) {
     }
 
@@ -41,7 +44,7 @@ public final class StudyRoomDtos {
     public record StudyRoomMemberResponse(Long userId, String name, Long totalStudyLevel, int currentStreak,
                                           int weeklyProblemCount, int weeklyPracticeCount,
                                           Integer weeklyGoal, Integer goalProgress,
-                                          int todayPracticeCount) {
+                                          int todayPracticeCount, boolean practicedToday) {
     }
 
     public record StudyRoomThumbnailUpdateResponse(String thumbnailUrl) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomStats.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomStats.java
@@ -1,0 +1,4 @@
+package com.aisip.OnO.backend.studyroom.dto;
+
+public record StudyRoomStats(int weeklyProblemCount, int weeklyPracticeCount, int currentStreak) {
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomTodayPracticeSummary.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomTodayPracticeSummary.java
@@ -1,0 +1,8 @@
+package com.aisip.OnO.backend.studyroom.dto;
+
+public record StudyRoomTodayPracticeSummary(int todayPracticeMemberCount, int todayPracticeCount) {
+
+    public static StudyRoomTodayPracticeSummary empty() {
+        return new StudyRoomTodayPracticeSummary(0, 0);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoom.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoom.java
@@ -53,4 +53,8 @@ public class StudyRoom extends BaseEntity {
     public void updateHostUserId(Long hostUserId) {
         this.hostUserId = hostUserId;
     }
+
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoom.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoom.java
@@ -1,0 +1,56 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room", indexes = {
+        @Index(name = "idx_study_room_host_user", columnList = "host_user_id")
+})
+public class StudyRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Version
+    private Long version;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Column(name = "host_user_id", nullable = false)
+    private Long hostUserId;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<StudyRoomMember> members = new ArrayList<>();
+
+    public static StudyRoom create(String name, Long hostUserId) {
+        return StudyRoom.builder()
+                .name(name)
+                .hostUserId(hostUserId)
+                .members(new ArrayList<>())
+                .build();
+    }
+
+    public void addMember(StudyRoomMember member) {
+        members.add(member);
+        member.updateRoom(this);
+    }
+
+    public void updateHostUserId(Long hostUserId) {
+        this.hostUserId = hostUserId;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoom.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoom.java
@@ -54,6 +54,10 @@ public class StudyRoom extends BaseEntity {
         this.hostUserId = hostUserId;
     }
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
     public void updateThumbnailUrl(String thumbnailUrl) {
         this.thumbnailUrl = thumbnailUrl;
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
@@ -1,0 +1,69 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_challenge", indexes = {
+        @Index(name = "idx_study_room_challenge_room_status_end", columnList = "room_id, status, end_at")
+})
+public class StudyRoomChallenge extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom room;
+
+    @Column(nullable = false, length = 40)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StudyRoomChallengeType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private StudyRoomChallengeMetric metric;
+
+    @Column(name = "target_value", nullable = false)
+    private Integer targetValue;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StudyRoomChallengeStatus status;
+
+    public static StudyRoomChallenge create(StudyRoom room, String title, StudyRoomChallengeType type,
+                                            StudyRoomChallengeMetric metric, Integer targetValue,
+                                            LocalDateTime startAt, LocalDateTime endAt) {
+        return StudyRoomChallenge.builder()
+                .room(room)
+                .title(title)
+                .type(type)
+                .metric(metric)
+                .targetValue(targetValue)
+                .startAt(startAt)
+                .endAt(endAt)
+                .status(StudyRoomChallengeStatus.IN_PROGRESS)
+                .build();
+    }
+
+    public void updateStatus(StudyRoomChallengeStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
@@ -39,6 +39,9 @@ public class StudyRoomChallenge extends BaseEntity {
     @Column(name = "period", length = 20)
     private StudyRoomChallengePeriod period;
 
+    @Column(name = "period_days")
+    private Integer periodDays;
+
     @Column(name = "target_value", nullable = false)
     private Integer targetValue;
 
@@ -54,13 +57,15 @@ public class StudyRoomChallenge extends BaseEntity {
 
     public static StudyRoomChallenge create(StudyRoom room, String title, StudyRoomChallengeType type,
                                             StudyRoomChallengeMetric metric, StudyRoomChallengePeriod period,
-                                            Integer targetValue, LocalDateTime startAt, LocalDateTime endAt) {
+                                            Integer periodDays, Integer targetValue,
+                                            LocalDateTime startAt, LocalDateTime endAt) {
         return StudyRoomChallenge.builder()
                 .room(room)
                 .title(title)
                 .type(type)
                 .metric(metric)
                 .period(period)
+                .periodDays(periodDays)
                 .targetValue(targetValue)
                 .startAt(startAt)
                 .endAt(endAt)

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
@@ -35,6 +35,10 @@ public class StudyRoomChallenge extends BaseEntity {
     @Column(nullable = false, length = 40)
     private StudyRoomChallengeMetric metric;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "period", length = 20)
+    private StudyRoomChallengePeriod period;
+
     @Column(name = "target_value", nullable = false)
     private Integer targetValue;
 
@@ -49,13 +53,14 @@ public class StudyRoomChallenge extends BaseEntity {
     private StudyRoomChallengeStatus status;
 
     public static StudyRoomChallenge create(StudyRoom room, String title, StudyRoomChallengeType type,
-                                            StudyRoomChallengeMetric metric, Integer targetValue,
-                                            LocalDateTime startAt, LocalDateTime endAt) {
+                                            StudyRoomChallengeMetric metric, StudyRoomChallengePeriod period,
+                                            Integer targetValue, LocalDateTime startAt, LocalDateTime endAt) {
         return StudyRoomChallenge.builder()
                 .room(room)
                 .title(title)
                 .type(type)
                 .metric(metric)
+                .period(period)
                 .targetValue(targetValue)
                 .startAt(startAt)
                 .endAt(endAt)

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeMetric.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeMetric.java
@@ -1,7 +1,15 @@
 package com.aisip.OnO.backend.studyroom.entity;
 
 public enum StudyRoomChallengeMetric {
+    PROBLEM_COUNT,
+    PRACTICE_COUNT,
+    ATTENDANCE,
+
+    // 기존에 저장된 챌린지 역직렬화 호환용 — 신규 생성 시에는 사용하지 않는다.
+    @Deprecated
     WEEKLY_PROBLEM_COUNT,
+    @Deprecated
     WEEKLY_PRACTICE_COUNT,
+    @Deprecated
     STREAK
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeMetric.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeMetric.java
@@ -1,0 +1,7 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+public enum StudyRoomChallengeMetric {
+    WEEKLY_PROBLEM_COUNT,
+    WEEKLY_PRACTICE_COUNT,
+    STREAK
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengePeriod.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengePeriod.java
@@ -1,0 +1,7 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+public enum StudyRoomChallengePeriod {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeStatus.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeStatus.java
@@ -1,0 +1,8 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+public enum StudyRoomChallengeStatus {
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED,
+    EXPIRED
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeType.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallengeType.java
@@ -1,0 +1,7 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+public enum StudyRoomChallengeType {
+    INDIVIDUAL,
+    GROUP,
+    STREAK
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeed.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeed.java
@@ -1,0 +1,50 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_feed", indexes = {
+        @Index(name = "idx_study_room_feed_room_created", columnList = "room_id, created_at"),
+        @Index(name = "idx_study_room_feed_room_user_type_created", columnList = "room_id, user_id, event_type, created_at")
+})
+public class StudyRoomFeed extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 40)
+    private StudyRoomFeedEventType eventType;
+
+    @Column(name = "metadata_json", columnDefinition = "TEXT")
+    private String metadataJson;
+
+    public static StudyRoomFeed create(StudyRoom room, User user, StudyRoomFeedEventType eventType, String metadataJson) {
+        return StudyRoomFeed.builder()
+                .room(room)
+                .user(user)
+                .eventType(eventType)
+                .metadataJson(metadataJson)
+                .build();
+    }
+
+    public void updateMetadataJson(String metadataJson) {
+        this.metadataJson = metadataJson;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeedEventType.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeedEventType.java
@@ -1,0 +1,11 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+public enum StudyRoomFeedEventType {
+    PROBLEM_REGISTERED,
+    PRACTICE_COMPLETED,
+    STREAK_MILESTONE,
+    LEVEL_UP,
+    CHALLENGE_CLEARED,
+    SESSION_STARTED,
+    PROBLEM_SHARED
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeedReaction.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeedReaction.java
@@ -26,7 +26,7 @@ public class StudyRoomFeedReaction extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, length = 16)
+    @Column(nullable = false, length = 80)
     private String emoji;
 
     public static StudyRoomFeedReaction create(StudyRoomFeed feed, User user, String emoji) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeedReaction.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomFeedReaction.java
@@ -1,0 +1,39 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_feed_reaction",
+        uniqueConstraints = @UniqueConstraint(name = "uk_study_room_feed_reaction", columnNames = {"feed_id", "user_id", "emoji"}))
+public class StudyRoomFeedReaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private StudyRoomFeed feed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 16)
+    private String emoji;
+
+    public static StudyRoomFeedReaction create(StudyRoomFeed feed, User user, String emoji) {
+        return StudyRoomFeedReaction.builder()
+                .feed(feed)
+                .user(user)
+                .emoji(emoji)
+                .build();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomInviteCode.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomInviteCode.java
@@ -1,0 +1,44 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_invite_code",
+        uniqueConstraints = @UniqueConstraint(name = "uk_study_room_invite_code", columnNames = "code"),
+        indexes = @Index(name = "idx_study_room_invite_room", columnList = "room_id"))
+public class StudyRoomInviteCode extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom room;
+
+    @Column(nullable = false, length = 6)
+    private String code;
+
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    public static StudyRoomInviteCode create(StudyRoom room, String code, LocalDateTime expiredAt) {
+        return StudyRoomInviteCode.builder()
+                .room(room)
+                .code(code)
+                .expiredAt(expiredAt)
+                .build();
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return !expiredAt.isAfter(now);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomMember.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomMember.java
@@ -1,0 +1,58 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_member",
+        uniqueConstraints = @UniqueConstraint(name = "uk_study_room_member_room_user", columnNames = {"room_id", "user_id"}),
+        indexes = {
+                @Index(name = "idx_study_room_member_user", columnList = "user_id"),
+                @Index(name = "idx_study_room_member_room", columnList = "room_id")
+        })
+public class StudyRoomMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StudyRoomMemberRole role;
+
+    @Column(name = "weekly_goal")
+    private Integer weeklyGoal;
+
+    public static StudyRoomMember create(User user, StudyRoomMemberRole role) {
+        return StudyRoomMember.builder()
+                .user(user)
+                .role(role)
+                .build();
+    }
+
+    public void updateRoom(StudyRoom room) {
+        this.room = room;
+    }
+
+    public void updateWeeklyGoal(Integer weeklyGoal) {
+        this.weeklyGoal = weeklyGoal;
+    }
+
+    public void promoteToHost() {
+        this.role = StudyRoomMemberRole.HOST;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomMemberRole.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomMemberRole.java
@@ -1,0 +1,6 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+public enum StudyRoomMemberRole {
+    HOST,
+    MEMBER
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblem.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblem.java
@@ -1,0 +1,47 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_shared_problem", indexes = {
+        @Index(name = "idx_study_room_shared_problem_room_created", columnList = "room_id, created_at"),
+        @Index(name = "idx_study_room_shared_problem_problem", columnList = "problem_id")
+})
+public class StudyRoomSharedProblem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shared_by_user_id", nullable = false)
+    private User sharedByUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Column(length = 100)
+    private String comment;
+
+    public static StudyRoomSharedProblem create(StudyRoom room, User sharedByUser, Problem problem, String comment) {
+        return StudyRoomSharedProblem.builder()
+                .room(room)
+                .sharedByUser(sharedByUser)
+                .problem(problem)
+                .comment(comment)
+                .build();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemComment.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemComment.java
@@ -1,0 +1,45 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_shared_problem_comment", indexes = {
+        @Index(name = "idx_shared_problem_comment_problem_id", columnList = "shared_problem_id, id"),
+        @Index(name = "idx_shared_problem_comment_author", columnList = "author_id")
+})
+public class StudyRoomSharedProblemComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shared_problem_id", nullable = false)
+    private StudyRoomSharedProblem sharedProblem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    public static StudyRoomSharedProblemComment create(StudyRoomSharedProblem sharedProblem, User author, String content) {
+        return StudyRoomSharedProblemComment.builder()
+                .sharedProblem(sharedProblem)
+                .author(author)
+                .content(content)
+                .build();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemCommentReaction.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemCommentReaction.java
@@ -1,0 +1,43 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_shared_problem_comment_reaction",
+        uniqueConstraints = @UniqueConstraint(name = "uk_shared_problem_comment_reaction", columnNames = {"comment_id", "user_id", "emoji"}),
+        indexes = {
+                @Index(name = "idx_shared_problem_comment_reaction_comment", columnList = "comment_id"),
+                @Index(name = "idx_shared_problem_comment_reaction_user", columnList = "user_id")
+        })
+public class StudyRoomSharedProblemCommentReaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private StudyRoomSharedProblemComment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 80)
+    private String emoji;
+
+    public static StudyRoomSharedProblemCommentReaction create(StudyRoomSharedProblemComment comment, User user, String emoji) {
+        return StudyRoomSharedProblemCommentReaction.builder()
+                .comment(comment)
+                .user(user)
+                .emoji(emoji)
+                .build();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemReaction.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemReaction.java
@@ -1,0 +1,39 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_shared_problem_reaction",
+        uniqueConstraints = @UniqueConstraint(name = "uk_study_room_shared_problem_reaction", columnNames = {"shared_problem_id", "user_id", "emoji"}))
+public class StudyRoomSharedProblemReaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shared_problem_id", nullable = false)
+    private StudyRoomSharedProblem sharedProblem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 16)
+    private String emoji;
+
+    public static StudyRoomSharedProblemReaction create(StudyRoomSharedProblem sharedProblem, User user, String emoji) {
+        return StudyRoomSharedProblemReaction.builder()
+                .sharedProblem(sharedProblem)
+                .user(user)
+                .emoji(emoji)
+                .build();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemReaction.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomSharedProblemReaction.java
@@ -26,7 +26,7 @@ public class StudyRoomSharedProblemReaction extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, length = 16)
+    @Column(nullable = false, length = 80)
     private String emoji;
 
     public static StudyRoomSharedProblemReaction create(StudyRoomSharedProblem sharedProblem, User user, String emoji) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomWeeklyReport.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomWeeklyReport.java
@@ -1,0 +1,70 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_weekly_report",
+        uniqueConstraints = @UniqueConstraint(name = "uk_study_room_weekly_report", columnNames = {"room_id", "week_start"}))
+public class StudyRoomWeeklyReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom room;
+
+    @Column(name = "week_start", nullable = false)
+    private LocalDate weekStart;
+
+    @Column(name = "week_end", nullable = false)
+    private LocalDate weekEnd;
+
+    @Column(name = "top_member_name")
+    private String topMemberName;
+
+    @Column(name = "top_member_problem_count", nullable = false)
+    private Integer topMemberProblemCount;
+
+    @Column(name = "longest_streak_name")
+    private String longestStreakName;
+
+    @Column(name = "longest_streak_days", nullable = false)
+    private Integer longestStreakDays;
+
+    @Column(name = "total_problems", nullable = false)
+    private Integer totalProblems;
+
+    @Column(name = "challenges_completed", nullable = false)
+    private Integer challengesCompleted;
+
+    @Column(name = "cheer_message", nullable = false)
+    private String cheerMessage;
+
+    public static StudyRoomWeeklyReport create(StudyRoom room, LocalDate weekStart, LocalDate weekEnd,
+                                               String topMemberName, int topMemberProblemCount,
+                                               String longestStreakName, int longestStreakDays,
+                                               int totalProblems, int challengesCompleted, String cheerMessage) {
+        return StudyRoomWeeklyReport.builder()
+                .room(room)
+                .weekStart(weekStart)
+                .weekEnd(weekEnd)
+                .topMemberName(topMemberName)
+                .topMemberProblemCount(topMemberProblemCount)
+                .longestStreakName(longestStreakName)
+                .longestStreakDays(longestStreakDays)
+                .totalProblems(totalProblems)
+                .challengesCompleted(challengesCompleted)
+                .cheerMessage(cheerMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomWeeklyReportRead.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomWeeklyReportRead.java
@@ -1,0 +1,41 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_room_weekly_report_read",
+        uniqueConstraints = @UniqueConstraint(name = "uk_study_room_weekly_report_read", columnNames = {"report_id", "user_id"}))
+public class StudyRoomWeeklyReportRead extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private StudyRoomWeeklyReport report;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "read_at", nullable = false)
+    private LocalDateTime readAt;
+
+    public static StudyRoomWeeklyReportRead create(StudyRoomWeeklyReport report, User user, LocalDateTime readAt) {
+        return StudyRoomWeeklyReportRead.builder()
+                .report(report)
+                .user(user)
+                .readAt(readAt)
+                .build();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudySession.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudySession.java
@@ -1,0 +1,55 @@
+package com.aisip.OnO.backend.studyroom.entity;
+
+import com.aisip.OnO.backend.common.entity.BaseEntity;
+import com.aisip.OnO.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_session", indexes = {
+        @Index(name = "idx_study_session_room_ended", columnList = "room_id, ended_at"),
+        @Index(name = "idx_study_session_user_ended", columnList = "user_id, ended_at")
+})
+public class StudySession extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    @Column(name = "duration_minutes")
+    private Integer durationMinutes;
+
+    public static StudySession start(StudyRoom room, User user, LocalDateTime startedAt) {
+        return StudySession.builder()
+                .room(room)
+                .user(user)
+                .startedAt(startedAt)
+                .build();
+    }
+
+    public void end(LocalDateTime endedAt) {
+        this.endedAt = endedAt;
+        this.durationMinutes = Math.toIntExact(Math.max(0, Duration.between(startedAt, endedAt).toMinutes()));
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/event/StudyRoomActivityEvent.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/event/StudyRoomActivityEvent.java
@@ -1,0 +1,8 @@
+package com.aisip.OnO.backend.studyroom.event;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+
+import java.util.Map;
+
+public record StudyRoomActivityEvent(Long userId, StudyRoomFeedEventType eventType, Map<String, Object> metadata) {
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
@@ -1,0 +1,31 @@
+package com.aisip.OnO.backend.studyroom.exception;
+
+import com.aisip.OnO.backend.common.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StudyRoomErrorCase implements ErrorCase {
+
+    STUDY_ROOM_NOT_FOUND(404, 10001, "스터디룸을 찾을 수 없습니다."),
+    STUDY_ROOM_FORBIDDEN(403, 10002, "스터디룸 멤버만 접근할 수 있습니다."),
+    STUDY_ROOM_HOST_ONLY(403, 10003, "스터디룸 방장만 사용할 수 있습니다."),
+    STUDY_ROOM_FULL(409, 10004, "스터디룸 최대 인원을 초과했습니다."),
+    STUDY_ROOM_LIMIT_EXCEEDED(409, 10005, "참여 가능한 스터디룸 수를 초과했습니다."),
+    INVITE_CODE_INVALID(400, 10006, "초대 코드가 유효하지 않습니다."),
+    INVITE_CODE_EXPIRED(400, 10007, "초대 코드가 만료되었습니다."),
+    ALREADY_MEMBER(409, 10008, "이미 참여 중인 스터디룸입니다."),
+    CHALLENGE_NOT_FOUND(404, 10009, "챌린지를 찾을 수 없습니다."),
+    CHALLENGE_LIMIT_EXCEEDED(409, 10010, "진행 중인 챌린지 수를 초과했습니다."),
+    SESSION_ALREADY_ACTIVE(409, 10011, "이미 진행 중인 공부 세션이 있습니다."),
+    SESSION_NOT_FOUND(404, 10012, "공부 세션을 찾을 수 없습니다."),
+    SHARED_PROBLEM_NOT_FOUND(404, 10013, "공유 문제를 찾을 수 없습니다."),
+    REPORT_NOT_FOUND(404, 10014, "주간 리포트를 찾을 수 없습니다."),
+    INVALID_REACTION_EMOJI(400, 10015, "허용되지 않은 반응입니다."),
+    INVALID_STUDY_ROOM_REQUEST(400, 10016, "스터디룸 요청 값이 올바르지 않습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
@@ -24,7 +24,9 @@ public enum StudyRoomErrorCase implements ErrorCase {
     REPORT_NOT_FOUND(404, 10014, "주간 리포트를 찾을 수 없습니다."),
     INVALID_REACTION_EMOJI(400, 10015, "허용되지 않은 반응입니다."),
     INVALID_STUDY_ROOM_REQUEST(400, 10016, "스터디룸 요청 값이 올바르지 않습니다."),
-    SHARED_PROBLEM_COMMENT_NOT_FOUND(404, 10017, "공유 문제 댓글을 찾을 수 없습니다.");
+    SHARED_PROBLEM_COMMENT_NOT_FOUND(404, 10017, "공유 문제 댓글을 찾을 수 없습니다."),
+    INVALID_SHARED_PROBLEM_COMMENT(400, 10018, "공유 문제 댓글 내용이 올바르지 않습니다."),
+    SHARED_PROBLEM_COMMENT_FORBIDDEN(403, 10019, "공유 문제 댓글에 대한 권한이 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
@@ -23,7 +23,8 @@ public enum StudyRoomErrorCase implements ErrorCase {
     SHARED_PROBLEM_NOT_FOUND(404, 10013, "공유 문제를 찾을 수 없습니다."),
     REPORT_NOT_FOUND(404, 10014, "주간 리포트를 찾을 수 없습니다."),
     INVALID_REACTION_EMOJI(400, 10015, "허용되지 않은 반응입니다."),
-    INVALID_STUDY_ROOM_REQUEST(400, 10016, "스터디룸 요청 값이 올바르지 않습니다.");
+    INVALID_STUDY_ROOM_REQUEST(400, 10016, "스터디룸 요청 값이 올바르지 않습니다."),
+    SHARED_PROBLEM_COMMENT_NOT_FOUND(404, 10017, "공유 문제 댓글을 찾을 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/exception/StudyRoomErrorCase.java
@@ -26,7 +26,8 @@ public enum StudyRoomErrorCase implements ErrorCase {
     INVALID_STUDY_ROOM_REQUEST(400, 10016, "스터디룸 요청 값이 올바르지 않습니다."),
     SHARED_PROBLEM_COMMENT_NOT_FOUND(404, 10017, "공유 문제 댓글을 찾을 수 없습니다."),
     INVALID_SHARED_PROBLEM_COMMENT(400, 10018, "공유 문제 댓글 내용이 올바르지 않습니다."),
-    SHARED_PROBLEM_COMMENT_FORBIDDEN(403, 10019, "공유 문제 댓글에 대한 권한이 없습니다.");
+    SHARED_PROBLEM_COMMENT_FORBIDDEN(403, 10019, "공유 문제 댓글에 대한 권한이 없습니다."),
+    ALREADY_SHARED_PROBLEM(409, 10020, "이미 공유된 문제입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/aisip/OnO/backend/studyroom/quartz/ChallengeNotificationJob.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/quartz/ChallengeNotificationJob.java
@@ -1,0 +1,50 @@
+package com.aisip.OnO.backend.studyroom.quartz;
+
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.util.fcm.dto.NotificationRequestDto;
+import com.aisip.OnO.backend.util.fcm.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeNotificationJob implements Job {
+
+    private final StudyRoomMemberRepository memberRepository;
+    private final FcmService fcmService;
+
+    @Override
+    public void execute(JobExecutionContext context) {
+        JobDataMap dataMap = context.getMergedJobDataMap();
+        Long roomId = Long.parseLong(dataMap.getString("roomId"));
+        String challengeTitle = dataMap.getString("challengeTitle");
+        String notificationType = dataMap.getString("notificationType");
+
+        String title, body;
+        if ("HALFWAY".equals(notificationType)) {
+            title = "챌린지 중간 알림";
+            body = "'" + challengeTitle + "' 챌린지가 절반 지났어요! 목표를 향해 달려가세요.";
+        } else {
+            title = "챌린지 마감 D-1";
+            body = "'" + challengeTitle + "' 챌린지가 내일 마감돼요. 마무리 스퍼트!";
+        }
+
+        NotificationRequestDto dto = new NotificationRequestDto(null, title, body,
+                Map.of("type", "CHALLENGE_NOTIFICATION", "roomId", String.valueOf(roomId)));
+
+        memberRepository.findAllWithUserByRoomId(roomId).forEach(member -> {
+            try {
+                fcmService.sendNotificationToAllUserDevice(member.getUser().getId(), dto);
+            } catch (Exception e) {
+                log.warn("챌린지 알림 발송 실패 - userId: {}", member.getUser().getId(), e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/quartz/ChallengeNotificationScheduler.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/quartz/ChallengeNotificationScheduler.java
@@ -1,0 +1,80 @@
+package com.aisip.OnO.backend.studyroom.quartz;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomChallenge;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeNotificationScheduler {
+
+    private static final String GROUP = "CHALLENGE_NOTIFICATION";
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    private final Scheduler scheduler;
+
+    public void scheduleNotifications(StudyRoomChallenge challenge) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startAt = challenge.getStartAt();
+        LocalDateTime endAt = challenge.getEndAt();
+
+        LocalDateTime halfwayAt = startAt.plus(Duration.between(startAt, endAt).dividedBy(2));
+        if (halfwayAt.isAfter(now)) {
+            schedule(challenge, "HALFWAY", halfwayAt);
+        }
+
+        LocalDateTime oneDayBeforeAt = endAt.minusDays(1);
+        if (oneDayBeforeAt.isAfter(now)) {
+            schedule(challenge, "ONE_DAY_LEFT", oneDayBeforeAt);
+        }
+    }
+
+    public void cancelNotifications(Long challengeId) {
+        cancelJob(challengeId, "HALFWAY");
+        cancelJob(challengeId, "ONE_DAY_LEFT");
+    }
+
+    private void schedule(StudyRoomChallenge challenge, String type, LocalDateTime fireAt) {
+        try {
+            String key = "challenge-" + challenge.getId() + "-" + type;
+            JobDataMap dataMap = new JobDataMap();
+            dataMap.put("roomId", String.valueOf(challenge.getRoom().getId()));
+            dataMap.put("challengeTitle", challenge.getTitle());
+            dataMap.put("notificationType", type);
+
+            JobDetail jobDetail = JobBuilder.newJob(ChallengeNotificationJob.class)
+                    .withIdentity(key, GROUP)
+                    .usingJobData(dataMap)
+                    .build();
+
+            Trigger trigger = TriggerBuilder.newTrigger()
+                    .withIdentity(key, GROUP)
+                    .startAt(Date.from(fireAt.atZone(ZONE).toInstant()))
+                    .withSchedule(SimpleScheduleBuilder.simpleSchedule())
+                    .build();
+
+            scheduler.scheduleJob(jobDetail, trigger);
+            log.info("챌린지 알림 등록 - challengeId: {}, type: {}, fireAt: {}", challenge.getId(), type, fireAt);
+        } catch (SchedulerException e) {
+            log.warn("챌린지 알림 등록 실패 - challengeId: {}, type: {}", challenge.getId(), type, e);
+        }
+    }
+
+    private void cancelJob(Long challengeId, String type) {
+        try {
+            String key = "challenge-" + challengeId + "-" + type;
+            scheduler.unscheduleJob(TriggerKey.triggerKey(key, GROUP));
+            scheduler.deleteJob(JobKey.jobKey(key, GROUP));
+        } catch (SchedulerException e) {
+            log.warn("챌린지 알림 취소 실패 - challengeId: {}, type: {}", challengeId, type, e);
+        }
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/quartz/StudyRoomScheduler.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/quartz/StudyRoomScheduler.java
@@ -1,0 +1,43 @@
+package com.aisip.OnO.backend.studyroom.quartz;
+
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StudyRoomScheduler {
+
+    @Bean
+    public JobDetail studyRoomWeeklyReportJobDetail() {
+        return JobBuilder.newJob(StudyRoomWeeklyReportJob.class)
+                .withIdentity("studyRoomWeeklyReportJob")
+                .storeDurably()
+                .build();
+    }
+
+    @Bean
+    public Trigger studyRoomWeeklyReportTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(studyRoomWeeklyReportJobDetail())
+                .withIdentity("studyRoomWeeklyReportTrigger")
+                .withSchedule(CronScheduleBuilder.cronSchedule("0 0 8 ? * MON").inTimeZone(java.util.TimeZone.getTimeZone("Asia/Seoul")))
+                .build();
+    }
+
+    @Bean
+    public JobDetail studySessionCleanupJobDetail() {
+        return JobBuilder.newJob(StudySessionCleanupJob.class)
+                .withIdentity("studySessionCleanupJob")
+                .storeDurably()
+                .build();
+    }
+
+    @Bean
+    public Trigger studySessionCleanupTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(studySessionCleanupJobDetail())
+                .withIdentity("studySessionCleanupTrigger")
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule().withIntervalInHours(1).repeatForever())
+                .build();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/quartz/StudyRoomWeeklyReportJob.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/quartz/StudyRoomWeeklyReportJob.java
@@ -1,0 +1,19 @@
+package com.aisip.OnO.backend.studyroom.quartz;
+
+import com.aisip.OnO.backend.studyroom.service.StudyRoomWeeklyReportService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StudyRoomWeeklyReportJob implements Job {
+
+    private final StudyRoomWeeklyReportService reportService;
+
+    @Override
+    public void execute(JobExecutionContext context) {
+        reportService.createPreviousWeekReports();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/quartz/StudySessionCleanupJob.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/quartz/StudySessionCleanupJob.java
@@ -1,0 +1,22 @@
+package com.aisip.OnO.backend.studyroom.quartz;
+
+import com.aisip.OnO.backend.studyroom.service.StudySessionService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class StudySessionCleanupJob implements Job {
+
+    private final StudySessionService sessionService;
+
+    @Override
+    public void execute(JobExecutionContext context) {
+        LocalDateTime now = LocalDateTime.now();
+        sessionService.closeExpiredSessions(now.minusHours(12), now);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomChallengeRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomChallengeRepository.java
@@ -1,0 +1,41 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomChallenge;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomChallengeStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface StudyRoomChallengeRepository extends JpaRepository<StudyRoomChallenge, Long> {
+
+    List<StudyRoomChallenge> findAllByRoomIdOrderByEndAtAsc(Long roomId);
+
+    @Query("select c from StudyRoomChallenge c " +
+            "where c.room.id = :roomId and c.status = :status and c.endAt >= :now " +
+            "order by c.endAt asc")
+    List<StudyRoomChallenge> findActiveByRoomId(@Param("roomId") Long roomId,
+                                                @Param("status") StudyRoomChallengeStatus status,
+                                                @Param("now") LocalDateTime now);
+
+    Optional<StudyRoomChallenge> findByIdAndRoomId(Long id, Long roomId);
+
+    long countByRoomIdAndStatus(Long roomId, StudyRoomChallengeStatus status);
+
+    @Query("select c from StudyRoomChallenge c where c.room.id in :roomIds and c.status = :status")
+    List<StudyRoomChallenge> findAllByRoomIdsAndStatus(@Param("roomIds") Collection<Long> roomIds,
+                                                       @Param("status") StudyRoomChallengeStatus status);
+
+    @Query("select c.room.id, count(c.id) from StudyRoomChallenge c " +
+            "where c.room.id in :roomIds and c.status = :status and c.endAt between :start and :end " +
+            "group by c.room.id")
+    List<Object[]> countByRoomIdsAndStatusAndEndAtBetween(@Param("roomIds") Collection<Long> roomIds,
+                                                          @Param("status") StudyRoomChallengeStatus status,
+                                                          @Param("start") LocalDateTime start,
+                                                          @Param("end") LocalDateTime end);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomFeedReactionRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomFeedReactionRepository.java
@@ -1,0 +1,20 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomFeedReactionRepository extends JpaRepository<StudyRoomFeedReaction, Long> {
+
+    Optional<StudyRoomFeedReaction> findByFeedIdAndUserIdAndEmoji(Long feedId, Long userId, String emoji);
+
+    @Query("select r from StudyRoomFeedReaction r where r.feed.id in :feedIds")
+    List<StudyRoomFeedReaction> findAllByFeedIds(@Param("feedIds") Collection<Long> feedIds);
+
+    List<StudyRoomFeedReaction> findAllByFeedId(Long feedId);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomFeedRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomFeedRepository.java
@@ -1,0 +1,31 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeed;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomFeedRepository extends JpaRepository<StudyRoomFeed, Long> {
+
+    @Query("select f from StudyRoomFeed f join fetch f.user where f.room.id = :roomId order by f.createdAt desc")
+    Page<StudyRoomFeed> findPageWithUserByRoomId(@Param("roomId") Long roomId, Pageable pageable);
+
+    @Query("select f from StudyRoomFeed f join fetch f.user " +
+            "where f.room.id = :roomId and (:cursor is null or f.id < :cursor) " +
+            "order by f.id desc")
+    List<StudyRoomFeed> findWithUserByRoomIdAndCursor(@Param("roomId") Long roomId,
+                                                      @Param("cursor") Long cursor,
+                                                      Pageable pageable);
+
+    Optional<StudyRoomFeed> findByIdAndRoomId(Long id, Long roomId);
+
+    Optional<StudyRoomFeed> findTopByRoomIdAndUserIdAndEventTypeAndCreatedAtBetweenOrderByCreatedAtDesc(
+            Long roomId, Long userId, StudyRoomFeedEventType eventType, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomInviteCodeRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomInviteCodeRepository.java
@@ -1,0 +1,23 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomInviteCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface StudyRoomInviteCodeRepository extends JpaRepository<StudyRoomInviteCode, Long> {
+
+    Optional<StudyRoomInviteCode> findTopByRoomIdOrderByExpiredAtDesc(Long roomId);
+
+    Optional<StudyRoomInviteCode> findByCode(String code);
+
+    boolean existsByCode(String code);
+
+    @Modifying
+    @Query("delete from StudyRoomInviteCode c where c.expiredAt < :threshold")
+    void deleteExpiredBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomMemberRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomMemberRepository.java
@@ -1,0 +1,40 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Collection;
+
+public interface StudyRoomMemberRepository extends JpaRepository<StudyRoomMember, Long> {
+
+    Optional<StudyRoomMember> findByRoomIdAndUserId(Long roomId, Long userId);
+
+    boolean existsByRoomIdAndUserId(Long roomId, Long userId);
+
+    long countByRoomId(Long roomId);
+
+    long countByUserId(Long userId);
+
+    long countByRoomIdAndRole(Long roomId, StudyRoomMemberRole role);
+
+    List<StudyRoomMember> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query("select m from StudyRoomMember m join fetch m.user where m.room.id = :roomId order by m.createdAt asc")
+    List<StudyRoomMember> findAllWithUserByRoomId(@Param("roomId") Long roomId);
+
+    @Query("select m from StudyRoomMember m join fetch m.room join fetch m.user where m.room.id in :roomIds order by m.room.id asc, m.createdAt asc")
+    List<StudyRoomMember> findAllWithRoomAndUserByRoomIds(@Param("roomIds") Collection<Long> roomIds);
+
+    @Query("select m from StudyRoomMember m join fetch m.room where m.user.id = :userId order by m.createdAt desc")
+    List<StudyRoomMember> findAllWithRoomByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("delete from StudyRoomMember m where m.room.id = :roomId and m.user.id = :userId")
+    void deleteByRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomMemberRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomMemberRepository.java
@@ -34,6 +34,14 @@ public interface StudyRoomMemberRepository extends JpaRepository<StudyRoomMember
     @Query("select m from StudyRoomMember m join fetch m.room where m.user.id = :userId order by m.createdAt desc")
     List<StudyRoomMember> findAllWithRoomByUserId(@Param("userId") Long userId);
 
+    @Query("""
+            select m.room.id, count(m.id)
+            from StudyRoomMember m
+            where m.room.id in :roomIds
+            group by m.room.id
+            """)
+    List<Object[]> countMembersByRoomIds(@Param("roomIds") Collection<Long> roomIds);
+
     @Modifying
     @Query("delete from StudyRoomMember m where m.room.id = :roomId and m.user.id = :userId")
     void deleteByRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomRepository.java
@@ -1,0 +1,22 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from StudyRoom r where r.id = :roomId")
+    Optional<StudyRoom> findByIdForUpdate(@Param("roomId") Long roomId);
+
+    @Query("select r from StudyRoom r where r.id > :cursor order by r.id asc")
+    List<StudyRoom> findBatchAfterId(@Param("cursor") Long cursor, Pageable pageable);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentReactionRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentReactionRepository.java
@@ -1,0 +1,38 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemCommentReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomSharedProblemCommentReactionRepository extends JpaRepository<StudyRoomSharedProblemCommentReaction, Long> {
+
+    Optional<StudyRoomSharedProblemCommentReaction> findByCommentIdAndUserIdAndEmoji(Long commentId, Long userId, String emoji);
+
+    @Query("select r from StudyRoomSharedProblemCommentReaction r where r.comment.id = :commentId")
+    List<StudyRoomSharedProblemCommentReaction> findAllByCommentId(@Param("commentId") Long commentId);
+
+    @Query("select r from StudyRoomSharedProblemCommentReaction r where r.comment.id in :commentIds")
+    List<StudyRoomSharedProblemCommentReaction> findAllByCommentIds(@Param("commentIds") Collection<Long> commentIds);
+
+    @Modifying
+    @Query("delete from StudyRoomSharedProblemCommentReaction r where r.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("delete from StudyRoomSharedProblemCommentReaction r where r.comment.id = :commentId")
+    void deleteByCommentId(@Param("commentId") Long commentId);
+
+    @Modifying
+    @Query("delete from StudyRoomSharedProblemCommentReaction r where r.comment.sharedProblem.id = :sharedProblemId")
+    void deleteBySharedProblemId(@Param("sharedProblemId") Long sharedProblemId);
+
+    @Modifying
+    @Query("delete from StudyRoomSharedProblemCommentReaction r where r.comment.author.id = :authorId")
+    void deleteByCommentAuthorId(@Param("authorId") Long authorId);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentRepository.java
@@ -1,0 +1,41 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemComment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomSharedProblemCommentRepository extends JpaRepository<StudyRoomSharedProblemComment, Long> {
+
+    @Query("""
+            select c
+            from StudyRoomSharedProblemComment c
+            join fetch c.author
+            where c.sharedProblem.id = :sharedProblemId
+              and (:cursor is null or c.id < :cursor)
+            order by c.id desc
+            """)
+    List<StudyRoomSharedProblemComment> findBySharedProblemIdAndCursor(@Param("sharedProblemId") Long sharedProblemId,
+                                                                       @Param("cursor") Long cursor,
+                                                                       Pageable pageable);
+
+    @Query("""
+            select c
+            from StudyRoomSharedProblemComment c
+            join fetch c.author
+            join fetch c.sharedProblem sp
+            join fetch sp.room
+            where c.id = :commentId
+              and sp.id = :sharedProblemId
+              and sp.room.id = :roomId
+            """)
+    Optional<StudyRoomSharedProblemComment> findByIdAndSharedProblemIdAndRoomId(@Param("commentId") Long commentId,
+                                                                                @Param("sharedProblemId") Long sharedProblemId,
+                                                                                @Param("roomId") Long roomId);
+
+    void deleteBySharedProblemId(Long sharedProblemId);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Collection;
 
 public interface StudyRoomSharedProblemCommentRepository extends JpaRepository<StudyRoomSharedProblemComment, Long> {
 
@@ -39,6 +40,14 @@ public interface StudyRoomSharedProblemCommentRepository extends JpaRepository<S
     Optional<StudyRoomSharedProblemComment> findByIdAndSharedProblemIdAndRoomId(@Param("commentId") Long commentId,
                                                                                 @Param("sharedProblemId") Long sharedProblemId,
                                                                                 @Param("roomId") Long roomId);
+
+    @Query("""
+            select c.sharedProblem.id, count(c.id)
+            from StudyRoomSharedProblemComment c
+            where c.sharedProblem.id in :sharedProblemIds
+            group by c.sharedProblem.id
+            """)
+    List<Object[]> countBySharedProblemIds(@Param("sharedProblemIds") Collection<Long> sharedProblemIds);
 
     @Modifying
     @Query("delete from StudyRoomSharedProblemComment c where c.sharedProblem.id = :sharedProblemId")

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemCommentRepository.java
@@ -3,6 +3,7 @@ package com.aisip.OnO.backend.studyroom.repository;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemComment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +15,8 @@ public interface StudyRoomSharedProblemCommentRepository extends JpaRepository<S
     @Query("""
             select c
             from StudyRoomSharedProblemComment c
+            join fetch c.sharedProblem sp
+            join fetch sp.room
             join fetch c.author
             where c.sharedProblem.id = :sharedProblemId
               and (:cursor is null or c.id < :cursor)
@@ -37,5 +40,11 @@ public interface StudyRoomSharedProblemCommentRepository extends JpaRepository<S
                                                                                 @Param("sharedProblemId") Long sharedProblemId,
                                                                                 @Param("roomId") Long roomId);
 
-    void deleteBySharedProblemId(Long sharedProblemId);
+    @Modifying
+    @Query("delete from StudyRoomSharedProblemComment c where c.sharedProblem.id = :sharedProblemId")
+    void deleteBySharedProblemId(@Param("sharedProblemId") Long sharedProblemId);
+
+    @Modifying
+    @Query("delete from StudyRoomSharedProblemComment c where c.author.id = :authorId")
+    void deleteByAuthorId(@Param("authorId") Long authorId);
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemReactionRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemReactionRepository.java
@@ -17,4 +17,6 @@ public interface StudyRoomSharedProblemReactionRepository extends JpaRepository<
     List<StudyRoomSharedProblemReaction> findAllBySharedProblemIds(@Param("sharedProblemIds") Collection<Long> sharedProblemIds);
 
     List<StudyRoomSharedProblemReaction> findAllBySharedProblemId(Long sharedProblemId);
+
+    void deleteBySharedProblemId(Long sharedProblemId);
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemReactionRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemReactionRepository.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.studyroom.repository;
 
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemReaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,5 +19,7 @@ public interface StudyRoomSharedProblemReactionRepository extends JpaRepository<
 
     List<StudyRoomSharedProblemReaction> findAllBySharedProblemId(Long sharedProblemId);
 
-    void deleteBySharedProblemId(Long sharedProblemId);
+    @Modifying
+    @Query("delete from StudyRoomSharedProblemReaction r where r.sharedProblem.id = :sharedProblemId")
+    void deleteBySharedProblemId(@Param("sharedProblemId") Long sharedProblemId);
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemReactionRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemReactionRepository.java
@@ -1,0 +1,20 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomSharedProblemReactionRepository extends JpaRepository<StudyRoomSharedProblemReaction, Long> {
+
+    Optional<StudyRoomSharedProblemReaction> findBySharedProblemIdAndUserIdAndEmoji(Long sharedProblemId, Long userId, String emoji);
+
+    @Query("select r from StudyRoomSharedProblemReaction r where r.sharedProblem.id in :sharedProblemIds")
+    List<StudyRoomSharedProblemReaction> findAllBySharedProblemIds(@Param("sharedProblemIds") Collection<Long> sharedProblemIds);
+
+    List<StudyRoomSharedProblemReaction> findAllBySharedProblemId(Long sharedProblemId);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemRepository.java
@@ -23,4 +23,6 @@ public interface StudyRoomSharedProblemRepository extends JpaRepository<StudyRoo
                                                        Pageable pageable);
 
     Optional<StudyRoomSharedProblem> findByIdAndRoomId(Long id, Long roomId);
+
+    boolean existsByRoomIdAndProblemId(Long roomId, Long problemId);
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomSharedProblemRepository.java
@@ -1,0 +1,26 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomSharedProblemRepository extends JpaRepository<StudyRoomSharedProblem, Long> {
+
+    @Query("select sp from StudyRoomSharedProblem sp join fetch sp.sharedByUser join fetch sp.problem where sp.room.id = :roomId order by sp.createdAt desc")
+    Page<StudyRoomSharedProblem> findPageByRoomId(@Param("roomId") Long roomId, Pageable pageable);
+
+    @Query("select sp from StudyRoomSharedProblem sp join fetch sp.sharedByUser join fetch sp.problem " +
+            "where sp.room.id = :roomId and (:cursor is null or sp.id < :cursor) " +
+            "order by sp.id desc")
+    List<StudyRoomSharedProblem> findByRoomIdAndCursor(@Param("roomId") Long roomId,
+                                                       @Param("cursor") Long cursor,
+                                                       Pageable pageable);
+
+    Optional<StudyRoomSharedProblem> findByIdAndRoomId(Long id, Long roomId);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomWeeklyReportReadRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomWeeklyReportReadRepository.java
@@ -1,0 +1,24 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomWeeklyReportRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomWeeklyReportReadRepository extends JpaRepository<StudyRoomWeeklyReportRead, Long> {
+
+    boolean existsByReportIdAndUserId(Long reportId, Long userId);
+
+    Optional<StudyRoomWeeklyReportRead> findByReportIdAndUserId(Long reportId, Long userId);
+
+    @Query("select r from StudyRoomWeeklyReportRead r where r.report.id in :reportIds and r.user.id = :userId")
+    List<StudyRoomWeeklyReportRead> findAllByReportIdsAndUserId(@Param("reportIds") Collection<Long> reportIds, @Param("userId") Long userId);
+
+    @Query("select count(rp) > 0 from StudyRoomWeeklyReport rp where rp.room.id = :roomId and not exists " +
+            "(select rr.id from StudyRoomWeeklyReportRead rr where rr.report = rp and rr.user.id = :userId)")
+    boolean existsUnreadReport(@Param("roomId") Long roomId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomWeeklyReportRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomWeeklyReportRepository.java
@@ -1,0 +1,18 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomWeeklyReport;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyRoomWeeklyReportRepository extends JpaRepository<StudyRoomWeeklyReport, Long> {
+
+    boolean existsByRoomIdAndWeekStart(Long roomId, LocalDate weekStart);
+
+    Optional<StudyRoomWeeklyReport> findByIdAndRoomId(Long id, Long roomId);
+
+    List<StudyRoomWeeklyReport> findAllByRoomIdOrderByWeekStartDesc(Long roomId, Pageable pageable);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudySessionRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudySessionRepository.java
@@ -1,0 +1,26 @@
+package com.aisip.OnO.backend.studyroom.repository;
+
+import com.aisip.OnO.backend.studyroom.entity.StudySession;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface StudySessionRepository extends JpaRepository<StudySession, Long> {
+
+    @Query("select s from StudySession s join fetch s.user where s.room.id = :roomId and s.endedAt is null order by s.startedAt asc")
+    List<StudySession> findActiveByRoomId(@Param("roomId") Long roomId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from StudySession s where s.user.id = :userId and s.endedAt is null")
+    List<StudySession> findActiveByUserIdForUpdate(@Param("userId") Long userId);
+
+    Optional<StudySession> findByIdAndRoomIdAndUserId(Long id, Long roomId, Long userId);
+
+    List<StudySession> findAllByEndedAtIsNullAndStartedAtBefore(LocalDateTime threshold);
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomAccessService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomAccessService.java
@@ -1,0 +1,43 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyRoomAccessService {
+
+    private final StudyRoomRepository roomRepository;
+    private final StudyRoomMemberRepository memberRepository;
+
+    public StudyRoom getRoomOrThrow(Long roomId) {
+        return roomRepository.findById(roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_NOT_FOUND));
+    }
+
+    public StudyRoomMember getMemberOrThrow(Long roomId, Long userId) {
+        getRoomOrThrow(roomId);
+        return memberRepository.findByRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN));
+    }
+
+    public void validateMember(Long roomId, Long userId) {
+        getMemberOrThrow(roomId, userId);
+    }
+
+    public void validateHost(Long roomId, Long userId) {
+        StudyRoomMember member = getMemberOrThrow(roomId, userId);
+        if (member.getRole() != StudyRoomMemberRole.HOST) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_HOST_ONLY);
+        }
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -5,9 +5,13 @@ import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
 import com.aisip.OnO.backend.studyroom.entity.*;
 import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.quartz.ChallengeNotificationScheduler;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomChallengeRepository;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.util.fcm.dto.NotificationRequestDto;
+import com.aisip.OnO.backend.util.fcm.service.FcmService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StudyRoomChallengeService {
@@ -28,6 +33,8 @@ public class StudyRoomChallengeService {
     private final StudyRoomChallengeRepository challengeRepository;
     private final StudyRoomMemberRepository memberRepository;
     private final StudyRoomStatsService statsService;
+    private final ChallengeNotificationScheduler notificationScheduler;
+    private final FcmService fcmService;
 
     @Transactional
     public List<ChallengeResponse> getChallenges(Long roomId, Long userId) {
@@ -64,6 +71,7 @@ public class StudyRoomChallengeService {
                 startAt,
                 request.endAt()
         ));
+        notificationScheduler.scheduleNotifications(challenge);
         return toResponse(challenge, memberRepository.findAllWithUserByRoomId(roomId), true);
     }
 
@@ -72,6 +80,7 @@ public class StudyRoomChallengeService {
         accessService.validateHost(roomId, userId);
         StudyRoomChallenge challenge = challengeRepository.findByIdAndRoomId(challengeId, roomId)
                 .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.CHALLENGE_NOT_FOUND));
+        notificationScheduler.cancelNotifications(challengeId);
         challengeRepository.delete(challenge);
     }
 
@@ -109,6 +118,9 @@ public class StudyRoomChallengeService {
         StudyRoomChallengeStatus status = effectiveStatus(challenge, memberProgress, groupCurrent);
         if (persistStatus && challenge.getStatus() != status) {
             challenge.updateStatus(status);
+            if (status == StudyRoomChallengeStatus.COMPLETED) {
+                notifyChallengeCompleted(challenge, members);
+            }
         }
         return new ChallengeResponse(
                 challenge.getId(),
@@ -211,6 +223,20 @@ public class StudyRoomChallengeService {
                 || request.periodDays() != null && request.periodDays() < 1) {
             throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
         }
+    }
+
+    private void notifyChallengeCompleted(StudyRoomChallenge challenge, List<StudyRoomMember> members) {
+        NotificationRequestDto dto = new NotificationRequestDto(null,
+                "챌린지 달성! 🎉",
+                "'" + challenge.getTitle() + "' 챌린지를 달성했어요!",
+                Map.of("type", "CHALLENGE_COMPLETED", "roomId", String.valueOf(challenge.getRoom().getId())));
+        members.forEach(member -> {
+            try {
+                fcmService.sendNotificationToAllUserDevice(member.getUser().getId(), dto);
+            } catch (Exception e) {
+                log.warn("챌린지 달성 알림 발송 실패 - userId: {}", member.getUser().getId(), e);
+            }
+        });
     }
 
     private LocalDate min(LocalDate left, LocalDate right) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -39,19 +39,23 @@ public class StudyRoomChallengeService {
 
     @Transactional
     public ChallengeResponse createChallenge(Long roomId, Long userId, ChallengeCreateRequest request) {
-        accessService.validateHost(roomId, userId);
+        accessService.validateMember(roomId, userId);
         validateCreateRequest(request);
         refreshRoomChallengeStatuses(roomId);
         if (challengeRepository.countByRoomIdAndStatus(roomId, StudyRoomChallengeStatus.IN_PROGRESS) >= MAX_IN_PROGRESS_CHALLENGE_COUNT) {
             throw new ApplicationException(StudyRoomErrorCase.CHALLENGE_LIMIT_EXCEEDED);
         }
         LocalDateTime startAt = request.startAt() == null ? LocalDateTime.now() : request.startAt();
+        StudyRoomChallengePeriod period = request.period() == null
+                ? null
+                : parseEnum(request.period(), StudyRoomChallengePeriod.class);
         StudyRoom room = accessService.getRoomOrThrow(roomId);
         StudyRoomChallenge challenge = challengeRepository.save(StudyRoomChallenge.create(
                 room,
                 request.title().trim(),
                 parseEnum(request.type(), StudyRoomChallengeType.class),
                 parseEnum(request.metric(), StudyRoomChallengeMetric.class),
+                period,
                 request.targetValue(),
                 startAt,
                 request.endAt()
@@ -78,17 +82,24 @@ public class StudyRoomChallengeService {
         LocalDate streakBaseDate = min(LocalDate.now(), challenge.getEndAt().toLocalDate());
         Map<Long, Integer> streaks = statsService.currentStreaks(userIds, streakBaseDate, challenge.getStartAt().toLocalDate());
         Map<Long, StudyRoomStats> stats = statsService.getStats(userIds, challenge.getStartAt(), challenge.getEndAt(), streaks);
+        Map<Long, Integer> attendanceDays = isAttendanceMetric(challenge.getMetric())
+                ? statsService.attendanceDayCounts(userIds, challenge.getStartAt(), challenge.getEndAt())
+                : Map.of();
         List<ChallengeMemberProgressResponse> memberProgress = challenge.getType() == StudyRoomChallengeType.GROUP
                 ? List.of()
                 : members.stream()
                 .map(member -> {
-                    int current = metricValue(challenge.getMetric(), stats.get(member.getUser().getId()));
+                    int current = metricValue(challenge.getMetric(), stats.get(member.getUser().getId()),
+                            attendanceDays.getOrDefault(member.getUser().getId(), 0));
                     return new ChallengeMemberProgressResponse(member.getUser().getId(), member.getUser().getName(),
                             current, current >= challenge.getTargetValue());
                 })
                 .toList();
         Integer groupCurrent = challenge.getType() == StudyRoomChallengeType.GROUP
-                ? stats.values().stream().mapToInt(stat -> metricValue(challenge.getMetric(), stat)).sum()
+                ? userIds.stream()
+                .mapToInt(memberId -> metricValue(challenge.getMetric(), stats.get(memberId),
+                        attendanceDays.getOrDefault(memberId, 0)))
+                .sum()
                 : null;
         StudyRoomChallengeStatus status = effectiveStatus(challenge, memberProgress, groupCurrent);
         if (persistStatus && challenge.getStatus() != status) {
@@ -99,6 +110,7 @@ public class StudyRoomChallengeService {
                 challenge.getTitle(),
                 toApiValue(challenge.getType().name()),
                 toApiValue(challenge.getMetric().name()),
+                challenge.getPeriod() == null ? null : toApiValue(challenge.getPeriod().name()),
                 challenge.getTargetValue(),
                 challenge.getStartAt(),
                 challenge.getEndAt(),
@@ -126,15 +138,19 @@ public class StudyRoomChallengeService {
         return StudyRoomChallengeStatus.IN_PROGRESS;
     }
 
-    private int metricValue(StudyRoomChallengeMetric metric, StudyRoomStats stats) {
+    private int metricValue(StudyRoomChallengeMetric metric, StudyRoomStats stats, int attendanceDays) {
         if (stats == null) {
             return 0;
         }
         return switch (metric) {
-            case WEEKLY_PROBLEM_COUNT -> stats.weeklyProblemCount();
-            case WEEKLY_PRACTICE_COUNT -> stats.weeklyPracticeCount();
-            case STREAK -> stats.currentStreak();
+            case PROBLEM_COUNT, WEEKLY_PROBLEM_COUNT -> stats.weeklyProblemCount();
+            case PRACTICE_COUNT, WEEKLY_PRACTICE_COUNT -> stats.weeklyPracticeCount();
+            case ATTENDANCE, STREAK -> attendanceDays;
         };
+    }
+
+    private boolean isAttendanceMetric(StudyRoomChallengeMetric metric) {
+        return metric == StudyRoomChallengeMetric.ATTENDANCE || metric == StudyRoomChallengeMetric.STREAK;
     }
 
     private void validateCreateRequest(ChallengeCreateRequest request) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -28,12 +29,14 @@ public class StudyRoomChallengeService {
     private final StudyRoomMemberRepository memberRepository;
     private final StudyRoomStatsService statsService;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public List<ChallengeResponse> getChallenges(Long roomId, Long userId) {
         accessService.validateMember(roomId, userId);
         List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(roomId);
-        return challengeRepository.findActiveByRoomId(roomId, StudyRoomChallengeStatus.IN_PROGRESS, LocalDateTime.now()).stream()
-                .map(challenge -> toResponse(challenge, members, false))
+        return challengeRepository.findAllByRoomIdOrderByEndAtAsc(roomId).stream()
+                .map(challenge -> toResponse(challenge, members, true))
+                .sorted(Comparator.comparing((ChallengeResponse r) -> "in_progress".equals(r.status()) ? 0 : 1)
+                        .thenComparing(Comparator.comparing(ChallengeResponse::endAt).reversed()))
                 .toList();
     }
 
@@ -56,6 +59,7 @@ public class StudyRoomChallengeService {
                 parseEnum(request.type(), StudyRoomChallengeType.class),
                 parseEnum(request.metric(), StudyRoomChallengeMetric.class),
                 period,
+                period == null ? request.periodDays() : null,
                 request.targetValue(),
                 startAt,
                 request.endAt()
@@ -112,6 +116,7 @@ public class StudyRoomChallengeService {
                 toApiValue(challenge.getType().name()),
                 toApiValue(challenge.getMetric().name()),
                 challenge.getPeriod() == null ? null : toApiValue(challenge.getPeriod().name()),
+                challenge.getPeriodDays(),
                 challenge.getTargetValue(),
                 challenge.getStartAt(),
                 challenge.getEndAt(),
@@ -127,7 +132,7 @@ public class StudyRoomChallengeService {
         if (challenge.getStatus() != StudyRoomChallengeStatus.IN_PROGRESS) {
             return challenge.getStatus();
         }
-        if (challenge.getPeriod() == null) {
+        if (challenge.getPeriod() == null && challenge.getPeriodDays() == null) {
             boolean completed = challenge.getType() == StudyRoomChallengeType.GROUP
                     ? groupCurrent != null && groupCurrent >= challenge.getTargetValue()
                     : !memberProgress.isEmpty() && memberProgress.stream().allMatch(ChallengeMemberProgressResponse::cleared);
@@ -160,25 +165,29 @@ public class StudyRoomChallengeService {
         LocalDateTime startAt = challenge.getStartAt();
         LocalDateTime endAt = challenge.getEndAt();
         StudyRoomChallengePeriod period = challenge.getPeriod();
-        if (period == null) {
+        Integer periodDays = challenge.getPeriodDays();
+        if (period == null && periodDays == null) {
             return new AggregationRange(startAt, endAt);
         }
         LocalDateTime anchor = clamp(now, startAt, endAt);
         LocalDateTime windowStart = startAt;
-        LocalDateTime windowEnd = addPeriod(windowStart, period);
+        LocalDateTime windowEnd = addPeriod(windowStart, period, periodDays);
         while (!windowEnd.isAfter(anchor) && windowEnd.isBefore(endAt)) {
             windowStart = windowEnd;
-            windowEnd = addPeriod(windowStart, period);
+            windowEnd = addPeriod(windowStart, period, periodDays);
         }
         return new AggregationRange(windowStart, windowEnd.isAfter(endAt) ? endAt : windowEnd);
     }
 
-    private LocalDateTime addPeriod(LocalDateTime base, StudyRoomChallengePeriod period) {
-        return switch (period) {
-            case DAILY -> base.plusDays(1);
-            case WEEKLY -> base.plusDays(7);
-            case MONTHLY -> base.plusMonths(1);
-        };
+    private LocalDateTime addPeriod(LocalDateTime base, StudyRoomChallengePeriod period, Integer periodDays) {
+        if (period != null) {
+            return switch (period) {
+                case DAILY -> base.plusDays(1);
+                case WEEKLY -> base.plusDays(7);
+                case MONTHLY -> base.plusMonths(1);
+            };
+        }
+        return base.plusDays(periodDays);
     }
 
     private LocalDateTime clamp(LocalDateTime value, LocalDateTime lower, LocalDateTime upper) {
@@ -197,7 +206,9 @@ public class StudyRoomChallengeService {
         if (request.title() == null || request.title().isBlank() || request.title().length() > 40
                 || request.targetValue() == null || request.targetValue() < 1
                 || request.endAt() == null || !request.endAt().isAfter(LocalDateTime.now())
-                || request.startAt() != null && !request.startAt().isBefore(request.endAt())) {
+                || request.startAt() != null && !request.startAt().isBefore(request.endAt())
+                || request.period() != null && request.periodDays() != null
+                || request.periodDays() != null && request.periodDays() < 1) {
             throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
         }
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -1,0 +1,164 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.entity.*;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomChallengeRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomChallengeService {
+
+    private static final int MAX_IN_PROGRESS_CHALLENGE_COUNT = 5;
+
+    private final StudyRoomAccessService accessService;
+    private final StudyRoomChallengeRepository challengeRepository;
+    private final StudyRoomMemberRepository memberRepository;
+    private final StudyRoomStatsService statsService;
+
+    @Transactional(readOnly = true)
+    public List<ChallengeResponse> getChallenges(Long roomId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(roomId);
+        return challengeRepository.findActiveByRoomId(roomId, StudyRoomChallengeStatus.IN_PROGRESS, LocalDateTime.now()).stream()
+                .map(challenge -> toResponse(challenge, members, false))
+                .toList();
+    }
+
+    @Transactional
+    public ChallengeResponse createChallenge(Long roomId, Long userId, ChallengeCreateRequest request) {
+        accessService.validateHost(roomId, userId);
+        validateCreateRequest(request);
+        refreshRoomChallengeStatuses(roomId);
+        if (challengeRepository.countByRoomIdAndStatus(roomId, StudyRoomChallengeStatus.IN_PROGRESS) >= MAX_IN_PROGRESS_CHALLENGE_COUNT) {
+            throw new ApplicationException(StudyRoomErrorCase.CHALLENGE_LIMIT_EXCEEDED);
+        }
+        LocalDateTime startAt = request.startAt() == null ? LocalDateTime.now() : request.startAt();
+        StudyRoom room = accessService.getRoomOrThrow(roomId);
+        StudyRoomChallenge challenge = challengeRepository.save(StudyRoomChallenge.create(
+                room,
+                request.title().trim(),
+                parseEnum(request.type(), StudyRoomChallengeType.class),
+                parseEnum(request.metric(), StudyRoomChallengeMetric.class),
+                request.targetValue(),
+                startAt,
+                request.endAt()
+        ));
+        return toResponse(challenge, memberRepository.findAllWithUserByRoomId(roomId), true);
+    }
+
+    @Transactional
+    public void deleteChallenge(Long roomId, Long challengeId, Long userId) {
+        accessService.validateHost(roomId, userId);
+        StudyRoomChallenge challenge = challengeRepository.findByIdAndRoomId(challengeId, roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.CHALLENGE_NOT_FOUND));
+        challengeRepository.delete(challenge);
+    }
+
+    private void refreshRoomChallengeStatuses(Long roomId) {
+        List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(roomId);
+        challengeRepository.findAllByRoomIdOrderByEndAtAsc(roomId)
+                .forEach(challenge -> toResponse(challenge, members, true));
+    }
+
+    private ChallengeResponse toResponse(StudyRoomChallenge challenge, List<StudyRoomMember> members, boolean persistStatus) {
+        List<Long> userIds = members.stream().map(member -> member.getUser().getId()).toList();
+        LocalDate streakBaseDate = min(LocalDate.now(), challenge.getEndAt().toLocalDate());
+        Map<Long, Integer> streaks = statsService.currentStreaks(userIds, streakBaseDate, challenge.getStartAt().toLocalDate());
+        Map<Long, StudyRoomStats> stats = statsService.getStats(userIds, challenge.getStartAt(), challenge.getEndAt(), streaks);
+        List<ChallengeMemberProgressResponse> memberProgress = challenge.getType() == StudyRoomChallengeType.GROUP
+                ? List.of()
+                : members.stream()
+                .map(member -> {
+                    int current = metricValue(challenge.getMetric(), stats.get(member.getUser().getId()));
+                    return new ChallengeMemberProgressResponse(member.getUser().getId(), member.getUser().getName(),
+                            current, current >= challenge.getTargetValue());
+                })
+                .toList();
+        Integer groupCurrent = challenge.getType() == StudyRoomChallengeType.GROUP
+                ? stats.values().stream().mapToInt(stat -> metricValue(challenge.getMetric(), stat)).sum()
+                : null;
+        StudyRoomChallengeStatus status = effectiveStatus(challenge, memberProgress, groupCurrent);
+        if (persistStatus && challenge.getStatus() != status) {
+            challenge.updateStatus(status);
+        }
+        return new ChallengeResponse(
+                challenge.getId(),
+                challenge.getTitle(),
+                toApiValue(challenge.getType().name()),
+                toApiValue(challenge.getMetric().name()),
+                challenge.getTargetValue(),
+                challenge.getStartAt(),
+                challenge.getEndAt(),
+                toApiValue(status.name()),
+                memberProgress,
+                groupCurrent
+        );
+    }
+
+    private StudyRoomChallengeStatus effectiveStatus(StudyRoomChallenge challenge,
+                                                    List<ChallengeMemberProgressResponse> memberProgress,
+                                                    Integer groupCurrent) {
+        if (challenge.getStatus() != StudyRoomChallengeStatus.IN_PROGRESS) {
+            return challenge.getStatus();
+        }
+        boolean completed = challenge.getType() == StudyRoomChallengeType.GROUP
+                ? groupCurrent != null && groupCurrent >= challenge.getTargetValue()
+                : !memberProgress.isEmpty() && memberProgress.stream().allMatch(ChallengeMemberProgressResponse::cleared);
+        if (completed) {
+            return StudyRoomChallengeStatus.COMPLETED;
+        }
+        if (challenge.getEndAt().isBefore(LocalDateTime.now())) {
+            return StudyRoomChallengeStatus.EXPIRED;
+        }
+        return StudyRoomChallengeStatus.IN_PROGRESS;
+    }
+
+    private int metricValue(StudyRoomChallengeMetric metric, StudyRoomStats stats) {
+        if (stats == null) {
+            return 0;
+        }
+        return switch (metric) {
+            case WEEKLY_PROBLEM_COUNT -> stats.weeklyProblemCount();
+            case WEEKLY_PRACTICE_COUNT -> stats.weeklyPracticeCount();
+            case STREAK -> stats.currentStreak();
+        };
+    }
+
+    private void validateCreateRequest(ChallengeCreateRequest request) {
+        if (request.title() == null || request.title().isBlank() || request.title().length() > 40
+                || request.targetValue() == null || request.targetValue() < 1
+                || request.endAt() == null || !request.endAt().isAfter(LocalDateTime.now())
+                || request.startAt() != null && !request.startAt().isBefore(request.endAt())) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+    }
+
+    private LocalDate min(LocalDate left, LocalDate right) {
+        return left.isBefore(right) ? left : right;
+    }
+
+    private <T extends Enum<T>> T parseEnum(String value, Class<T> enumClass) {
+        try {
+            return Enum.valueOf(enumClass, value.toUpperCase(Locale.ROOT));
+        } catch (Exception e) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+    }
+
+    private String toApiValue(String enumName) {
+        return enumName.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -79,11 +79,12 @@ public class StudyRoomChallengeService {
 
     private ChallengeResponse toResponse(StudyRoomChallenge challenge, List<StudyRoomMember> members, boolean persistStatus) {
         List<Long> userIds = members.stream().map(member -> member.getUser().getId()).toList();
+        AggregationRange range = resolveAggregationRange(challenge, LocalDateTime.now());
         LocalDate streakBaseDate = min(LocalDate.now(), challenge.getEndAt().toLocalDate());
         Map<Long, Integer> streaks = statsService.currentStreaks(userIds, streakBaseDate, challenge.getStartAt().toLocalDate());
-        Map<Long, StudyRoomStats> stats = statsService.getStats(userIds, challenge.getStartAt(), challenge.getEndAt(), streaks);
+        Map<Long, StudyRoomStats> stats = statsService.getStats(userIds, range.start(), range.end(), streaks);
         Map<Long, Integer> attendanceDays = isAttendanceMetric(challenge.getMetric())
-                ? statsService.attendanceDayCounts(userIds, challenge.getStartAt(), challenge.getEndAt())
+                ? statsService.attendanceDayCounts(userIds, range.start(), range.end())
                 : Map.of();
         List<ChallengeMemberProgressResponse> memberProgress = challenge.getType() == StudyRoomChallengeType.GROUP
                 ? List.of()
@@ -126,11 +127,13 @@ public class StudyRoomChallengeService {
         if (challenge.getStatus() != StudyRoomChallengeStatus.IN_PROGRESS) {
             return challenge.getStatus();
         }
-        boolean completed = challenge.getType() == StudyRoomChallengeType.GROUP
-                ? groupCurrent != null && groupCurrent >= challenge.getTargetValue()
-                : !memberProgress.isEmpty() && memberProgress.stream().allMatch(ChallengeMemberProgressResponse::cleared);
-        if (completed) {
-            return StudyRoomChallengeStatus.COMPLETED;
+        if (challenge.getPeriod() == null) {
+            boolean completed = challenge.getType() == StudyRoomChallengeType.GROUP
+                    ? groupCurrent != null && groupCurrent >= challenge.getTargetValue()
+                    : !memberProgress.isEmpty() && memberProgress.stream().allMatch(ChallengeMemberProgressResponse::cleared);
+            if (completed) {
+                return StudyRoomChallengeStatus.COMPLETED;
+            }
         }
         if (challenge.getEndAt().isBefore(LocalDateTime.now())) {
             return StudyRoomChallengeStatus.EXPIRED;
@@ -152,6 +155,43 @@ public class StudyRoomChallengeService {
     private boolean isAttendanceMetric(StudyRoomChallengeMetric metric) {
         return metric == StudyRoomChallengeMetric.ATTENDANCE || metric == StudyRoomChallengeMetric.STREAK;
     }
+
+    private AggregationRange resolveAggregationRange(StudyRoomChallenge challenge, LocalDateTime now) {
+        LocalDateTime startAt = challenge.getStartAt();
+        LocalDateTime endAt = challenge.getEndAt();
+        StudyRoomChallengePeriod period = challenge.getPeriod();
+        if (period == null) {
+            return new AggregationRange(startAt, endAt);
+        }
+        LocalDateTime anchor = clamp(now, startAt, endAt);
+        LocalDateTime windowStart = startAt;
+        LocalDateTime windowEnd = addPeriod(windowStart, period);
+        while (!windowEnd.isAfter(anchor) && windowEnd.isBefore(endAt)) {
+            windowStart = windowEnd;
+            windowEnd = addPeriod(windowStart, period);
+        }
+        return new AggregationRange(windowStart, windowEnd.isAfter(endAt) ? endAt : windowEnd);
+    }
+
+    private LocalDateTime addPeriod(LocalDateTime base, StudyRoomChallengePeriod period) {
+        return switch (period) {
+            case DAILY -> base.plusDays(1);
+            case WEEKLY -> base.plusDays(7);
+            case MONTHLY -> base.plusMonths(1);
+        };
+    }
+
+    private LocalDateTime clamp(LocalDateTime value, LocalDateTime lower, LocalDateTime upper) {
+        if (value.isBefore(lower)) {
+            return lower;
+        }
+        if (value.isAfter(upper)) {
+            return upper;
+        }
+        return value;
+    }
+
+    private record AggregationRange(LocalDateTime start, LocalDateTime end) {}
 
     private void validateCreateRequest(ChallengeCreateRequest request) {
         if (request.title() == null || request.title().isBlank() || request.title().length() > 40

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.studyroom.service;
 
+import com.aisip.OnO.backend.common.emoji.CustomEmojiValidator;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
@@ -35,7 +36,6 @@ import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMI
 public class StudyRoomFeedService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-    private static final Set<String> ALLOWED_FEED_EMOJIS = Set.of("🔥", "👍", "🎉");
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
     };
 
@@ -46,6 +46,7 @@ public class StudyRoomFeedService {
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final StudyRoomReactionService reactionService;
+    private final CustomEmojiValidator customEmojiValidator;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<FeedItemResponse> getFeed(Long roomId, Long userId, Long cursor, int size) {
@@ -68,9 +69,7 @@ public class StudyRoomFeedService {
     @Transactional
     public FeedReactionToggleResponse toggleReaction(Long roomId, Long feedId, Long userId, ReactionToggleRequest request) {
         accessService.validateMember(roomId, userId);
-        if (!ALLOWED_FEED_EMOJIS.contains(request.emoji())) {
-            throw new ApplicationException(StudyRoomErrorCase.INVALID_REACTION_EMOJI);
-        }
+        customEmojiValidator.validate(request.emoji());
         StudyRoomFeed feed = feedRepository.findByIdAndRoomId(feedId, roomId)
                 .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_NOT_FOUND));
         User user = userRepository.findById(userId)

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
@@ -1,0 +1,159 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.common.response.CursorPageResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.*;
+import com.aisip.OnO.backend.studyroom.event.StudyRoomActivityEvent;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.exception.UserErrorCase;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudyRoomFeedService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Set<String> ALLOWED_FEED_EMOJIS = Set.of("🔥", "👍", "🎉");
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    private final StudyRoomAccessService accessService;
+    private final StudyRoomMemberRepository memberRepository;
+    private final StudyRoomFeedRepository feedRepository;
+    private final StudyRoomFeedReactionRepository reactionRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+    private final StudyRoomReactionService reactionService;
+
+    @Transactional(readOnly = true)
+    public CursorPageResponse<FeedItemResponse> getFeed(Long roomId, Long userId, Long cursor, int size) {
+        accessService.validateMember(roomId, userId);
+        int safeSize = Math.min(size, 50);
+        List<StudyRoomFeed> feeds = feedRepository.findWithUserByRoomIdAndCursor(roomId, cursor, PageRequest.of(0, safeSize + 1));
+        boolean hasNext = feeds.size() > safeSize;
+        List<StudyRoomFeed> contentFeeds = hasNext ? feeds.subList(0, safeSize) : feeds;
+        Map<Long, List<StudyRoomFeedReaction>> reactions = reactionRepository.findAllByFeedIds(
+                        contentFeeds.stream().map(StudyRoomFeed::getId).toList())
+                .stream()
+                .collect(Collectors.groupingBy(reaction -> reaction.getFeed().getId()));
+        List<FeedItemResponse> content = contentFeeds.stream()
+                .map(feed -> toFeedItem(feed, reactions.getOrDefault(feed.getId(), List.of()), userId))
+                .toList();
+        Long nextCursor = hasNext && !contentFeeds.isEmpty() ? contentFeeds.get(contentFeeds.size() - 1).getId() : null;
+        return new CursorPageResponse<>(content, nextCursor, hasNext, safeSize);
+    }
+
+    @Transactional
+    public FeedReactionToggleResponse toggleReaction(Long roomId, Long feedId, Long userId, ReactionToggleRequest request) {
+        accessService.validateMember(roomId, userId);
+        if (!ALLOWED_FEED_EMOJIS.contains(request.emoji())) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_REACTION_EMOJI);
+        }
+        StudyRoomFeed feed = feedRepository.findByIdAndRoomId(feedId, roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        reactionRepository.findByFeedIdAndUserIdAndEmoji(feedId, userId, request.emoji())
+                .ifPresentOrElse(reactionRepository::delete,
+                        () -> reactionRepository.save(StudyRoomFeedReaction.create(feed, user, request.emoji())));
+        List<ReactionResponse> reactions = reactionService.summarizeFeedReactions(reactionRepository.findAllByFeedId(feedId), userId);
+        return new FeedReactionToggleResponse(feedId, reactions);
+    }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @Transactional(propagation = REQUIRES_NEW)
+    public void handleActivity(StudyRoomActivityEvent event) {
+        try {
+            createFeedsForUserRooms(event.userId(), event.eventType(), event.metadata());
+        } catch (Exception e) {
+            log.error("Failed to create study room feed. userId: {}, eventType: {}", event.userId(), event.eventType(), e);
+        }
+    }
+
+    @Transactional
+    public void createFeedsForUserRooms(Long userId, StudyRoomFeedEventType eventType, Map<String, Object> metadata) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        List<StudyRoomMember> memberships = memberRepository.findAllWithRoomByUserId(userId);
+        for (StudyRoomMember membership : memberships) {
+            createOrAccumulate(membership.getRoom(), user, eventType, metadata == null ? Map.of() : metadata);
+        }
+    }
+
+    private void createOrAccumulate(StudyRoom room, User user, StudyRoomFeedEventType eventType, Map<String, Object> metadata) {
+        if (eventType == StudyRoomFeedEventType.PROBLEM_REGISTERED) {
+            LocalDate today = LocalDate.now(KST);
+            LocalDateTime start = today.atStartOfDay();
+            LocalDateTime end = today.atTime(LocalTime.MAX);
+            Optional<StudyRoomFeed> existing = feedRepository
+                    .findTopByRoomIdAndUserIdAndEventTypeAndCreatedAtBetweenOrderByCreatedAtDesc(
+                            room.getId(), user.getId(), eventType, start, end);
+            if (existing.isPresent()) {
+                Map<String, Object> current = readMetadata(existing.get().getMetadataJson());
+                int oldCount = ((Number) current.getOrDefault("count", 0)).intValue();
+                int newCount = ((Number) metadata.getOrDefault("count", 1)).intValue();
+                current.put("count", oldCount + newCount);
+                existing.get().updateMetadataJson(writeMetadata(current));
+                return;
+            }
+        }
+        feedRepository.save(StudyRoomFeed.create(room, user, eventType, writeMetadata(metadata)));
+    }
+
+    private FeedItemResponse toFeedItem(StudyRoomFeed feed, List<StudyRoomFeedReaction> reactions, Long userId) {
+        return new FeedItemResponse(
+                feed.getId(),
+                feed.getUser().getId(),
+                feed.getUser().getName(),
+                toApiValue(feed.getEventType().name()),
+                readMetadata(feed.getMetadataJson()),
+                feed.getCreatedAt(),
+                reactionService.summarizeFeedReactions(reactions, userId)
+        );
+    }
+
+    private Map<String, Object> readMetadata(String metadataJson) {
+        if (metadataJson == null || metadataJson.isBlank()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return objectMapper.readValue(metadataJson, MAP_TYPE);
+        } catch (Exception e) {
+            return new LinkedHashMap<>();
+        }
+    }
+
+    private String writeMetadata(Map<String, Object> metadata) {
+        try {
+            return objectMapper.writeValueAsString(metadata == null ? Map.of() : metadata);
+        } catch (Exception e) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+    }
+
+    static String toApiValue(String enumName) {
+        return enumName.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
@@ -126,6 +126,7 @@ public class StudyRoomFeedService {
                 feed.getId(),
                 feed.getUser().getId(),
                 feed.getUser().getName(),
+                feed.getUser().getProfileImageUrl(),
                 toApiValue(feed.getEventType().name()),
                 readMetadata(feed.getMetadataJson()),
                 feed.getCreatedAt(),

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomInviteCodeIssuer.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomInviteCodeIssuer.java
@@ -1,0 +1,50 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.InviteCodeResponse;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomInviteCode;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomInviteCodeRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomInviteCodeIssuer {
+
+    private static final int INVITE_CODE_BOUND = 1_000_000;
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final StudyRoomRepository roomRepository;
+    private final StudyRoomInviteCodeRepository inviteCodeRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public InviteCodeResponse createOrReuse(Long roomId, LocalDateTime now) {
+        Optional<StudyRoomInviteCode> existing = inviteCodeRepository.findTopByRoomIdOrderByExpiredAtDesc(roomId)
+                .filter(code -> !code.isExpired(now));
+        if (existing.isPresent()) {
+            StudyRoomInviteCode code = existing.get();
+            return new InviteCodeResponse(code.getCode(), code.getExpiredAt());
+        }
+
+        inviteCodeRepository.deleteExpiredBefore(now.minusDays(7));
+        StudyRoom room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_NOT_FOUND));
+        String code;
+        do {
+            code = "%06d".formatted(RANDOM.nextInt(INVITE_CODE_BOUND));
+        } while (inviteCodeRepository.existsByCode(code));
+
+        StudyRoomInviteCode inviteCode = inviteCodeRepository.saveAndFlush(
+                StudyRoomInviteCode.create(room, code, now.plusHours(24)));
+        return new InviteCodeResponse(inviteCode.getCode(), inviteCode.getExpiredAt());
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomInviteService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomInviteService.java
@@ -1,0 +1,82 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomInviteCode;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomInviteCodeRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.exception.UserErrorCase;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomInviteService {
+
+    private static final int INVITE_CODE_RETRY_COUNT = 5;
+
+    private final StudyRoomAccessService accessService;
+    private final StudyRoomInviteCodeRepository inviteCodeRepository;
+    private final StudyRoomMemberRepository memberRepository;
+    private final UserRepository userRepository;
+    private final StudyRoomService studyRoomService;
+    private final StudyRoomInviteCodeIssuer inviteCodeIssuer;
+
+    public InviteCodeResponse issueInviteCode(Long roomId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        LocalDateTime now = LocalDateTime.now();
+        return inviteCodeRepository.findTopByRoomIdOrderByExpiredAtDesc(roomId)
+                .filter(code -> !code.isExpired(now))
+                .map(code -> new InviteCodeResponse(code.getCode(), code.getExpiredAt()))
+                .orElseGet(() -> createInviteCode(roomId, now));
+    }
+
+    @Transactional
+    public StudyRoomDetailResponse join(StudyRoomJoinRequest request, Long userId) {
+        if (request.code() == null || !request.code().matches("\\d{6}")) {
+            throw new ApplicationException(StudyRoomErrorCase.INVITE_CODE_INVALID);
+        }
+        StudyRoomInviteCode inviteCode = inviteCodeRepository.findByCode(request.code())
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.INVITE_CODE_INVALID));
+        if (inviteCode.isExpired(LocalDateTime.now())) {
+            throw new ApplicationException(StudyRoomErrorCase.INVITE_CODE_EXPIRED);
+        }
+        StudyRoom room = studyRoomService.lockRoom(inviteCode.getRoom().getId());
+        if (memberRepository.existsByRoomIdAndUserId(room.getId(), userId)) {
+            throw new ApplicationException(StudyRoomErrorCase.ALREADY_MEMBER);
+        }
+        if (memberRepository.countByRoomId(room.getId()) >= StudyRoomService.MAX_ROOM_MEMBER_COUNT) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FULL);
+        }
+        if (memberRepository.countByUserId(userId) >= StudyRoomService.MAX_USER_ROOM_COUNT) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_LIMIT_EXCEEDED);
+        }
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        room.addMember(StudyRoomMember.create(user, StudyRoomMemberRole.MEMBER));
+        return studyRoomService.buildDetail(room);
+    }
+
+    private InviteCodeResponse createInviteCode(Long roomId, LocalDateTime now) {
+        for (int attempt = 0; attempt < INVITE_CODE_RETRY_COUNT; attempt++) {
+            try {
+                return inviteCodeIssuer.createOrReuse(roomId, now);
+            } catch (DataIntegrityViolationException ignored) {
+                if (attempt == INVITE_CODE_RETRY_COUNT - 1) {
+                    throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+                }
+            }
+        }
+        throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
@@ -1,0 +1,66 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.mission.entity.UserMissionStatus;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomWeeklyReportReadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class StudyRoomMapper {
+
+    private final StudyRoomWeeklyReportReadRepository reportReadRepository;
+
+    public StudyRoomListResponse toListResponse(StudyRoomMember member) {
+        StudyRoom room = member.getRoom();
+        return new StudyRoomListResponse(
+                room.getId(),
+                room.getName(),
+                room.getHostUserId(),
+                room.getMembers().size(),
+                room.getThumbnailUrl(),
+                reportReadRepository.existsUnreadReport(room.getId(), member.getUser().getId())
+        );
+    }
+
+    public StudyRoomDetailResponse toDetailResponse(StudyRoom room, List<StudyRoomMember> members,
+                                                    Map<Long, StudyRoomStats> statsByUserId) {
+        List<StudyRoomMemberResponse> memberResponses = members.stream()
+                .map(member -> toMemberResponse(member, statsByUserId.get(member.getUser().getId())))
+                .toList();
+        return new StudyRoomDetailResponse(
+                room.getId(),
+                room.getName(),
+                room.getHostUserId(),
+                room.getThumbnailUrl(),
+                memberResponses.size(),
+                memberResponses
+        );
+    }
+
+    public StudyRoomMemberResponse toMemberResponse(StudyRoomMember member, StudyRoomStats stats) {
+        int weeklyProblemCount = stats == null ? 0 : stats.weeklyProblemCount();
+        int weeklyPracticeCount = stats == null ? 0 : stats.weeklyPracticeCount();
+        int currentStreak = stats == null ? 0 : stats.currentStreak();
+        Integer goalProgress = member.getWeeklyGoal() == null ? null : weeklyProblemCount;
+        UserMissionStatus missionStatus = member.getUser().getUserMissionStatus();
+        Long totalStudyLevel = missionStatus == null ? 1L : missionStatus.getTotalStudyLevel();
+        return new StudyRoomMemberResponse(
+                member.getUser().getId(),
+                member.getUser().getName(),
+                totalStudyLevel,
+                currentStreak,
+                weeklyProblemCount,
+                weeklyPracticeCount,
+                member.getWeeklyGoal(),
+                goalProgress
+        );
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
@@ -64,6 +64,7 @@ public class StudyRoomMapper {
         return new StudyRoomMemberResponse(
                 member.getUser().getId(),
                 member.getUser().getName(),
+                member.getUser().getProfileImageUrl(),
                 totalStudyLevel,
                 currentStreak,
                 weeklyProblemCount,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
@@ -3,6 +3,7 @@ package com.aisip.OnO.backend.studyroom.service;
 import com.aisip.OnO.backend.mission.entity.UserMissionStatus;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomTodayPracticeSummary;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomWeeklyReportReadRepository;
@@ -18,22 +19,30 @@ public class StudyRoomMapper {
 
     private final StudyRoomWeeklyReportReadRepository reportReadRepository;
 
-    public StudyRoomListResponse toListResponse(StudyRoomMember member) {
+    public StudyRoomListResponse toListResponse(StudyRoomMember member, int memberCount,
+                                                StudyRoomTodayPracticeSummary todayPracticeSummary) {
         StudyRoom room = member.getRoom();
         return new StudyRoomListResponse(
                 room.getId(),
                 room.getName(),
                 room.getHostUserId(),
-                room.getMembers().size(),
+                memberCount,
                 room.getThumbnailUrl(),
-                reportReadRepository.existsUnreadReport(room.getId(), member.getUser().getId())
+                reportReadRepository.existsUnreadReport(room.getId(), member.getUser().getId()),
+                todayPracticeSummary.todayPracticeMemberCount(),
+                todayPracticeSummary.todayPracticeCount()
         );
     }
 
     public StudyRoomDetailResponse toDetailResponse(StudyRoom room, List<StudyRoomMember> members,
-                                                    Map<Long, StudyRoomStats> statsByUserId) {
+                                                    Map<Long, StudyRoomStats> statsByUserId,
+                                                    Map<Long, Integer> todayPracticeCountsByUserId) {
         List<StudyRoomMemberResponse> memberResponses = members.stream()
-                .map(member -> toMemberResponse(member, statsByUserId.get(member.getUser().getId())))
+                .map(member -> toMemberResponse(
+                        member,
+                        statsByUserId.get(member.getUser().getId()),
+                        todayPracticeCountsByUserId.getOrDefault(member.getUser().getId(), 0)
+                ))
                 .toList();
         return new StudyRoomDetailResponse(
                 room.getId(),
@@ -45,7 +54,7 @@ public class StudyRoomMapper {
         );
     }
 
-    public StudyRoomMemberResponse toMemberResponse(StudyRoomMember member, StudyRoomStats stats) {
+    public StudyRoomMemberResponse toMemberResponse(StudyRoomMember member, StudyRoomStats stats, int todayPracticeCount) {
         int weeklyProblemCount = stats == null ? 0 : stats.weeklyProblemCount();
         int weeklyPracticeCount = stats == null ? 0 : stats.weeklyPracticeCount();
         int currentStreak = stats == null ? 0 : stats.currentStreak();
@@ -60,7 +69,8 @@ public class StudyRoomMapper {
                 weeklyProblemCount,
                 weeklyPracticeCount,
                 member.getWeeklyGoal(),
-                goalProgress
+                goalProgress,
+                todayPracticeCount
         );
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
@@ -70,7 +70,8 @@ public class StudyRoomMapper {
                 weeklyPracticeCount,
                 member.getWeeklyGoal(),
                 goalProgress,
-                todayPracticeCount
+                todayPracticeCount,
+                todayPracticeCount > 0
         );
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomReactionService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomReactionService.java
@@ -1,0 +1,46 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.ReactionResponse;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedReaction;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemReaction;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class StudyRoomReactionService {
+
+    public List<ReactionResponse> summarizeFeedReactions(Collection<StudyRoomFeedReaction> reactions, Long userId) {
+        return summarize(reactions, userId, StudyRoomFeedReaction::getEmoji, reaction -> reaction.getUser().getId());
+    }
+
+    public List<ReactionResponse> summarizeSharedProblemReactions(Collection<StudyRoomSharedProblemReaction> reactions, Long userId) {
+        return summarize(reactions, userId, StudyRoomSharedProblemReaction::getEmoji, reaction -> reaction.getUser().getId());
+    }
+
+    private <T> List<ReactionResponse> summarize(Collection<T> reactions, Long userId,
+                                                 Function<T, String> emojiGetter,
+                                                 Function<T, Long> userIdGetter) {
+        Map<String, MutableReaction> grouped = new LinkedHashMap<>();
+        for (T reaction : reactions) {
+            String emoji = emojiGetter.apply(reaction);
+            MutableReaction mutable = grouped.computeIfAbsent(emoji, key -> new MutableReaction());
+            mutable.count++;
+            if (userId.equals(userIdGetter.apply(reaction))) {
+                mutable.reactedByMe = true;
+            }
+        }
+        return grouped.entrySet().stream()
+                .map(entry -> new ReactionResponse(entry.getKey(), entry.getValue().count, entry.getValue().reactedByMe))
+                .toList();
+    }
+
+    private static class MutableReaction {
+        private long count;
+        private boolean reactedByMe;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomReactionService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomReactionService.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.studyroom.service;
 
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.ReactionResponse;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedReaction;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemCommentReaction;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemReaction;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,10 @@ public class StudyRoomReactionService {
 
     public List<ReactionResponse> summarizeSharedProblemReactions(Collection<StudyRoomSharedProblemReaction> reactions, Long userId) {
         return summarize(reactions, userId, StudyRoomSharedProblemReaction::getEmoji, reaction -> reaction.getUser().getId());
+    }
+
+    public List<ReactionResponse> summarizeSharedProblemCommentReactions(Collection<StudyRoomSharedProblemCommentReaction> reactions, Long userId) {
+        return summarize(reactions, userId, StudyRoomSharedProblemCommentReaction::getEmoji, reaction -> reaction.getUser().getId());
     }
 
     private <T> List<ReactionResponse> summarize(Collection<T> reactions, Long userId,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -1,0 +1,136 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.exception.UserErrorCase;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomService {
+
+    public static final int MAX_ROOM_MEMBER_COUNT = 20;
+    public static final int MAX_USER_ROOM_COUNT = 10;
+
+    private final StudyRoomRepository roomRepository;
+    private final StudyRoomMemberRepository memberRepository;
+    private final UserRepository userRepository;
+    private final StudyRoomAccessService accessService;
+    private final StudyRoomStatsService statsService;
+    private final StudyRoomMapper mapper;
+
+    @Transactional(readOnly = true)
+    public List<StudyRoomListResponse> getMyRooms(Long userId) {
+        return memberRepository.findAllWithRoomByUserId(userId).stream()
+                .map(mapper::toListResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public StudyRoomDetailResponse getRoom(Long roomId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        StudyRoom room = accessService.getRoomOrThrow(roomId);
+        return buildDetail(room);
+    }
+
+    @Transactional
+    public StudyRoomDetailResponse createRoom(StudyRoomCreateRequest request, Long userId) {
+        String name = validateName(request.name());
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        if (memberRepository.countByUserId(userId) >= MAX_USER_ROOM_COUNT) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_LIMIT_EXCEEDED);
+        }
+        StudyRoom room = StudyRoom.create(name, userId);
+        room.addMember(StudyRoomMember.create(user, StudyRoomMemberRole.HOST));
+        roomRepository.save(room);
+        return buildDetail(room);
+    }
+
+    @Transactional
+    public void deleteRoom(Long roomId, Long userId) {
+        accessService.validateHost(roomId, userId);
+        StudyRoom room = lockRoom(roomId);
+        roomRepository.delete(room);
+    }
+
+    @Transactional
+    public StudyRoom lockRoom(Long roomId) {
+        return roomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_NOT_FOUND));
+    }
+
+    @Transactional
+    public void leaveRoom(Long roomId, Long userId) {
+        StudyRoomMember member = accessService.getMemberOrThrow(roomId, userId);
+        if (member.getRole() != StudyRoomMemberRole.HOST) {
+            memberRepository.deleteByRoomIdAndUserId(roomId, userId);
+            return;
+        }
+
+        StudyRoom room = roomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_NOT_FOUND));
+        List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(roomId);
+        StudyRoomMember nextHost = members.stream()
+                .filter(candidate -> !candidate.getUser().getId().equals(userId))
+                .findFirst()
+                .orElse(null);
+        if (nextHost == null) {
+            roomRepository.delete(room);
+            return;
+        }
+        nextHost.promoteToHost();
+        room.updateHostUserId(nextHost.getUser().getId());
+        memberRepository.deleteByRoomIdAndUserId(roomId, userId);
+    }
+
+    @Transactional
+    public void kickMember(Long roomId, Long memberUserId, Long hostUserId) {
+        accessService.validateHost(roomId, hostUserId);
+        StudyRoomMember member = accessService.getMemberOrThrow(roomId, memberUserId);
+        if (member.getRole() == StudyRoomMemberRole.HOST) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_HOST_ONLY);
+        }
+        memberRepository.deleteByRoomIdAndUserId(roomId, memberUserId);
+    }
+
+    @Transactional
+    public GoalUpdateResponse updateGoal(Long roomId, Long userId, StudyRoomGoalUpdateRequest request) {
+        StudyRoomMember member = accessService.getMemberOrThrow(roomId, userId);
+        Integer weeklyGoal = request.weeklyGoal();
+        if (weeklyGoal != null && weeklyGoal < 0) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+        member.updateWeeklyGoal(weeklyGoal == null || weeklyGoal == 0 ? null : weeklyGoal);
+        StudyRoomStats stats = statsService.getWeeklyStats(List.of(userId)).get(userId);
+        return new GoalUpdateResponse(member.getWeeklyGoal(), member.getWeeklyGoal() == null ? null : stats.weeklyProblemCount());
+    }
+
+    StudyRoomDetailResponse buildDetail(StudyRoom room) {
+        List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(room.getId());
+        List<Long> userIds = members.stream().map(member -> member.getUser().getId()).toList();
+        Map<Long, StudyRoomStats> stats = statsService.getWeeklyStats(userIds);
+        return mapper.toDetailResponse(room, members, stats);
+    }
+
+    private String validateName(String name) {
+        if (name == null || name.isBlank() || name.length() > 20) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+        return name.trim();
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -95,6 +95,27 @@ public class StudyRoomService {
     }
 
     @Transactional
+    public StudyRoomDetailResponse updateRoom(Long roomId, Long userId, String name, MultipartFile thumbnailImage) {
+        if ((name == null || name.isBlank()) && (thumbnailImage == null || thumbnailImage.isEmpty())) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+        accessService.validateHost(roomId, userId);
+        StudyRoom room = lockRoom(roomId);
+        if (name != null) {
+            room.updateName(validateName(name));
+        }
+        if (thumbnailImage != null) {
+            validateThumbnail(thumbnailImage);
+            String previousThumbnailUrl = room.getThumbnailUrl();
+            String thumbnailUrl = fileUploadService.uploadFileToS3(thumbnailImage);
+            deleteThumbnailOnRollback(thumbnailUrl, roomId);
+            room.updateThumbnailUrl(thumbnailUrl);
+            deleteThumbnailAsync(previousThumbnailUrl, roomId);
+        }
+        return buildDetail(room);
+    }
+
+    @Transactional
     public void deleteRoom(Long roomId, Long userId) {
         accessService.validateHost(roomId, userId);
         StudyRoom room = lockRoom(roomId);

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -19,9 +19,13 @@ import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 @Service
@@ -30,6 +34,7 @@ public class StudyRoomService {
 
     public static final int MAX_ROOM_MEMBER_COUNT = 20;
     public static final int MAX_USER_ROOM_COUNT = 10;
+    private static final long MAX_THUMBNAIL_SIZE_BYTES = 5 * 1024 * 1024;
 
     private final StudyRoomRepository roomRepository;
     private final StudyRoomMemberRepository memberRepository;
@@ -93,6 +98,7 @@ public class StudyRoomService {
     public void deleteRoom(Long roomId, Long userId) {
         accessService.validateHost(roomId, userId);
         StudyRoom room = lockRoom(roomId);
+        deleteThumbnailAsync(room.getThumbnailUrl(), roomId);
         roomRepository.delete(room);
     }
 
@@ -118,6 +124,7 @@ public class StudyRoomService {
                 .findFirst()
                 .orElse(null);
         if (nextHost == null) {
+            deleteThumbnailAsync(room.getThumbnailUrl(), roomId);
             roomRepository.delete(room);
             return;
         }
@@ -151,16 +158,13 @@ public class StudyRoomService {
     @Transactional
     public StudyRoomThumbnailUpdateResponse updateThumbnail(Long roomId, Long userId, MultipartFile thumbnail) {
         accessService.validateHost(roomId, userId);
-        if (thumbnail == null || thumbnail.isEmpty()) {
-            throw new ApplicationException(FileUploadErrorCase.FILE_UPLOAD_FAILED);
-        }
+        validateThumbnail(thumbnail);
         StudyRoom room = accessService.getRoomOrThrow(roomId);
         String previousThumbnailUrl = room.getThumbnailUrl();
         String thumbnailUrl = fileUploadService.uploadFileToS3(thumbnail);
+        deleteThumbnailOnRollback(thumbnailUrl, roomId);
         room.updateThumbnailUrl(thumbnailUrl);
-        if (previousThumbnailUrl != null && !previousThumbnailUrl.isBlank()) {
-            s3DeleteProducer.sendDeleteMessage(previousThumbnailUrl, roomId);
-        }
+        deleteThumbnailAsync(previousThumbnailUrl, roomId);
         return new StudyRoomThumbnailUpdateResponse(thumbnailUrl);
     }
 
@@ -177,5 +181,110 @@ public class StudyRoomService {
             throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
         }
         return name.trim();
+    }
+
+    private void validateThumbnail(MultipartFile thumbnail) {
+        if (thumbnail == null || thumbnail.isEmpty()) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+        if (thumbnail.getSize() > MAX_THUMBNAIL_SIZE_BYTES) {
+            throw new ApplicationException(FileUploadErrorCase.FILE_SIZE_EXCEEDED);
+        }
+
+        String extension = getLowercaseExtension(thumbnail.getOriginalFilename());
+        String contentType = thumbnail.getContentType();
+        if (!isAllowedImageType(contentType, extension) || !hasAllowedImageSignature(thumbnail, contentType)) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+    }
+
+    private String getLowercaseExtension(String originalFilename) {
+        if (originalFilename == null) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+        int dotIndex = originalFilename.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == originalFilename.length() - 1) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+        return originalFilename.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isAllowedImageType(String contentType, String extension) {
+        if (contentType == null) {
+            return false;
+        }
+        return switch (contentType) {
+            case "image/jpeg" -> extension.equals("jpg") || extension.equals("jpeg");
+            case "image/png" -> extension.equals("png");
+            case "image/webp" -> extension.equals("webp");
+            default -> false;
+        };
+    }
+
+    private boolean hasAllowedImageSignature(MultipartFile thumbnail, String contentType) {
+        byte[] header = new byte[12];
+        int read;
+        try {
+            read = thumbnail.getInputStream().read(header);
+        } catch (IOException e) {
+            throw new ApplicationException(FileUploadErrorCase.FILE_UPLOAD_FAILED);
+        }
+
+        return switch (contentType) {
+            case "image/jpeg" -> read >= 3
+                    && (header[0] & 0xFF) == 0xFF
+                    && (header[1] & 0xFF) == 0xD8
+                    && (header[2] & 0xFF) == 0xFF;
+            case "image/png" -> read >= 8
+                    && (header[0] & 0xFF) == 0x89
+                    && header[1] == 0x50
+                    && header[2] == 0x4E
+                    && header[3] == 0x47
+                    && header[4] == 0x0D
+                    && header[5] == 0x0A
+                    && header[6] == 0x1A
+                    && header[7] == 0x0A;
+            case "image/webp" -> read >= 12
+                    && header[0] == 0x52
+                    && header[1] == 0x49
+                    && header[2] == 0x46
+                    && header[3] == 0x46
+                    && header[8] == 0x57
+                    && header[9] == 0x45
+                    && header[10] == 0x42
+                    && header[11] == 0x50;
+            default -> false;
+        };
+    }
+
+    private void deleteThumbnailAsync(String thumbnailUrl, Long roomId) {
+        if (thumbnailUrl == null || thumbnailUrl.isBlank()) {
+            return;
+        }
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            s3DeleteProducer.sendDeleteMessage(thumbnailUrl, roomId);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                s3DeleteProducer.sendDeleteMessage(thumbnailUrl, roomId);
+            }
+        });
+    }
+
+    private void deleteThumbnailOnRollback(String thumbnailUrl, Long roomId) {
+        if (thumbnailUrl == null || thumbnailUrl.isBlank()
+                || !TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_ROLLED_BACK) {
+                    s3DeleteProducer.sendDeleteMessage(thumbnailUrl, roomId);
+                }
+            }
+        });
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -3,6 +3,7 @@ package com.aisip.OnO.backend.studyroom.service;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomTodayPracticeSummary;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
@@ -35,8 +36,20 @@ public class StudyRoomService {
 
     @Transactional(readOnly = true)
     public List<StudyRoomListResponse> getMyRooms(Long userId) {
-        return memberRepository.findAllWithRoomByUserId(userId).stream()
-                .map(mapper::toListResponse)
+        List<StudyRoomMember> memberships = memberRepository.findAllWithRoomByUserId(userId);
+        List<Long> roomIds = memberships.stream().map(member -> member.getRoom().getId()).toList();
+        if (roomIds.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, Integer> memberCounts = memberRepository.countMembersByRoomIds(roomIds).stream()
+                .collect(java.util.stream.Collectors.toMap(row -> (Long) row[0], row -> Math.toIntExact((Long) row[1])));
+        Map<Long, StudyRoomTodayPracticeSummary> todayPracticeSummaries = statsService.getTodayPracticeSummariesByRoomIds(roomIds);
+        return memberships.stream()
+                .map(member -> mapper.toListResponse(
+                        member,
+                        memberCounts.getOrDefault(member.getRoom().getId(), 0),
+                        todayPracticeSummaries.getOrDefault(member.getRoom().getId(), StudyRoomTodayPracticeSummary.empty())
+                ))
                 .toList();
     }
 
@@ -124,7 +137,8 @@ public class StudyRoomService {
         List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(room.getId());
         List<Long> userIds = members.stream().map(member -> member.getUser().getId()).toList();
         Map<Long, StudyRoomStats> stats = statsService.getWeeklyStats(userIds);
-        return mapper.toDetailResponse(room, members, stats);
+        Map<Long, Integer> todayPracticeCounts = statsService.getTodayPracticeCounts(userIds);
+        return mapper.toDetailResponse(room, members, stats, todayPracticeCounts);
     }
 
     private String validateName(String name) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -10,12 +10,16 @@ import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
 import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.exception.UserErrorCase;
 import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.fileupload.exception.FileUploadErrorCase;
+import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Map;
@@ -33,6 +37,8 @@ public class StudyRoomService {
     private final StudyRoomAccessService accessService;
     private final StudyRoomStatsService statsService;
     private final StudyRoomMapper mapper;
+    private final FileUploadService fileUploadService;
+    private final S3DeleteProducer s3DeleteProducer;
 
     @Transactional(readOnly = true)
     public List<StudyRoomListResponse> getMyRooms(Long userId) {
@@ -131,6 +137,22 @@ public class StudyRoomService {
         member.updateWeeklyGoal(weeklyGoal == null || weeklyGoal == 0 ? null : weeklyGoal);
         StudyRoomStats stats = statsService.getWeeklyStats(List.of(userId)).get(userId);
         return new GoalUpdateResponse(member.getWeeklyGoal(), member.getWeeklyGoal() == null ? null : stats.weeklyProblemCount());
+    }
+
+    @Transactional
+    public StudyRoomThumbnailUpdateResponse updateThumbnail(Long roomId, Long userId, MultipartFile thumbnail) {
+        accessService.validateHost(roomId, userId);
+        if (thumbnail == null || thumbnail.isEmpty()) {
+            throw new ApplicationException(FileUploadErrorCase.FILE_UPLOAD_FAILED);
+        }
+        StudyRoom room = accessService.getRoomOrThrow(roomId);
+        String previousThumbnailUrl = room.getThumbnailUrl();
+        String thumbnailUrl = fileUploadService.uploadFileToS3(thumbnail);
+        room.updateThumbnailUrl(thumbnailUrl);
+        if (previousThumbnailUrl != null && !previousThumbnailUrl.isBlank()) {
+            s3DeleteProducer.sendDeleteMessage(previousThumbnailUrl, roomId);
+        }
+        return new StudyRoomThumbnailUpdateResponse(thumbnailUrl);
     }
 
     StudyRoomDetailResponse buildDetail(StudyRoom room) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -68,7 +68,7 @@ public class StudyRoomService {
 
     @Transactional
     public StudyRoomDetailResponse createRoom(StudyRoomCreateRequest request, Long userId) {
-        String name = validateName(request.name());
+        String name = validateName(request == null ? null : request.name());
         User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
         if (memberRepository.countByUserId(userId) >= MAX_USER_ROOM_COUNT) {
@@ -77,6 +77,15 @@ public class StudyRoomService {
         StudyRoom room = StudyRoom.create(name, userId);
         room.addMember(StudyRoomMember.create(user, StudyRoomMemberRole.HOST));
         roomRepository.save(room);
+        return buildDetail(room);
+    }
+
+    @Transactional
+    public StudyRoomDetailResponse updateRoom(Long roomId, Long userId, StudyRoomUpdateRequest request) {
+        String name = validateName(request == null ? null : request.name());
+        accessService.validateHost(roomId, userId);
+        StudyRoom room = lockRoom(roomId);
+        room.updateName(name);
         return buildDetail(room);
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.studyroom.service;
 
+import com.aisip.OnO.backend.common.emoji.CustomEmojiValidator;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
@@ -7,8 +8,10 @@ import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblem;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemComment;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemCommentReaction;
 import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentReactionRepository;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemRepository;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.exception.UserErrorCase;
@@ -20,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +35,10 @@ public class StudyRoomSharedProblemCommentService {
     private final StudyRoomAccessService accessService;
     private final StudyRoomSharedProblemRepository sharedProblemRepository;
     private final StudyRoomSharedProblemCommentRepository commentRepository;
+    private final StudyRoomSharedProblemCommentReactionRepository commentReactionRepository;
     private final UserRepository userRepository;
+    private final StudyRoomReactionService reactionService;
+    private final CustomEmojiValidator customEmojiValidator;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<SharedProblemCommentResponse> getComments(Long roomId, Long sharedProblemId,
@@ -42,8 +50,15 @@ public class StudyRoomSharedProblemCommentService {
                 sharedProblemId, cursor, PageRequest.of(0, safeSize + 1));
         boolean hasNext = comments.size() > safeSize;
         List<StudyRoomSharedProblemComment> contentComments = hasNext ? comments.subList(0, safeSize) : comments;
+        List<Long> commentIds = contentComments.stream()
+                .map(StudyRoomSharedProblemComment::getId)
+                .toList();
+        Map<Long, List<StudyRoomSharedProblemCommentReaction>> reactions = commentIds.isEmpty()
+                ? Map.of()
+                : commentReactionRepository.findAllByCommentIds(commentIds).stream()
+                .collect(Collectors.groupingBy(reaction -> reaction.getComment().getId()));
         List<SharedProblemCommentResponse> content = contentComments.stream()
-                .map(comment -> toResponse(comment, userId))
+                .map(comment -> toResponse(comment, reactions.getOrDefault(comment.getId(), List.of()), userId))
                 .toList();
         Long nextCursor = hasNext && !contentComments.isEmpty()
                 ? contentComments.get(contentComments.size() - 1).getId()
@@ -60,7 +75,7 @@ public class StudyRoomSharedProblemCommentService {
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
         StudyRoomSharedProblemComment comment = commentRepository.save(
                 StudyRoomSharedProblemComment.create(sharedProblem, user, validateContent(request)));
-        return toResponse(comment, userId, false);
+        return toResponse(comment, List.of(), userId, false);
     }
 
     @Transactional
@@ -72,7 +87,22 @@ public class StudyRoomSharedProblemCommentService {
             throw new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_COMMENT_FORBIDDEN);
         }
         comment.updateContent(validateContent(request));
-        return toResponse(comment, userId, true);
+        return toResponse(comment, commentReactionRepository.findAllByCommentId(commentId), userId, true);
+    }
+
+    @Transactional
+    public SharedProblemCommentReactionToggleResponse toggleReaction(Long roomId, Long sharedProblemId, Long commentId,
+                                                                     Long userId, ReactionToggleRequest request) {
+        accessService.validateMember(roomId, userId);
+        customEmojiValidator.validate(request.emoji());
+        StudyRoomSharedProblemComment comment = getCommentOrThrow(roomId, sharedProblemId, commentId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        commentReactionRepository.findByCommentIdAndUserIdAndEmoji(commentId, userId, request.emoji())
+                .ifPresentOrElse(commentReactionRepository::delete,
+                        () -> commentReactionRepository.save(StudyRoomSharedProblemCommentReaction.create(comment, user, request.emoji())));
+        return new SharedProblemCommentReactionToggleResponse(commentId,
+                reactionService.summarizeSharedProblemCommentReactions(commentReactionRepository.findAllByCommentId(commentId), userId));
     }
 
     @Transactional
@@ -84,6 +114,7 @@ public class StudyRoomSharedProblemCommentService {
         if (!mine && !host) {
             throw new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_COMMENT_FORBIDDEN);
         }
+        commentReactionRepository.deleteByCommentId(commentId);
         commentRepository.delete(comment);
     }
 
@@ -106,10 +137,19 @@ public class StudyRoomSharedProblemCommentService {
     }
 
     private SharedProblemCommentResponse toResponse(StudyRoomSharedProblemComment comment, Long userId) {
-        return toResponse(comment, userId, false);
+        return toResponse(comment, List.of(), userId, false);
     }
 
-    private SharedProblemCommentResponse toResponse(StudyRoomSharedProblemComment comment, Long userId, boolean forceEdited) {
+    private SharedProblemCommentResponse toResponse(StudyRoomSharedProblemComment comment,
+                                                    List<StudyRoomSharedProblemCommentReaction> reactions,
+                                                    Long userId) {
+        return toResponse(comment, reactions, userId, false);
+    }
+
+    private SharedProblemCommentResponse toResponse(StudyRoomSharedProblemComment comment,
+                                                    List<StudyRoomSharedProblemCommentReaction> reactions,
+                                                    Long userId,
+                                                    boolean forceEdited) {
         LocalDateTime createdAt = comment.getCreatedAt();
         LocalDateTime updatedAt = comment.getUpdatedAt();
         Long authorId = comment.getAuthor().getId();
@@ -120,12 +160,13 @@ public class StudyRoomSharedProblemCommentService {
                 comment.getContent(),
                 authorId,
                 comment.getAuthor().getName(),
-                null,
+                comment.getAuthor().getProfileImageUrl(),
                 createdAt,
                 updatedAt,
                 forceEdited || createdAt != null && updatedAt != null && updatedAt.isAfter(createdAt),
                 mine,
-                canDelete
+                canDelete,
+                reactionService.summarizeSharedProblemCommentReactions(reactions, userId)
         );
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
@@ -1,0 +1,123 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.common.response.CursorPageResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblem;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomSharedProblemComment;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.exception.UserErrorCase;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomSharedProblemCommentService {
+
+    private static final int MAX_COMMENT_LENGTH = 1000;
+
+    private final StudyRoomAccessService accessService;
+    private final StudyRoomSharedProblemRepository sharedProblemRepository;
+    private final StudyRoomSharedProblemCommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public CursorPageResponse<SharedProblemCommentResponse> getComments(Long roomId, Long sharedProblemId,
+                                                                        Long userId, Long cursor, int size) {
+        accessService.validateMember(roomId, userId);
+        getSharedProblemOrThrow(roomId, sharedProblemId);
+        int safeSize = Math.min(Math.max(size, 1), 50);
+        List<StudyRoomSharedProblemComment> comments = commentRepository.findBySharedProblemIdAndCursor(
+                sharedProblemId, cursor, PageRequest.of(0, safeSize + 1));
+        boolean hasNext = comments.size() > safeSize;
+        List<StudyRoomSharedProblemComment> contentComments = hasNext ? comments.subList(0, safeSize) : comments;
+        List<SharedProblemCommentResponse> content = contentComments.stream()
+                .map(comment -> toResponse(comment, userId))
+                .toList();
+        Long nextCursor = hasNext && !contentComments.isEmpty()
+                ? contentComments.get(contentComments.size() - 1).getId()
+                : null;
+        return new CursorPageResponse<>(content, nextCursor, hasNext, safeSize);
+    }
+
+    @Transactional
+    public SharedProblemCommentResponse createComment(Long roomId, Long sharedProblemId, Long userId,
+                                                      SharedProblemCommentRequest request) {
+        accessService.validateMember(roomId, userId);
+        StudyRoomSharedProblem sharedProblem = getSharedProblemOrThrow(roomId, sharedProblemId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        StudyRoomSharedProblemComment comment = commentRepository.save(
+                StudyRoomSharedProblemComment.create(sharedProblem, user, validateContent(request)));
+        return toResponse(comment, userId);
+    }
+
+    @Transactional
+    public SharedProblemCommentResponse updateComment(Long roomId, Long sharedProblemId, Long commentId,
+                                                      Long userId, SharedProblemCommentRequest request) {
+        accessService.validateMember(roomId, userId);
+        StudyRoomSharedProblemComment comment = getCommentOrThrow(roomId, sharedProblemId, commentId);
+        if (!comment.getAuthor().getId().equals(userId)) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
+        }
+        comment.updateContent(validateContent(request));
+        return toResponse(comment, userId);
+    }
+
+    @Transactional
+    public void deleteComment(Long roomId, Long sharedProblemId, Long commentId, Long userId) {
+        StudyRoomMember member = accessService.getMemberOrThrow(roomId, userId);
+        StudyRoomSharedProblemComment comment = getCommentOrThrow(roomId, sharedProblemId, commentId);
+        boolean mine = comment.getAuthor().getId().equals(userId);
+        boolean host = member.getRole() == StudyRoomMemberRole.HOST;
+        if (!mine && !host) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
+        }
+        commentRepository.delete(comment);
+    }
+
+    private StudyRoomSharedProblem getSharedProblemOrThrow(Long roomId, Long sharedProblemId) {
+        return sharedProblemRepository.findByIdAndRoomId(sharedProblemId, roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_NOT_FOUND));
+    }
+
+    private StudyRoomSharedProblemComment getCommentOrThrow(Long roomId, Long sharedProblemId, Long commentId) {
+        return commentRepository.findByIdAndSharedProblemIdAndRoomId(commentId, sharedProblemId, roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_COMMENT_NOT_FOUND));
+    }
+
+    private String validateContent(SharedProblemCommentRequest request) {
+        String content = request == null ? null : request.content();
+        if (content == null || content.isBlank() || content.length() > MAX_COMMENT_LENGTH) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+        return content.trim();
+    }
+
+    private SharedProblemCommentResponse toResponse(StudyRoomSharedProblemComment comment, Long userId) {
+        LocalDateTime createdAt = comment.getCreatedAt();
+        LocalDateTime updatedAt = comment.getUpdatedAt();
+        return new SharedProblemCommentResponse(
+                comment.getId(),
+                comment.getContent(),
+                comment.getAuthor().getId(),
+                comment.getAuthor().getName(),
+                null,
+                createdAt,
+                updatedAt,
+                createdAt != null && updatedAt != null && updatedAt.isAfter(createdAt),
+                comment.getAuthor().getId().equals(userId)
+        );
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
@@ -60,7 +60,7 @@ public class StudyRoomSharedProblemCommentService {
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
         StudyRoomSharedProblemComment comment = commentRepository.save(
                 StudyRoomSharedProblemComment.create(sharedProblem, user, validateContent(request)));
-        return toResponse(comment, userId);
+        return toResponse(comment, userId, false);
     }
 
     @Transactional
@@ -72,7 +72,7 @@ public class StudyRoomSharedProblemCommentService {
             throw new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_COMMENT_FORBIDDEN);
         }
         comment.updateContent(validateContent(request));
-        return toResponse(comment, userId);
+        return toResponse(comment, userId, true);
     }
 
     @Transactional
@@ -106,18 +106,26 @@ public class StudyRoomSharedProblemCommentService {
     }
 
     private SharedProblemCommentResponse toResponse(StudyRoomSharedProblemComment comment, Long userId) {
+        return toResponse(comment, userId, false);
+    }
+
+    private SharedProblemCommentResponse toResponse(StudyRoomSharedProblemComment comment, Long userId, boolean forceEdited) {
         LocalDateTime createdAt = comment.getCreatedAt();
         LocalDateTime updatedAt = comment.getUpdatedAt();
+        Long authorId = comment.getAuthor().getId();
+        boolean mine = authorId.equals(userId);
+        boolean canDelete = mine || comment.getSharedProblem().getRoom().getHostUserId().equals(userId);
         return new SharedProblemCommentResponse(
                 comment.getId(),
                 comment.getContent(),
-                comment.getAuthor().getId(),
+                authorId,
                 comment.getAuthor().getName(),
                 null,
                 createdAt,
                 updatedAt,
-                createdAt != null && updatedAt != null && updatedAt.isAfter(createdAt),
-                comment.getAuthor().getId().equals(userId)
+                forceEdited || createdAt != null && updatedAt != null && updatedAt.isAfter(createdAt),
+                mine,
+                canDelete
         );
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
@@ -25,7 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StudyRoomSharedProblemCommentService {
 
-    private static final int MAX_COMMENT_LENGTH = 1000;
+    private static final int MAX_COMMENT_LENGTH = 300;
 
     private final StudyRoomAccessService accessService;
     private final StudyRoomSharedProblemRepository sharedProblemRepository;
@@ -69,7 +69,7 @@ public class StudyRoomSharedProblemCommentService {
         accessService.validateMember(roomId, userId);
         StudyRoomSharedProblemComment comment = getCommentOrThrow(roomId, sharedProblemId, commentId);
         if (!comment.getAuthor().getId().equals(userId)) {
-            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
+            throw new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_COMMENT_FORBIDDEN);
         }
         comment.updateContent(validateContent(request));
         return toResponse(comment, userId);
@@ -82,7 +82,7 @@ public class StudyRoomSharedProblemCommentService {
         boolean mine = comment.getAuthor().getId().equals(userId);
         boolean host = member.getRole() == StudyRoomMemberRole.HOST;
         if (!mine && !host) {
-            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
+            throw new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_COMMENT_FORBIDDEN);
         }
         commentRepository.delete(comment);
     }
@@ -100,7 +100,7 @@ public class StudyRoomSharedProblemCommentService {
     private String validateContent(SharedProblemCommentRequest request) {
         String content = request == null ? null : request.content();
         if (content == null || content.isBlank() || content.length() > MAX_COMMENT_LENGTH) {
-            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_SHARED_PROBLEM_COMMENT);
         }
         return content.trim();
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemCommentService.java
@@ -16,7 +16,10 @@ import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemReposito
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.exception.UserErrorCase;
 import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.fcm.dto.NotificationRequestDto;
+import com.aisip.OnO.backend.util.fcm.service.FcmService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StudyRoomSharedProblemCommentService {
@@ -39,6 +43,7 @@ public class StudyRoomSharedProblemCommentService {
     private final UserRepository userRepository;
     private final StudyRoomReactionService reactionService;
     private final CustomEmojiValidator customEmojiValidator;
+    private final FcmService fcmService;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<SharedProblemCommentResponse> getComments(Long roomId, Long sharedProblemId,
@@ -75,6 +80,20 @@ public class StudyRoomSharedProblemCommentService {
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
         StudyRoomSharedProblemComment comment = commentRepository.save(
                 StudyRoomSharedProblemComment.create(sharedProblem, user, validateContent(request)));
+        Long sharerId = sharedProblem.getSharedByUser().getId();
+        if (!sharerId.equals(userId)) {
+            String preview = comment.getContent().length() > 50
+                    ? comment.getContent().substring(0, 50) + "…"
+                    : comment.getContent();
+            try {
+                fcmService.sendNotificationToAllUserDevice(sharerId, new NotificationRequestDto(null,
+                        "공유 문제에 댓글이 달렸어요",
+                        user.getName() + ": " + preview,
+                        Map.of("type", "SHARED_PROBLEM_COMMENT", "roomId", String.valueOf(roomId), "sharedProblemId", String.valueOf(sharedProblemId))));
+            } catch (Exception e) {
+                log.warn("댓글 알림 발송 실패 - userId: {}", sharerId, e);
+            }
+        }
         return toResponse(comment, List.of(), userId, false);
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.studyroom.service;
 
+import com.aisip.OnO.backend.common.emoji.CustomEmojiValidator;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
 import com.aisip.OnO.backend.problem.entity.Problem;
@@ -22,14 +23,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class StudyRoomSharedProblemService {
-
-    private static final Set<String> ALLOWED_SHARED_PROBLEM_EMOJIS = Set.of("😱", "🔥", "👍", "🎉");
 
     private final StudyRoomAccessService accessService;
     private final StudyRoomSharedProblemRepository sharedProblemRepository;
@@ -38,6 +36,7 @@ public class StudyRoomSharedProblemService {
     private final ProblemService problemService;
     private final StudyRoomReactionService reactionService;
     private final ApplicationEventPublisher eventPublisher;
+    private final CustomEmojiValidator customEmojiValidator;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<SharedProblemResponse> getSharedProblems(Long roomId, Long userId, Long cursor, int size) {
@@ -79,9 +78,7 @@ public class StudyRoomSharedProblemService {
     @Transactional
     public SharedProblemReactionToggleResponse toggleReaction(Long roomId, Long sharedProblemId, Long userId, ReactionToggleRequest request) {
         accessService.validateMember(roomId, userId);
-        if (!ALLOWED_SHARED_PROBLEM_EMOJIS.contains(request.emoji())) {
-            throw new ApplicationException(StudyRoomErrorCase.INVALID_REACTION_EMOJI);
-        }
+        customEmojiValidator.validate(request.emoji());
         StudyRoomSharedProblem sharedProblem = sharedProblemRepository.findByIdAndRoomId(sharedProblemId, roomId)
                 .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_NOT_FOUND));
         User user = userRepository.findById(userId)

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
@@ -15,7 +15,10 @@ import com.aisip.OnO.backend.studyroom.repository.*;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.exception.UserErrorCase;
 import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.fcm.dto.NotificationRequestDto;
+import com.aisip.OnO.backend.util.fcm.service.FcmService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StudyRoomSharedProblemService {
@@ -34,11 +38,13 @@ public class StudyRoomSharedProblemService {
     private final StudyRoomSharedProblemReactionRepository reactionRepository;
     private final StudyRoomSharedProblemCommentRepository commentRepository;
     private final StudyRoomSharedProblemCommentReactionRepository commentReactionRepository;
+    private final StudyRoomMemberRepository memberRepository;
     private final UserRepository userRepository;
     private final ProblemService problemService;
     private final StudyRoomReactionService reactionService;
     private final ApplicationEventPublisher eventPublisher;
     private final CustomEmojiValidator customEmojiValidator;
+    private final FcmService fcmService;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<SharedProblemResponse> getSharedProblems(Long roomId, Long userId, Long cursor, int size) {
@@ -88,6 +94,10 @@ public class StudyRoomSharedProblemService {
         eventPublisher.publishEvent(new StudyRoomActivityEvent(userId, StudyRoomFeedEventType.PROBLEM_SHARED,
                 Map.of("reference", problem.getReference() == null ? "" : problem.getReference(),
                         "sharedProblemId", sharedProblem.getId())));
+        notifyRoomMembers(roomId, userId,
+                user.getName() + "님이 문제를 공유했어요",
+                referenceOrFallback(problem.getReference()),
+                Map.of("type", "SHARED_PROBLEM", "roomId", String.valueOf(roomId), "sharedProblemId", String.valueOf(sharedProblem.getId())));
         return toResponse(sharedProblem, List.of(), 0L, userId);
     }
 
@@ -99,9 +109,22 @@ public class StudyRoomSharedProblemService {
                 .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_NOT_FOUND));
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
-        reactionRepository.findBySharedProblemIdAndUserIdAndEmoji(sharedProblemId, userId, request.emoji())
-                .ifPresentOrElse(reactionRepository::delete,
-                        () -> reactionRepository.save(StudyRoomSharedProblemReaction.create(sharedProblem, user, request.emoji())));
+        boolean added;
+        var existing = reactionRepository.findBySharedProblemIdAndUserIdAndEmoji(sharedProblemId, userId, request.emoji());
+        if (existing.isPresent()) {
+            reactionRepository.delete(existing.get());
+            added = false;
+        } else {
+            reactionRepository.save(StudyRoomSharedProblemReaction.create(sharedProblem, user, request.emoji()));
+            added = true;
+        }
+        Long sharerId = sharedProblem.getSharedByUser().getId();
+        if (added && !sharerId.equals(userId)) {
+            notifyUser(sharerId,
+                    "공유 문제에 반응이 달렸어요",
+                    user.getName() + "님이 " + request.emoji() + " 반응을 남겼어요.",
+                    Map.of("type", "SHARED_PROBLEM_REACTION", "roomId", String.valueOf(roomId), "sharedProblemId", String.valueOf(sharedProblemId)));
+        }
         return new SharedProblemReactionToggleResponse(sharedProblemId,
                 reactionService.summarizeSharedProblemReactions(reactionRepository.findAllBySharedProblemId(sharedProblemId), userId));
     }
@@ -156,5 +179,27 @@ public class StudyRoomSharedProblemService {
         return problemImageUrls(problem).stream()
                 .findFirst()
                 .orElse(null);
+    }
+
+    private void notifyRoomMembers(Long roomId, Long excludeUserId, String title, String body, Map<String, String> data) {
+        NotificationRequestDto dto = new NotificationRequestDto(null, title, body, data);
+        memberRepository.findAllWithUserByRoomId(roomId).forEach(member -> {
+            Long memberId = member.getUser().getId();
+            if (!memberId.equals(excludeUserId)) {
+                notifyUser(memberId, dto);
+            }
+        });
+    }
+
+    private void notifyUser(Long userId, String title, String body, Map<String, String> data) {
+        notifyUser(userId, new NotificationRequestDto(null, title, body, data));
+    }
+
+    private void notifyUser(Long userId, NotificationRequestDto dto) {
+        try {
+            fcmService.sendNotificationToAllUserDevice(userId, dto);
+        } catch (Exception e) {
+            log.warn("공유 문제 알림 발송 실패 - userId: {}", userId, e);
+        }
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
@@ -32,6 +32,7 @@ public class StudyRoomSharedProblemService {
     private final StudyRoomAccessService accessService;
     private final StudyRoomSharedProblemRepository sharedProblemRepository;
     private final StudyRoomSharedProblemReactionRepository reactionRepository;
+    private final StudyRoomSharedProblemCommentRepository commentRepository;
     private final UserRepository userRepository;
     private final ProblemService problemService;
     private final StudyRoomReactionService reactionService;
@@ -98,6 +99,7 @@ public class StudyRoomSharedProblemService {
         if (!sharedProblem.getSharedByUser().getId().equals(userId)) {
             throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
         }
+        commentRepository.deleteBySharedProblemId(sharedProblemId);
         reactionRepository.deleteBySharedProblemId(sharedProblemId);
         sharedProblemRepository.delete(sharedProblem);
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
@@ -77,6 +77,9 @@ public class StudyRoomSharedProblemService {
         if (request.problemId() == null || request.comment() != null && request.comment().length() > 100) {
             throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
         }
+        if (sharedProblemRepository.existsByRoomIdAndProblemId(roomId, request.problemId())) {
+            throw new ApplicationException(StudyRoomErrorCase.ALREADY_SHARED_PROBLEM);
+        }
         Problem problem = problemService.findProblemEntityWithImageData(request.problemId(), userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
@@ -33,6 +33,7 @@ public class StudyRoomSharedProblemService {
     private final StudyRoomSharedProblemRepository sharedProblemRepository;
     private final StudyRoomSharedProblemReactionRepository reactionRepository;
     private final StudyRoomSharedProblemCommentRepository commentRepository;
+    private final StudyRoomSharedProblemCommentReactionRepository commentReactionRepository;
     private final UserRepository userRepository;
     private final ProblemService problemService;
     private final StudyRoomReactionService reactionService;
@@ -46,12 +47,23 @@ public class StudyRoomSharedProblemService {
         List<StudyRoomSharedProblem> sharedProblems = sharedProblemRepository.findByRoomIdAndCursor(roomId, cursor, PageRequest.of(0, safeSize + 1));
         boolean hasNext = sharedProblems.size() > safeSize;
         List<StudyRoomSharedProblem> contentSharedProblems = hasNext ? sharedProblems.subList(0, safeSize) : sharedProblems;
-        Map<Long, List<StudyRoomSharedProblemReaction>> reactions = reactionRepository.findAllBySharedProblemIds(
-                        contentSharedProblems.stream().map(StudyRoomSharedProblem::getId).toList())
-                .stream()
+        List<Long> sharedProblemIds = contentSharedProblems.stream()
+                .map(StudyRoomSharedProblem::getId)
+                .toList();
+        Map<Long, List<StudyRoomSharedProblemReaction>> reactions = sharedProblemIds.isEmpty()
+                ? Map.of()
+                : reactionRepository.findAllBySharedProblemIds(sharedProblemIds).stream()
                 .collect(Collectors.groupingBy(reaction -> reaction.getSharedProblem().getId()));
+        Map<Long, Long> commentCounts = sharedProblemIds.isEmpty()
+                ? Map.of()
+                : commentRepository.countBySharedProblemIds(sharedProblemIds).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
         List<SharedProblemResponse> content = contentSharedProblems.stream()
-                .map(sharedProblem -> toResponse(sharedProblem, reactions.getOrDefault(sharedProblem.getId(), List.of()), userId))
+                .map(sharedProblem -> toResponse(
+                        sharedProblem,
+                        reactions.getOrDefault(sharedProblem.getId(), List.of()),
+                        commentCounts.getOrDefault(sharedProblem.getId(), 0L),
+                        userId))
                 .toList();
         Long nextCursor = hasNext && !contentSharedProblems.isEmpty()
                 ? contentSharedProblems.get(contentSharedProblems.size() - 1).getId()
@@ -73,7 +85,7 @@ public class StudyRoomSharedProblemService {
         eventPublisher.publishEvent(new StudyRoomActivityEvent(userId, StudyRoomFeedEventType.PROBLEM_SHARED,
                 Map.of("reference", problem.getReference() == null ? "" : problem.getReference(),
                         "sharedProblemId", sharedProblem.getId())));
-        return toResponse(sharedProblem, List.of(), userId);
+        return toResponse(sharedProblem, List.of(), 0L, userId);
     }
 
     @Transactional
@@ -99,6 +111,7 @@ public class StudyRoomSharedProblemService {
         if (!sharedProblem.getSharedByUser().getId().equals(userId)) {
             throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
         }
+        commentReactionRepository.deleteBySharedProblemId(sharedProblemId);
         commentRepository.deleteBySharedProblemId(sharedProblemId);
         reactionRepository.deleteBySharedProblemId(sharedProblemId);
         sharedProblemRepository.delete(sharedProblem);
@@ -106,25 +119,38 @@ public class StudyRoomSharedProblemService {
 
     private SharedProblemResponse toResponse(StudyRoomSharedProblem sharedProblem,
                                              List<StudyRoomSharedProblemReaction> reactions,
+                                             long commentCount,
                                              Long userId) {
         Problem problem = sharedProblem.getProblem();
         return new SharedProblemResponse(
                 sharedProblem.getId(),
                 sharedProblem.getSharedByUser().getId(),
                 sharedProblem.getSharedByUser().getName(),
+                sharedProblem.getSharedByUser().getProfileImageUrl(),
                 problem.getId(),
                 problemImageUrl(problem),
-                problem.getReference(),
+                problemImageUrls(problem),
+                referenceOrFallback(problem.getReference()),
                 sharedProblem.getComment(),
+                commentCount,
                 sharedProblem.getCreatedAt(),
                 reactionService.summarizeSharedProblemReactions(reactions, userId)
         );
     }
 
-    private String problemImageUrl(Problem problem) {
+    private String referenceOrFallback(String reference) {
+        return reference == null || reference.isBlank() ? "공유 문제" : reference;
+    }
+
+    private List<String> problemImageUrls(Problem problem) {
         return problem.getProblemImageDataList().stream()
                 .filter(image -> image.getProblemImageType() == ProblemImageType.PROBLEM_IMAGE)
                 .map(ProblemImageData::getImageUrl)
+                .toList();
+    }
+
+    private String problemImageUrl(Problem problem) {
+        return problemImageUrls(problem).stream()
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
@@ -98,6 +98,7 @@ public class StudyRoomSharedProblemService {
         if (!sharedProblem.getSharedByUser().getId().equals(userId)) {
             throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
         }
+        reactionRepository.deleteBySharedProblemId(sharedProblemId);
         sharedProblemRepository.delete(sharedProblem);
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomSharedProblemService.java
@@ -1,0 +1,131 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.common.response.CursorPageResponse;
+import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.entity.ProblemImageData;
+import com.aisip.OnO.backend.problem.entity.ProblemImageType;
+import com.aisip.OnO.backend.problem.service.ProblemService;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.*;
+import com.aisip.OnO.backend.studyroom.event.StudyRoomActivityEvent;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.exception.UserErrorCase;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomSharedProblemService {
+
+    private static final Set<String> ALLOWED_SHARED_PROBLEM_EMOJIS = Set.of("😱", "🔥", "👍", "🎉");
+
+    private final StudyRoomAccessService accessService;
+    private final StudyRoomSharedProblemRepository sharedProblemRepository;
+    private final StudyRoomSharedProblemReactionRepository reactionRepository;
+    private final UserRepository userRepository;
+    private final ProblemService problemService;
+    private final StudyRoomReactionService reactionService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional(readOnly = true)
+    public CursorPageResponse<SharedProblemResponse> getSharedProblems(Long roomId, Long userId, Long cursor, int size) {
+        accessService.validateMember(roomId, userId);
+        int safeSize = Math.min(size, 50);
+        List<StudyRoomSharedProblem> sharedProblems = sharedProblemRepository.findByRoomIdAndCursor(roomId, cursor, PageRequest.of(0, safeSize + 1));
+        boolean hasNext = sharedProblems.size() > safeSize;
+        List<StudyRoomSharedProblem> contentSharedProblems = hasNext ? sharedProblems.subList(0, safeSize) : sharedProblems;
+        Map<Long, List<StudyRoomSharedProblemReaction>> reactions = reactionRepository.findAllBySharedProblemIds(
+                        contentSharedProblems.stream().map(StudyRoomSharedProblem::getId).toList())
+                .stream()
+                .collect(Collectors.groupingBy(reaction -> reaction.getSharedProblem().getId()));
+        List<SharedProblemResponse> content = contentSharedProblems.stream()
+                .map(sharedProblem -> toResponse(sharedProblem, reactions.getOrDefault(sharedProblem.getId(), List.of()), userId))
+                .toList();
+        Long nextCursor = hasNext && !contentSharedProblems.isEmpty()
+                ? contentSharedProblems.get(contentSharedProblems.size() - 1).getId()
+                : null;
+        return new CursorPageResponse<>(content, nextCursor, hasNext, safeSize);
+    }
+
+    @Transactional
+    public SharedProblemResponse shareProblem(Long roomId, Long userId, SharedProblemCreateRequest request) {
+        accessService.validateMember(roomId, userId);
+        if (request.problemId() == null || request.comment() != null && request.comment().length() > 100) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+        Problem problem = problemService.findProblemEntityWithImageData(request.problemId(), userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        StudyRoomSharedProblem sharedProblem = sharedProblemRepository.save(
+                StudyRoomSharedProblem.create(accessService.getRoomOrThrow(roomId), user, problem, request.comment()));
+        eventPublisher.publishEvent(new StudyRoomActivityEvent(userId, StudyRoomFeedEventType.PROBLEM_SHARED,
+                Map.of("reference", problem.getReference() == null ? "" : problem.getReference(),
+                        "sharedProblemId", sharedProblem.getId())));
+        return toResponse(sharedProblem, List.of(), userId);
+    }
+
+    @Transactional
+    public SharedProblemReactionToggleResponse toggleReaction(Long roomId, Long sharedProblemId, Long userId, ReactionToggleRequest request) {
+        accessService.validateMember(roomId, userId);
+        if (!ALLOWED_SHARED_PROBLEM_EMOJIS.contains(request.emoji())) {
+            throw new ApplicationException(StudyRoomErrorCase.INVALID_REACTION_EMOJI);
+        }
+        StudyRoomSharedProblem sharedProblem = sharedProblemRepository.findByIdAndRoomId(sharedProblemId, roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        reactionRepository.findBySharedProblemIdAndUserIdAndEmoji(sharedProblemId, userId, request.emoji())
+                .ifPresentOrElse(reactionRepository::delete,
+                        () -> reactionRepository.save(StudyRoomSharedProblemReaction.create(sharedProblem, user, request.emoji())));
+        return new SharedProblemReactionToggleResponse(sharedProblemId,
+                reactionService.summarizeSharedProblemReactions(reactionRepository.findAllBySharedProblemId(sharedProblemId), userId));
+    }
+
+    @Transactional
+    public void deleteSharedProblem(Long roomId, Long sharedProblemId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        StudyRoomSharedProblem sharedProblem = sharedProblemRepository.findByIdAndRoomId(sharedProblemId, roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.SHARED_PROBLEM_NOT_FOUND));
+        if (!sharedProblem.getSharedByUser().getId().equals(userId)) {
+            throw new ApplicationException(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
+        }
+        sharedProblemRepository.delete(sharedProblem);
+    }
+
+    private SharedProblemResponse toResponse(StudyRoomSharedProblem sharedProblem,
+                                             List<StudyRoomSharedProblemReaction> reactions,
+                                             Long userId) {
+        Problem problem = sharedProblem.getProblem();
+        return new SharedProblemResponse(
+                sharedProblem.getId(),
+                sharedProblem.getSharedByUser().getId(),
+                sharedProblem.getSharedByUser().getName(),
+                problem.getId(),
+                problemImageUrl(problem),
+                problem.getReference(),
+                sharedProblem.getComment(),
+                sharedProblem.getCreatedAt(),
+                reactionService.summarizeSharedProblemReactions(reactions, userId)
+        );
+    }
+
+    private String problemImageUrl(Problem problem) {
+        return problem.getProblemImageDataList().stream()
+                .filter(image -> image.getProblemImageType() == ProblemImageType.PROBLEM_IMAGE)
+                .map(ProblemImageData::getImageUrl)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomStatsService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomStatsService.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.studyroom.service;
 
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomTodayPracticeSummary;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,38 @@ public class StudyRoomStatsService {
         return getStats(userIds, start, end, today);
     }
 
+    public Map<Long, Integer> getTodayPracticeCounts(Collection<Long> userIds) {
+        LocalDate today = LocalDate.now(KST);
+        return countPractices(userIds, today.atStartOfDay(), today.atTime(LocalTime.MAX));
+    }
+
+    public Map<Long, StudyRoomTodayPracticeSummary> getTodayPracticeSummariesByRoomIds(Collection<Long> roomIds) {
+        List<Long> ids = roomIds.stream().distinct().toList();
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        LocalDate today = LocalDate.now(KST);
+        List<Object[]> rows = entityManager.createQuery("""
+                        select m.room.id, count(distinct ps.userId), count(ps.id)
+                        from StudyRoomMember m
+                        join ProblemSolve ps on ps.userId = m.user.id
+                        where m.room.id in :roomIds and ps.practicedAt between :start and :end
+                        group by m.room.id
+                        """, Object[].class)
+                .setParameter("roomIds", ids)
+                .setParameter("start", today.atStartOfDay())
+                .setParameter("end", today.atTime(LocalTime.MAX))
+                .getResultList();
+        Map<Long, StudyRoomTodayPracticeSummary> result = new HashMap<>();
+        for (Object[] row : rows) {
+            result.put((Long) row[0], new StudyRoomTodayPracticeSummary(
+                    Math.toIntExact((Long) row[1]),
+                    Math.toIntExact((Long) row[2])
+            ));
+        }
+        return result;
+    }
+
     public Map<Long, StudyRoomStats> getStats(Collection<Long> userIds, LocalDateTime start, LocalDateTime end, LocalDate today) {
         List<Long> ids = userIds.stream().distinct().toList();
         Map<Long, Integer> streaks = currentStreaks(ids, today);
@@ -53,6 +86,23 @@ public class StudyRoomStatsService {
                     practices.getOrDefault(userId, 0),
                     streaks.getOrDefault(userId, 0)
             ));
+        }
+        return result;
+    }
+
+    public Map<Long, Integer> attendanceDayCounts(Collection<Long> userIds, LocalDateTime start, LocalDateTime end) {
+        List<Long> ids = userIds.stream().distinct().toList();
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        LocalDate today = end.toLocalDate();
+        Map<Long, TreeSet<LocalDate>> studyDates = new HashMap<>();
+        addStudyDates(studyDates, findProblemStudyDates(ids, today, start));
+        addStudyDates(studyDates, findPracticeStudyDates(ids, today, start));
+
+        Map<Long, Integer> result = new HashMap<>();
+        for (Long userId : ids) {
+            result.put(userId, studyDates.getOrDefault(userId, new TreeSet<>()).size());
         }
         return result;
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomStatsService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomStatsService.java
@@ -1,0 +1,182 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.Collection;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyRoomStatsService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final EntityManager entityManager;
+
+    public Map<Long, StudyRoomStats> getWeeklyStats(Collection<Long> userIds) {
+        LocalDate today = LocalDate.now(KST);
+        LocalDate startDate = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = today.atTime(LocalTime.MAX);
+        return getStats(userIds, start, end, today);
+    }
+
+    public Map<Long, StudyRoomStats> getStats(Collection<Long> userIds, LocalDateTime start, LocalDateTime end, LocalDate today) {
+        List<Long> ids = userIds.stream().distinct().toList();
+        Map<Long, Integer> streaks = currentStreaks(ids, today);
+        return getStats(ids, start, end, streaks);
+    }
+
+    public Map<Long, StudyRoomStats> getStats(Collection<Long> userIds, LocalDateTime start, LocalDateTime end,
+                                              Map<Long, Integer> streaks) {
+        List<Long> ids = userIds.stream().distinct().toList();
+        Map<Long, Integer> problems = countProblems(userIds, start, end);
+        Map<Long, Integer> practices = countPractices(userIds, start, end);
+        Map<Long, StudyRoomStats> result = new HashMap<>();
+        for (Long userId : ids) {
+            result.put(userId, new StudyRoomStats(
+                    problems.getOrDefault(userId, 0),
+                    practices.getOrDefault(userId, 0),
+                    streaks.getOrDefault(userId, 0)
+            ));
+        }
+        return result;
+    }
+
+    public Map<Long, Integer> currentStreaks(Collection<Long> userIds, LocalDate today) {
+        return currentStreaks(userIds, today, null);
+    }
+
+    public Map<Long, Integer> currentStreaks(Collection<Long> userIds, LocalDate today, LocalDate startDate) {
+        List<Long> ids = userIds.stream().distinct().toList();
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        LocalDateTime startAt = (startDate == null ? LocalDate.of(1970, 1, 1) : startDate).atStartOfDay();
+        Map<Long, TreeSet<LocalDate>> studyDates = new HashMap<>();
+        addStudyDates(studyDates, findProblemStudyDates(ids, today, startAt));
+        addStudyDates(studyDates, findPracticeStudyDates(ids, today, startAt));
+
+        Map<Long, Integer> result = new HashMap<>();
+        for (Long userId : ids) {
+            result.put(userId, currentStreak(studyDates.getOrDefault(userId, new TreeSet<>()), today));
+        }
+        return result;
+    }
+
+    private Map<Long, Integer> countProblems(Collection<Long> userIds, LocalDateTime start, LocalDateTime end) {
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Object[]> rows = entityManager.createQuery("""
+                        select p.userId, count(p.id)
+                        from Problem p
+                        where p.userId in :userIds and p.createdAt between :start and :end
+                        group by p.userId
+                        """, Object[].class)
+                .setParameter("userIds", userIds)
+                .setParameter("start", start)
+                .setParameter("end", end)
+                .getResultList();
+        return toCountMap(rows);
+    }
+
+    private Map<Long, Integer> countPractices(Collection<Long> userIds, LocalDateTime start, LocalDateTime end) {
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Object[]> rows = entityManager.createQuery("""
+                        select ps.userId, count(ps.id)
+                        from ProblemSolve ps
+                        where ps.userId in :userIds and ps.practicedAt between :start and :end
+                        group by ps.userId
+                        """, Object[].class)
+                .setParameter("userIds", userIds)
+                .setParameter("start", start)
+                .setParameter("end", end)
+                .getResultList();
+        return toCountMap(rows);
+    }
+
+    private Map<Long, Integer> toCountMap(List<Object[]> rows) {
+        Map<Long, Integer> result = new HashMap<>();
+        for (Object[] row : rows) {
+            result.put((Long) row[0], Math.toIntExact((Long) row[1]));
+        }
+        return result;
+    }
+
+    private List<Object[]> findProblemStudyDates(List<Long> userIds, LocalDate today, LocalDateTime startAt) {
+        return entityManager.createNativeQuery("""
+                        select p.user_id, date(p.created_at)
+                        from problem p
+                        where p.user_id in (:userIds)
+                          and p.created_at >= :startAt
+                          and p.created_at < :endExclusive
+                          and p.deleted_at is null
+                        group by p.user_id, date(p.created_at)
+                        """)
+                .setParameter("userIds", userIds)
+                .setParameter("startAt", startAt)
+                .setParameter("endExclusive", today.plusDays(1).atStartOfDay())
+                .getResultList();
+    }
+
+    private List<Object[]> findPracticeStudyDates(List<Long> userIds, LocalDate today, LocalDateTime startAt) {
+        return entityManager.createNativeQuery("""
+                        select ps.user_id, date(ps.practiced_at)
+                        from problem_solve ps
+                        where ps.user_id in (:userIds)
+                          and ps.practiced_at >= :startAt
+                          and ps.practiced_at < :endExclusive
+                          and ps.deleted_at is null
+                        group by ps.user_id, date(ps.practiced_at)
+                        """)
+                .setParameter("userIds", userIds)
+                .setParameter("startAt", startAt)
+                .setParameter("endExclusive", today.plusDays(1).atStartOfDay())
+                .getResultList();
+    }
+
+    private void addStudyDates(Map<Long, TreeSet<LocalDate>> studyDates, List<Object[]> rows) {
+        for (Object[] row : rows) {
+            Long userId = ((Number) row[0]).longValue();
+            LocalDate date = toLocalDate(row[1]);
+            studyDates.computeIfAbsent(userId, key -> new TreeSet<>()).add(date);
+        }
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof java.sql.Date date) {
+            return date.toLocalDate();
+        }
+        if (value instanceof LocalDate date) {
+            return date;
+        }
+        return LocalDate.parse(value.toString());
+    }
+
+    private int currentStreak(TreeSet<LocalDate> dates, LocalDate today) {
+        LocalDate cursor = dates.contains(today) ? today : today.minusDays(1);
+        int streak = 0;
+        while (dates.contains(cursor)) {
+            streak++;
+            cursor = cursor.minusDays(1);
+        }
+        return streak;
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomWeeklyReportService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomWeeklyReportService.java
@@ -161,7 +161,10 @@ public class StudyRoomWeeklyReportService {
                     challenge.getStartAt().toLocalDate()
             );
             Map<Long, StudyRoomStats> stats = statsService.getStats(userIds, challenge.getStartAt(), challenge.getEndAt(), streaks);
-            if (isChallengeCompleted(challenge, members, stats)) {
+            Map<Long, Integer> attendanceDays = isAttendanceMetric(challenge.getMetric())
+                    ? statsService.attendanceDayCounts(userIds, challenge.getStartAt(), challenge.getEndAt())
+                    : Map.of();
+            if (isChallengeCompleted(challenge, members, stats, attendanceDays)) {
                 challenge.updateStatus(StudyRoomChallengeStatus.COMPLETED);
                 continue;
             }
@@ -172,27 +175,34 @@ public class StudyRoomWeeklyReportService {
     }
 
     private boolean isChallengeCompleted(StudyRoomChallenge challenge, List<StudyRoomMember> members,
-                                         Map<Long, StudyRoomStats> stats) {
+                                         Map<Long, StudyRoomStats> stats, Map<Long, Integer> attendanceDays) {
         if (members.isEmpty()) {
             return false;
         }
         if (challenge.getType() == StudyRoomChallengeType.GROUP) {
-            int groupCurrent = stats.values().stream()
-                    .mapToInt(stat -> metricValue(challenge.getMetric(), stat))
+            int groupCurrent = members.stream()
+                    .mapToInt(member -> metricValue(challenge.getMetric(),
+                            stats.getOrDefault(member.getUser().getId(), new StudyRoomStats(0, 0, 0)),
+                            attendanceDays.getOrDefault(member.getUser().getId(), 0)))
                     .sum();
             return groupCurrent >= challenge.getTargetValue();
         }
         return members.stream()
                 .allMatch(member -> metricValue(challenge.getMetric(),
-                        stats.getOrDefault(member.getUser().getId(), new StudyRoomStats(0, 0, 0))) >= challenge.getTargetValue());
+                        stats.getOrDefault(member.getUser().getId(), new StudyRoomStats(0, 0, 0)),
+                        attendanceDays.getOrDefault(member.getUser().getId(), 0)) >= challenge.getTargetValue());
     }
 
-    private int metricValue(StudyRoomChallengeMetric metric, StudyRoomStats stats) {
+    private int metricValue(StudyRoomChallengeMetric metric, StudyRoomStats stats, int attendanceDays) {
         return switch (metric) {
-            case WEEKLY_PROBLEM_COUNT -> stats.weeklyProblemCount();
-            case WEEKLY_PRACTICE_COUNT -> stats.weeklyPracticeCount();
-            case STREAK -> stats.currentStreak();
+            case PROBLEM_COUNT, WEEKLY_PROBLEM_COUNT -> stats.weeklyProblemCount();
+            case PRACTICE_COUNT, WEEKLY_PRACTICE_COUNT -> stats.weeklyPracticeCount();
+            case ATTENDANCE, STREAK -> attendanceDays;
         };
+    }
+
+    private boolean isAttendanceMetric(StudyRoomChallengeMetric metric) {
+        return metric == StudyRoomChallengeMetric.ATTENDANCE || metric == StudyRoomChallengeMetric.STREAK;
     }
 
     private LocalDate min(LocalDate left, LocalDate right) {

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomWeeklyReportService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomWeeklyReportService.java
@@ -1,0 +1,209 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.entity.*;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.exception.UserErrorCase;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomWeeklyReportService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final String DEFAULT_CHEER_MESSAGE = "이번 주도 모두 고생했어요!";
+    private static final int REPORT_ROOM_BATCH_SIZE = 100;
+
+    private final StudyRoomAccessService accessService;
+    private final StudyRoomRepository roomRepository;
+    private final StudyRoomMemberRepository memberRepository;
+    private final StudyRoomWeeklyReportRepository reportRepository;
+    private final StudyRoomWeeklyReportReadRepository readRepository;
+    private final StudyRoomChallengeRepository challengeRepository;
+    private final StudyRoomStatsService statsService;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<WeeklyReportResponse> getReports(Long roomId, Long userId, int limit) {
+        accessService.validateMember(roomId, userId);
+        int safeLimit = Math.max(1, Math.min(limit, 12));
+        List<StudyRoomWeeklyReport> reports = reportRepository.findAllByRoomIdOrderByWeekStartDesc(roomId, PageRequest.of(0, safeLimit));
+        Set<Long> readReportIds = readRepository.findAllByReportIdsAndUserId(
+                        reports.stream().map(StudyRoomWeeklyReport::getId).toList(), userId)
+                .stream()
+                .map(read -> read.getReport().getId())
+                .collect(Collectors.toSet());
+        return reports.stream().map(report -> toResponse(report, readReportIds.contains(report.getId()))).toList();
+    }
+
+    @Transactional
+    public WeeklyReportReadResponse markRead(Long roomId, Long reportId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        StudyRoomWeeklyReport report = reportRepository.findByIdAndRoomId(reportId, roomId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.REPORT_NOT_FOUND));
+        if (readRepository.findByReportIdAndUserId(reportId, userId).isEmpty()) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+            readRepository.save(StudyRoomWeeklyReportRead.create(report, user, LocalDateTime.now()));
+        }
+        return new WeeklyReportReadResponse(reportId, true);
+    }
+
+    @Transactional
+    public void createPreviousWeekReports() {
+        LocalDate today = LocalDate.now(KST);
+        LocalDate weekStart = today.with(TemporalAdjusters.previous(DayOfWeek.MONDAY));
+        LocalDate weekEnd = weekStart.plusDays(6);
+        LocalDateTime start = weekStart.atStartOfDay();
+        LocalDateTime end = weekEnd.atTime(LocalTime.MAX);
+        Long cursor = 0L;
+        while (true) {
+            List<StudyRoom> rooms = roomRepository.findBatchAfterId(cursor, PageRequest.of(0, REPORT_ROOM_BATCH_SIZE));
+            if (rooms.isEmpty()) {
+                return;
+            }
+            createReportsForBatch(rooms, weekStart, weekEnd, start, end);
+            cursor = rooms.get(rooms.size() - 1).getId();
+        }
+    }
+
+    void createReportIfAbsent(StudyRoom room, LocalDate weekStart, LocalDate weekEnd, LocalDateTime start, LocalDateTime end) {
+        List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(room.getId());
+        List<Long> userIds = members.stream().map(member -> member.getUser().getId()).toList();
+        Map<Long, StudyRoomStats> stats = statsService.getStats(userIds, start, end, weekEnd);
+        createReportIfAbsent(room, members, stats, weekStart, weekEnd, 0);
+    }
+
+    private void createReportsForBatch(List<StudyRoom> rooms, LocalDate weekStart, LocalDate weekEnd,
+                                       LocalDateTime start, LocalDateTime end) {
+        List<Long> roomIds = rooms.stream().map(StudyRoom::getId).toList();
+        List<StudyRoomMember> members = memberRepository.findAllWithRoomAndUserByRoomIds(roomIds);
+        Map<Long, List<StudyRoomMember>> membersByRoomId = members.stream()
+                .collect(Collectors.groupingBy(member -> member.getRoom().getId(), LinkedHashMap::new, Collectors.toList()));
+        List<Long> userIds = members.stream().map(member -> member.getUser().getId()).distinct().toList();
+        Map<Long, Integer> streaks = statsService.currentStreaks(userIds, weekEnd);
+        Map<Long, StudyRoomStats> statsByUserId = statsService.getStats(userIds, start, end, streaks);
+        refreshChallengeStatuses(roomIds, membersByRoomId);
+        Map<Long, Integer> completedChallengeCounts = completedChallengeCounts(roomIds, start, end);
+
+        for (StudyRoom room : rooms) {
+            List<StudyRoomMember> roomMembers = membersByRoomId.getOrDefault(room.getId(), List.of());
+            Map<Long, StudyRoomStats> roomStats = roomMembers.stream()
+                    .collect(Collectors.toMap(
+                            member -> member.getUser().getId(),
+                            member -> statsByUserId.getOrDefault(member.getUser().getId(), new StudyRoomStats(0, 0, 0))
+                    ));
+            createReportIfAbsent(room, roomMembers, roomStats, weekStart, weekEnd,
+                    completedChallengeCounts.getOrDefault(room.getId(), 0));
+        }
+    }
+
+    private void createReportIfAbsent(StudyRoom room, List<StudyRoomMember> members, Map<Long, StudyRoomStats> stats,
+                                      LocalDate weekStart, LocalDate weekEnd, int challengesCompleted) {
+        if (reportRepository.existsByRoomIdAndWeekStart(room.getId(), weekStart)) {
+            return;
+        }
+        StudyRoomMember topProblemMember = members.stream()
+                .max(Comparator.comparingInt(member -> stats.getOrDefault(member.getUser().getId(), new StudyRoomStats(0, 0, 0)).weeklyProblemCount()))
+                .orElse(null);
+        StudyRoomMember topStreakMember = members.stream()
+                .max(Comparator.comparingInt(member -> stats.getOrDefault(member.getUser().getId(), new StudyRoomStats(0, 0, 0)).currentStreak()))
+                .orElse(null);
+        int topProblems = topProblemMember == null ? 0 : stats.getOrDefault(topProblemMember.getUser().getId(), new StudyRoomStats(0, 0, 0)).weeklyProblemCount();
+        int longestStreak = topStreakMember == null ? 0 : stats.getOrDefault(topStreakMember.getUser().getId(), new StudyRoomStats(0, 0, 0)).currentStreak();
+        int totalProblems = stats.values().stream().mapToInt(StudyRoomStats::weeklyProblemCount).sum();
+        reportRepository.save(StudyRoomWeeklyReport.create(
+                room,
+                weekStart,
+                weekEnd,
+                topProblemMember == null ? null : topProblemMember.getUser().getName(),
+                topProblems,
+                topStreakMember == null ? null : topStreakMember.getUser().getName(),
+                longestStreak,
+                totalProblems,
+                challengesCompleted,
+                DEFAULT_CHEER_MESSAGE
+        ));
+    }
+
+    private Map<Long, Integer> completedChallengeCounts(List<Long> roomIds, LocalDateTime start, LocalDateTime end) {
+        Map<Long, Integer> result = new HashMap<>();
+        challengeRepository.countByRoomIdsAndStatusAndEndAtBetween(roomIds, StudyRoomChallengeStatus.COMPLETED, start, end)
+                .forEach(row -> result.put((Long) row[0], Math.toIntExact((Long) row[1])));
+        return result;
+    }
+
+    private void refreshChallengeStatuses(List<Long> roomIds, Map<Long, List<StudyRoomMember>> membersByRoomId) {
+        List<StudyRoomChallenge> challenges = challengeRepository.findAllByRoomIdsAndStatus(roomIds, StudyRoomChallengeStatus.IN_PROGRESS);
+        for (StudyRoomChallenge challenge : challenges) {
+            List<StudyRoomMember> members = membersByRoomId.getOrDefault(challenge.getRoom().getId(), List.of());
+            List<Long> userIds = members.stream().map(member -> member.getUser().getId()).toList();
+            Map<Long, Integer> streaks = statsService.currentStreaks(
+                    userIds,
+                    min(LocalDate.now(KST), challenge.getEndAt().toLocalDate()),
+                    challenge.getStartAt().toLocalDate()
+            );
+            Map<Long, StudyRoomStats> stats = statsService.getStats(userIds, challenge.getStartAt(), challenge.getEndAt(), streaks);
+            if (isChallengeCompleted(challenge, members, stats)) {
+                challenge.updateStatus(StudyRoomChallengeStatus.COMPLETED);
+                continue;
+            }
+            if (challenge.getEndAt().isBefore(LocalDateTime.now())) {
+                challenge.updateStatus(StudyRoomChallengeStatus.EXPIRED);
+            }
+        }
+    }
+
+    private boolean isChallengeCompleted(StudyRoomChallenge challenge, List<StudyRoomMember> members,
+                                         Map<Long, StudyRoomStats> stats) {
+        if (members.isEmpty()) {
+            return false;
+        }
+        if (challenge.getType() == StudyRoomChallengeType.GROUP) {
+            int groupCurrent = stats.values().stream()
+                    .mapToInt(stat -> metricValue(challenge.getMetric(), stat))
+                    .sum();
+            return groupCurrent >= challenge.getTargetValue();
+        }
+        return members.stream()
+                .allMatch(member -> metricValue(challenge.getMetric(),
+                        stats.getOrDefault(member.getUser().getId(), new StudyRoomStats(0, 0, 0))) >= challenge.getTargetValue());
+    }
+
+    private int metricValue(StudyRoomChallengeMetric metric, StudyRoomStats stats) {
+        return switch (metric) {
+            case WEEKLY_PROBLEM_COUNT -> stats.weeklyProblemCount();
+            case WEEKLY_PRACTICE_COUNT -> stats.weeklyPracticeCount();
+            case STREAK -> stats.currentStreak();
+        };
+    }
+
+    private LocalDate min(LocalDate left, LocalDate right) {
+        return left.isBefore(right) ? left : right;
+    }
+
+    private WeeklyReportResponse toResponse(StudyRoomWeeklyReport report, boolean read) {
+        return new WeeklyReportResponse(report.getId(), report.getWeekStart(), report.getWeekEnd(),
+                report.getTopMemberName(), report.getTopMemberProblemCount(),
+                report.getLongestStreakName(), report.getLongestStreakDays(),
+                report.getTotalProblems(), report.getChallengesCompleted(),
+                report.getCheerMessage(), read);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudySessionService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudySessionService.java
@@ -1,0 +1,70 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+import com.aisip.OnO.backend.studyroom.entity.StudySession;
+import com.aisip.OnO.backend.studyroom.event.StudyRoomActivityEvent;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudySessionRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.exception.UserErrorCase;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StudySessionService {
+
+    private final StudyRoomAccessService accessService;
+    private final StudySessionRepository sessionRepository;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional(readOnly = true)
+    public ActiveStudySessionsResponse getActiveSessions(Long roomId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        return new ActiveStudySessionsResponse(sessionRepository.findActiveByRoomId(roomId).stream()
+                .map(session -> new ActiveStudySessionResponse(
+                        session.getUser().getId(), session.getUser().getName(), session.getStartedAt()))
+                .toList());
+    }
+
+    @Transactional
+    public StudySessionStartResponse start(Long roomId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        if (!sessionRepository.findActiveByUserIdForUpdate(userId).isEmpty()) {
+            throw new ApplicationException(StudyRoomErrorCase.SESSION_ALREADY_ACTIVE);
+        }
+        StudyRoom room = accessService.getRoomOrThrow(roomId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        StudySession session = sessionRepository.save(StudySession.start(room, user, LocalDateTime.now()));
+        eventPublisher.publishEvent(new StudyRoomActivityEvent(userId, StudyRoomFeedEventType.SESSION_STARTED, Map.of()));
+        return new StudySessionStartResponse(session.getId(), session.getStartedAt());
+    }
+
+    @Transactional
+    public StudySessionEndResponse end(Long roomId, Long sessionId, Long userId) {
+        accessService.validateMember(roomId, userId);
+        StudySession session = sessionRepository.findByIdAndRoomIdAndUserId(sessionId, roomId, userId)
+                .orElseThrow(() -> new ApplicationException(StudyRoomErrorCase.SESSION_NOT_FOUND));
+        if (session.getEndedAt() == null) {
+            session.end(LocalDateTime.now());
+        }
+        return new StudySessionEndResponse(session.getId(), session.getStartedAt(), session.getEndedAt(), session.getDurationMinutes());
+    }
+
+    @Transactional
+    public void closeExpiredSessions(LocalDateTime threshold, LocalDateTime endedAt) {
+        sessionRepository.findAllByEndedAtIsNullAndStartedAtBefore(threshold)
+                .forEach(session -> session.end(endedAt));
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
+++ b/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
@@ -7,8 +7,10 @@ import com.aisip.OnO.backend.user.dto.UserRegisterDto;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,6 +47,18 @@ public class UserController {
         userService.updateNotificationSettings(userId, dto.notificationEnabled());
 
         return CommonResponse.success("알림 설정이 변경되었습니다.");
+    }
+
+    @PatchMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public CommonResponse<UserResponseDto> updateProfileImage(@RequestParam("profileImage") MultipartFile profileImage) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return CommonResponse.success(userService.updateProfileImage(userId, profileImage));
+    }
+
+    @DeleteMapping("/me/profile-image")
+    public CommonResponse<UserResponseDto> deleteProfileImage() {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return CommonResponse.success(userService.deleteProfileImage(userId));
     }
 
     // ✅ 사용자 계정 삭제

--- a/src/main/java/com/aisip/OnO/backend/user/dto/UserResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/user/dto/UserResponseDto.java
@@ -12,6 +12,7 @@ public record UserResponseDto (
     Long userId,
     String name,
     String email,
+    String profileImageUrl,
     Long attendanceLevel,
     Long attendancePoint,
     Long noteWriteLevel,
@@ -35,6 +36,7 @@ public record UserResponseDto (
                 .userId(user.getId())
                 .name(user.getName())
                 .email(user.getEmail())
+                .profileImageUrl(user.getProfileImageUrl())
                 .attendanceLevel(getResponseLevel(missionStatus.getAttendanceLevel()))
                 .attendancePoint(getResponsePoint(missionStatus.getAttendanceLevel(), missionStatus.getAttendancePoint()))
                 .noteWriteLevel(getResponseLevel(missionStatus.getNoteWriteLevel()))

--- a/src/main/java/com/aisip/OnO/backend/user/entity/User.java
+++ b/src/main/java/com/aisip/OnO/backend/user/entity/User.java
@@ -43,6 +43,9 @@ public class User extends BaseEntity {
 
     private String platform;
 
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
     private LocalDateTime lastActiveAt;
 
     private LocalDate lastNotifiedAt;
@@ -89,6 +92,10 @@ public class User extends BaseEntity {
 
     public void updateNotificationEnabled(boolean enabled) {
         this.notificationEnabled = enabled;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 
     public void updateUser(UserRegisterDto userRegisterDto) {

--- a/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/user/repository/UserRepository.java
@@ -4,6 +4,8 @@ import com.aisip.OnO.backend.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,6 +23,10 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     Optional<User> findByIdentifier(String identifier);
 
     Optional<User> findByName(String name);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.id = :userId")
+    Optional<User> findByIdForUpdate(@Param("userId") Long userId);
 
     Page<User> findAll(Pageable pageable);
 

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -5,20 +5,28 @@ import com.aisip.OnO.backend.folder.service.FolderService;
 import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
 import com.aisip.OnO.backend.problem.service.ProblemService;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentReactionRepository;
 import com.aisip.OnO.backend.user.dto.UserRegisterDto;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.exception.UserErrorCase;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.fileupload.exception.FileUploadErrorCase;
+import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import com.aisip.OnO.backend.util.webhook.DiscordWebhookNotificationService;
+import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -26,6 +34,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -34,6 +43,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private static final long MAX_PROFILE_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 
     private final UserRepository userRepository;
 
@@ -44,6 +54,12 @@ public class UserService {
     private final PracticeNoteService practiceNoteService;
 
     private final StudyRoomSharedProblemCommentRepository sharedProblemCommentRepository;
+
+    private final StudyRoomSharedProblemCommentReactionRepository sharedProblemCommentReactionRepository;
+
+    private final FileUploadService fileUploadService;
+
+    private final S3DeleteProducer s3DeleteProducer;
 
     private final DiscordWebhookNotificationService discordWebhookNotificationService;
 
@@ -144,8 +160,32 @@ public class UserService {
     }
 
     @Transactional
+    public UserResponseDto updateProfileImage(Long userId, MultipartFile profileImage) {
+        validateProfileImage(profileImage);
+        User user = findUserEntity(userId);
+        String previousProfileImageUrl = user.getProfileImageUrl();
+        String profileImageUrl = fileUploadService.uploadFileToS3(profileImage);
+        deleteImageOnRollback(profileImageUrl, userId);
+        user.updateProfileImageUrl(profileImageUrl);
+        deleteImageAsync(previousProfileImageUrl, userId);
+        return UserResponseDto.from(user);
+    }
+
+    @Transactional
+    public UserResponseDto deleteProfileImage(Long userId) {
+        User user = findUserEntity(userId);
+        String previousProfileImageUrl = user.getProfileImageUrl();
+        user.updateProfileImageUrl(null);
+        deleteImageAsync(previousProfileImageUrl, userId);
+        return UserResponseDto.from(user);
+    }
+
+    @Transactional
     public void deleteUserById(Long userId) {
         User user = findUserEntity(userId);
+        deleteImageAsync(user.getProfileImageUrl(), userId);
+        sharedProblemCommentReactionRepository.deleteByCommentAuthorId(userId);
+        sharedProblemCommentReactionRepository.deleteByUserId(userId);
         sharedProblemCommentRepository.deleteByAuthorId(userId);
         practiceNoteService.deleteAllPracticesByUser(userId);
         problemService.deleteAllUserProblems(userId);
@@ -162,6 +202,111 @@ public class UserService {
 
     private String makeDeletedIdentifier(Long userId) {
         return "deleted:" + userId + ":" + UUID.randomUUID();
+    }
+
+    private void validateProfileImage(MultipartFile profileImage) {
+        if (profileImage == null || profileImage.isEmpty()) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+        if (profileImage.getSize() > MAX_PROFILE_IMAGE_SIZE_BYTES) {
+            throw new ApplicationException(FileUploadErrorCase.FILE_SIZE_EXCEEDED);
+        }
+
+        String extension = getLowercaseExtension(profileImage.getOriginalFilename());
+        String contentType = profileImage.getContentType();
+        if (!isAllowedImageType(contentType, extension) || !hasAllowedImageSignature(profileImage, contentType)) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+    }
+
+    private String getLowercaseExtension(String originalFilename) {
+        if (originalFilename == null) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+        int dotIndex = originalFilename.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == originalFilename.length() - 1) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+        return originalFilename.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isAllowedImageType(String contentType, String extension) {
+        if (contentType == null) {
+            return false;
+        }
+        return switch (contentType) {
+            case "image/jpeg" -> extension.equals("jpg") || extension.equals("jpeg");
+            case "image/png" -> extension.equals("png");
+            case "image/webp" -> extension.equals("webp");
+            default -> false;
+        };
+    }
+
+    private boolean hasAllowedImageSignature(MultipartFile profileImage, String contentType) {
+        byte[] header = new byte[12];
+        int read;
+        try {
+            read = profileImage.getInputStream().read(header);
+        } catch (IOException e) {
+            throw new ApplicationException(FileUploadErrorCase.FILE_UPLOAD_FAILED);
+        }
+
+        return switch (contentType) {
+            case "image/jpeg" -> read >= 3
+                    && (header[0] & 0xFF) == 0xFF
+                    && (header[1] & 0xFF) == 0xD8
+                    && (header[2] & 0xFF) == 0xFF;
+            case "image/png" -> read >= 8
+                    && (header[0] & 0xFF) == 0x89
+                    && header[1] == 0x50
+                    && header[2] == 0x4E
+                    && header[3] == 0x47
+                    && header[4] == 0x0D
+                    && header[5] == 0x0A
+                    && header[6] == 0x1A
+                    && header[7] == 0x0A;
+            case "image/webp" -> read >= 12
+                    && header[0] == 0x52
+                    && header[1] == 0x49
+                    && header[2] == 0x46
+                    && header[3] == 0x46
+                    && header[8] == 0x57
+                    && header[9] == 0x45
+                    && header[10] == 0x42
+                    && header[11] == 0x50;
+            default -> false;
+        };
+    }
+
+    private void deleteImageAsync(String imageUrl, Long userId) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return;
+        }
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            s3DeleteProducer.sendDeleteMessage(imageUrl, userId);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                s3DeleteProducer.sendDeleteMessage(imageUrl, userId);
+            }
+        });
+    }
+
+    private void deleteImageOnRollback(String imageUrl, Long userId) {
+        if (imageUrl == null || imageUrl.isBlank()
+                || !TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_ROLLED_BACK) {
+                    s3DeleteProducer.sendDeleteMessage(imageUrl, userId);
+                }
+            }
+        });
     }
 
     private String makeGuestName() {

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.aisip.OnO.backend.admin.dto.AdminUserResponseDto;
 import com.aisip.OnO.backend.folder.service.FolderService;
 import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
 import com.aisip.OnO.backend.problem.service.ProblemService;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentRepository;
 import com.aisip.OnO.backend.user.dto.UserRegisterDto;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.entity.User;
@@ -41,6 +42,8 @@ public class UserService {
     private final ProblemService problemService;
 
     private final PracticeNoteService practiceNoteService;
+
+    private final StudyRoomSharedProblemCommentRepository sharedProblemCommentRepository;
 
     private final DiscordWebhookNotificationService discordWebhookNotificationService;
 
@@ -143,6 +146,7 @@ public class UserService {
     @Transactional
     public void deleteUserById(Long userId) {
         User user = findUserEntity(userId);
+        sharedProblemCommentRepository.deleteByAuthorId(userId);
         practiceNoteService.deleteAllPracticesByUser(userId);
         problemService.deleteAllUserProblems(userId);
         folderService.deleteAllUserFolders(userId);

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/exception/FileUploadErrorCase.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/exception/FileUploadErrorCase.java
@@ -10,7 +10,11 @@ public enum FileUploadErrorCase implements ErrorCase {
 
     FILE_UPLOAD_FAILED(400, 2001, "파일 업로드 중 문제가 발생했습니다."),
 
-    FILE_NOT_FOUND(404, 2002, "파일을 찾을 수 없습니다.");
+    FILE_NOT_FOUND(404, 2002, "파일을 찾을 수 없습니다."),
+
+    INVALID_IMAGE_FILE(400, 2003, "이미지 파일 형식이 올바르지 않습니다."),
+
+    FILE_SIZE_EXCEEDED(400, 2004, "파일 최대 용량을 초과했습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/resources/db/migration/V10__add_shared_problem_comment.sql
+++ b/src/main/resources/db/migration/V10__add_shared_problem_comment.sql
@@ -1,0 +1,14 @@
+CREATE TABLE study_room_shared_problem_comment (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    shared_problem_id BIGINT NOT NULL,
+    author_id BIGINT NOT NULL,
+    content VARCHAR(1000) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_shared_problem_comment_problem FOREIGN KEY (shared_problem_id) REFERENCES study_room_shared_problem (id) ON DELETE CASCADE,
+    CONSTRAINT fk_shared_problem_comment_author FOREIGN KEY (author_id) REFERENCES user (id)
+);
+CREATE INDEX idx_shared_problem_comment_problem_id ON study_room_shared_problem_comment (shared_problem_id, id);
+CREATE INDEX idx_shared_problem_comment_author ON study_room_shared_problem_comment (author_id);

--- a/src/main/resources/db/migration/V11__add_comment_reactions_and_user_profile_image.sql
+++ b/src/main/resources/db/migration/V11__add_comment_reactions_and_user_profile_image.sql
@@ -1,0 +1,18 @@
+ALTER TABLE user
+    ADD COLUMN profile_image_url VARCHAR(255);
+
+CREATE TABLE study_room_shared_problem_comment_reaction (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    comment_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    emoji VARCHAR(80) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_shared_problem_comment_reaction UNIQUE (comment_id, user_id, emoji),
+    CONSTRAINT fk_shared_problem_comment_reaction_comment FOREIGN KEY (comment_id) REFERENCES study_room_shared_problem_comment (id) ON DELETE CASCADE,
+    CONSTRAINT fk_shared_problem_comment_reaction_user FOREIGN KEY (user_id) REFERENCES user (id)
+);
+CREATE INDEX idx_shared_problem_comment_reaction_comment ON study_room_shared_problem_comment_reaction (comment_id);
+CREATE INDEX idx_shared_problem_comment_reaction_user ON study_room_shared_problem_comment_reaction (user_id);

--- a/src/main/resources/db/migration/V12__add_challenge_period_days.sql
+++ b/src/main/resources/db/migration/V12__add_challenge_period_days.sql
@@ -1,0 +1,1 @@
+ALTER TABLE study_room_challenge ADD COLUMN period_days INT NULL;

--- a/src/main/resources/db/migration/V6__add_study_room_schema.sql
+++ b/src/main/resources/db/migration/V6__add_study_room_schema.sql
@@ -1,0 +1,173 @@
+CREATE TABLE study_room (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    version BIGINT,
+    name VARCHAR(20) NOT NULL,
+    host_user_id BIGINT NOT NULL,
+    thumbnail_url VARCHAR(255),
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id)
+);
+CREATE INDEX idx_study_room_host_user ON study_room (host_user_id);
+
+CREATE TABLE study_room_member (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    role VARCHAR(20) NOT NULL,
+    weekly_goal INT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_study_room_member_room_user UNIQUE (room_id, user_id),
+    CONSTRAINT fk_study_room_member_room FOREIGN KEY (room_id) REFERENCES study_room (id) ON DELETE CASCADE,
+    CONSTRAINT fk_study_room_member_user FOREIGN KEY (user_id) REFERENCES user (id)
+);
+CREATE INDEX idx_study_room_member_user ON study_room_member (user_id);
+CREATE INDEX idx_study_room_member_room ON study_room_member (room_id);
+
+CREATE TABLE study_room_invite_code (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    code VARCHAR(6) NOT NULL,
+    expired_at DATETIME(6) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_study_room_invite_code UNIQUE (code),
+    CONSTRAINT fk_study_room_invite_room FOREIGN KEY (room_id) REFERENCES study_room (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_study_room_invite_room ON study_room_invite_code (room_id);
+
+CREATE TABLE study_room_feed (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    event_type VARCHAR(40) NOT NULL,
+    metadata_json TEXT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_study_room_feed_room FOREIGN KEY (room_id) REFERENCES study_room (id) ON DELETE CASCADE,
+    CONSTRAINT fk_study_room_feed_user FOREIGN KEY (user_id) REFERENCES user (id)
+);
+CREATE INDEX idx_study_room_feed_room_created ON study_room_feed (room_id, created_at);
+CREATE INDEX idx_study_room_feed_room_user_type_created ON study_room_feed (room_id, user_id, event_type, created_at);
+
+CREATE TABLE study_room_feed_reaction (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    feed_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    emoji VARCHAR(16) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_study_room_feed_reaction UNIQUE (feed_id, user_id, emoji),
+    CONSTRAINT fk_study_room_feed_reaction_feed FOREIGN KEY (feed_id) REFERENCES study_room_feed (id) ON DELETE CASCADE,
+    CONSTRAINT fk_study_room_feed_reaction_user FOREIGN KEY (user_id) REFERENCES user (id)
+);
+
+CREATE TABLE study_room_challenge (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    title VARCHAR(40) NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    metric VARCHAR(40) NOT NULL,
+    target_value INT NOT NULL,
+    start_at DATETIME(6) NOT NULL,
+    end_at DATETIME(6) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_study_room_challenge_room FOREIGN KEY (room_id) REFERENCES study_room (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_study_room_challenge_room_status_end ON study_room_challenge (room_id, status, end_at);
+
+CREATE TABLE study_session (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    started_at DATETIME(6) NOT NULL,
+    ended_at DATETIME(6),
+    duration_minutes INT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_study_session_room FOREIGN KEY (room_id) REFERENCES study_room (id) ON DELETE CASCADE,
+    CONSTRAINT fk_study_session_user FOREIGN KEY (user_id) REFERENCES user (id)
+);
+CREATE INDEX idx_study_session_room_ended ON study_session (room_id, ended_at);
+CREATE INDEX idx_study_session_user_ended ON study_session (user_id, ended_at);
+
+CREATE TABLE study_room_shared_problem (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    shared_by_user_id BIGINT NOT NULL,
+    problem_id BIGINT NOT NULL,
+    comment VARCHAR(100),
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_study_room_shared_problem_room FOREIGN KEY (room_id) REFERENCES study_room (id) ON DELETE CASCADE,
+    CONSTRAINT fk_study_room_shared_problem_user FOREIGN KEY (shared_by_user_id) REFERENCES user (id),
+    CONSTRAINT fk_study_room_shared_problem_problem FOREIGN KEY (problem_id) REFERENCES problem (id)
+);
+CREATE INDEX idx_study_room_shared_problem_room_created ON study_room_shared_problem (room_id, created_at);
+CREATE INDEX idx_study_room_shared_problem_problem ON study_room_shared_problem (problem_id);
+
+CREATE TABLE study_room_shared_problem_reaction (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    shared_problem_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    emoji VARCHAR(16) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_study_room_shared_problem_reaction UNIQUE (shared_problem_id, user_id, emoji),
+    CONSTRAINT fk_study_room_shared_problem_reaction_shared FOREIGN KEY (shared_problem_id) REFERENCES study_room_shared_problem (id) ON DELETE CASCADE,
+    CONSTRAINT fk_study_room_shared_problem_reaction_user FOREIGN KEY (user_id) REFERENCES user (id)
+);
+
+CREATE TABLE study_room_weekly_report (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    room_id BIGINT NOT NULL,
+    week_start DATE NOT NULL,
+    week_end DATE NOT NULL,
+    top_member_name VARCHAR(255),
+    top_member_problem_count INT NOT NULL,
+    longest_streak_name VARCHAR(255),
+    longest_streak_days INT NOT NULL,
+    total_problems INT NOT NULL,
+    challenges_completed INT NOT NULL,
+    cheer_message VARCHAR(255) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_study_room_weekly_report UNIQUE (room_id, week_start),
+    CONSTRAINT fk_study_room_weekly_report_room FOREIGN KEY (room_id) REFERENCES study_room (id) ON DELETE CASCADE
+);
+
+CREATE TABLE study_room_weekly_report_read (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    report_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    read_at DATETIME(6) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_study_room_weekly_report_read UNIQUE (report_id, user_id),
+    CONSTRAINT fk_study_room_weekly_report_read_report FOREIGN KEY (report_id) REFERENCES study_room_weekly_report (id) ON DELETE CASCADE,
+    CONSTRAINT fk_study_room_weekly_report_read_user FOREIGN KEY (user_id) REFERENCES user (id)
+);

--- a/src/main/resources/db/migration/V7__add_custom_emoji_fields.sql
+++ b/src/main/resources/db/migration/V7__add_custom_emoji_fields.sql
@@ -1,0 +1,16 @@
+ALTER TABLE practice_note
+    ADD COLUMN last_session_mood_emoji_key VARCHAR(80) NULL;
+
+CREATE TABLE learning_calendar_mood (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    study_date DATE NOT NULL,
+    emoji_key VARCHAR(80) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    deleted_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_learning_calendar_mood_user_date UNIQUE (user_id, study_date),
+    CONSTRAINT fk_learning_calendar_mood_user FOREIGN KEY (user_id) REFERENCES user (id)
+);
+CREATE INDEX idx_learning_calendar_mood_user_date ON learning_calendar_mood (user_id, study_date);

--- a/src/main/resources/db/migration/V8__add_study_room_challenge_period.sql
+++ b/src/main/resources/db/migration/V8__add_study_room_challenge_period.sql
@@ -1,0 +1,2 @@
+ALTER TABLE study_room_challenge
+    ADD COLUMN period VARCHAR(20) NULL AFTER metric;

--- a/src/main/resources/db/migration/V9__widen_study_room_reaction_emoji.sql
+++ b/src/main/resources/db/migration/V9__widen_study_room_reaction_emoji.sql
@@ -1,0 +1,5 @@
+ALTER TABLE study_room_feed_reaction
+    MODIFY COLUMN emoji VARCHAR(80) NOT NULL;
+
+ALTER TABLE study_room_shared_problem_reaction
+    MODIFY COLUMN emoji VARCHAR(80) NOT NULL;

--- a/src/test/java/com/aisip/OnO/backend/learningcalendar/controller/LearningCalendarControllerTest.java
+++ b/src/test/java/com/aisip/OnO/backend/learningcalendar/controller/LearningCalendarControllerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -53,6 +54,7 @@ class LearningCalendarControllerTest {
                         .noteWriteCount(1)
                         .studyMinutes(12)
                         .reviewedItems(List.of("이차방정식 오답노트"))
+                        .moodEmojiKey("happy_tears")
                         .build()))
                 .build();
         given(learningCalendarService.getLearningCalendar(7L, 2026, 5)).willReturn(response);
@@ -72,9 +74,35 @@ class LearningCalendarControllerTest {
                 .andExpect(jsonPath("$.data.records[0].reviewCount").value(2))
                 .andExpect(jsonPath("$.data.records[0].noteWriteCount").value(1))
                 .andExpect(jsonPath("$.data.records[0].studyMinutes").value(12))
-                .andExpect(jsonPath("$.data.records[0].reviewedItems[0]").value("이차방정식 오답노트"));
+                .andExpect(jsonPath("$.data.records[0].reviewedItems[0]").value("이차방정식 오답노트"))
+                .andExpect(jsonPath("$.data.records[0].moodEmojiKey").value("happy_tears"));
 
         verify(learningCalendarService).getLearningCalendar(7L, 2026, 5);
+    }
+
+    @Test
+    @DisplayName("학습 달력 감정 이모지 저장")
+    @WithMockCustomUser(userId = 7L)
+    void updateMood() throws Exception {
+        given(learningCalendarService.updateMood(7L, new com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarMoodRequestDto(
+                LocalDate.of(2026, 6, 7),
+                "happy_tears"
+        ))).willReturn(new com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarMoodResponseDto(
+                LocalDate.of(2026, 6, 7),
+                "happy_tears"
+        ));
+
+        mockMvc.perform(patch("/api/learning-calendar/mood")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-06-07",
+                                  "emojiKey": "happy_tears"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.date").value("2026-06-07"))
+                .andExpect(jsonPath("$.data.emojiKey").value("happy_tears"));
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/learningcalendar/service/LearningCalendarServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/learningcalendar/service/LearningCalendarServiceTest.java
@@ -1,6 +1,9 @@
 package com.aisip.OnO.backend.learningcalendar.service;
 
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarMoodRequestDto;
 import com.aisip.OnO.backend.learningcalendar.dto.LearningCalendarResponseDto;
+import com.aisip.OnO.backend.learningcalendar.exception.LearningCalendarErrorCase;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
@@ -24,6 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -96,6 +100,42 @@ class LearningCalendarServiceTest {
         assertThat(records.get(LocalDate.of(2026, 5, 2)).noteWriteCount()).isEqualTo(1);
         assertThat(records.get(LocalDate.of(2026, 5, 6)).hasStudied()).isFalse();
         assertThat(records.get(LocalDate.of(2026, 5, 6)).reviewedItems()).isEmpty();
+        assertThat(records.get(LocalDate.of(2026, 5, 1)).moodEmojiKey()).isNull();
+    }
+
+    @Test
+    @DisplayName("학습 기록이 있는 날짜에 감정 이모지를 저장하고 조회한다")
+    void updateMood_success() {
+        User targetUser = createUser("calendar-mood-user");
+        Long userId = targetUser.getId();
+        createProblemWrite(userId, LocalDateTime.of(2026, 6, 7, 8, 0));
+
+        learningCalendarService.updateMood(userId,
+                new LearningCalendarMoodRequestDto(LocalDate.of(2026, 6, 7), "happy_tears"));
+        learningCalendarService.updateMood(userId,
+                new LearningCalendarMoodRequestDto(LocalDate.of(2026, 6, 7), "success_checkmark"));
+
+        LearningCalendarResponseDto response = learningCalendarService.getLearningCalendar(
+                userId,
+                2026,
+                6,
+                LocalDate.of(2026, 6, 8)
+        );
+
+        Map<LocalDate, LearningCalendarResponseDto.DailyStudyRecord> records = response.records().stream()
+                .collect(Collectors.toMap(LearningCalendarResponseDto.DailyStudyRecord::date, record -> record));
+        assertThat(records.get(LocalDate.of(2026, 6, 7)).moodEmojiKey()).isEqualTo("success_checkmark");
+    }
+
+    @Test
+    @DisplayName("학습 기록이 없는 날짜에는 감정 이모지를 저장할 수 없다")
+    void updateMood_recordNotFound() {
+        User targetUser = createUser("calendar-mood-empty-user");
+
+        assertThatThrownBy(() -> learningCalendarService.updateMood(targetUser.getId(),
+                new LearningCalendarMoodRequestDto(LocalDate.of(2026, 6, 7), "happy_tears")))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(LearningCalendarErrorCase.CALENDAR_RECORD_NOT_FOUND.getMessage());
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/practicenote/service/PracticeNoteServiceTest.java
@@ -1,10 +1,12 @@
 package com.aisip.OnO.backend.practicenote.service;
 
 import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.common.emoji.CustomEmojiErrorCase;
 import com.aisip.OnO.backend.folder.dto.FolderRegisterDto;
 import com.aisip.OnO.backend.folder.entity.Folder;
 import com.aisip.OnO.backend.folder.repository.FolderRepository;
 import com.aisip.OnO.backend.practicenote.dto.PracticeNoteDetailResponseDto;
+import com.aisip.OnO.backend.practicenote.dto.PracticeNoteCompleteRequestDto;
 import com.aisip.OnO.backend.practicenote.dto.PracticeNoteRegisterDto;
 import com.aisip.OnO.backend.practicenote.dto.PracticeNoteThumbnailResponseDto;
 import com.aisip.OnO.backend.practicenote.dto.PracticeNoteUpdateDto;
@@ -280,6 +282,35 @@ class PracticeNoteServiceTest {
         //then
         PracticeNote practiceNote = practiceNoteRepository.findById(practiceNoteId).get();
         assertThat(practiceNote.getPracticeCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("복습 완료 소감 이모지를 최신 복습노트에 저장한다")
+    void addPracticeNoteCount_withMoodEmojiKey() {
+        Long practiceNoteId = practiceNoteList.get(0).getId();
+
+        practiceNoteService.addPracticeNoteCount(userId, practiceNoteId,
+                new PracticeNoteCompleteRequestDto("success_checkmark"));
+
+        PracticeNote practiceNote = practiceNoteRepository.findById(practiceNoteId).get();
+        assertThat(practiceNote.getPracticeCount()).isEqualTo(1);
+        assertThat(practiceNote.getLastSessionMoodEmojiKey()).isEqualTo("success_checkmark");
+
+        PracticeNoteDetailResponseDto detail = practiceNoteService.findPracticeNoteDetail(practiceNoteId, userId);
+        assertThat(detail.lastSessionMoodEmojiKey()).isEqualTo("success_checkmark");
+        assertThat(practiceNoteService.findAllPracticeThumbnailsByUser(userId).get(0).lastSessionMoodEmojiKey())
+                .isEqualTo("success_checkmark");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 복습 완료 소감 이모지는 예외")
+    void addPracticeNoteCount_invalidMoodEmojiKey() {
+        Long practiceNoteId = practiceNoteList.get(0).getId();
+
+        assertThatThrownBy(() -> practiceNoteService.addPracticeNoteCount(userId, practiceNoteId,
+                new PracticeNoteCompleteRequestDto("not_supported")))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(CustomEmojiErrorCase.INVALID_EMOJI_KEY.getMessage());
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
@@ -188,6 +188,28 @@ class StudyRoomApiIntegrationTest {
     }
 
     @Test
+    void hostCanUpdateRoomNameAndThumbnailInSingleMultipartRequest() throws Exception {
+        User host = saveUser("방장", "room-multipart-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("기존 통합 수정방");
+        MockMultipartFile thumbnailImage = new MockMultipartFile("thumbnailImage", "thumbnail.png", "image/png", pngBytes());
+        given(fileUploadService.uploadFileToS3(any())).willReturn("https://cdn.example.com/updated-room.png");
+
+        mockMvc.perform(multipart("/api/study-rooms/{roomId}", roomId)
+                        .file(thumbnailImage)
+                        .param("name", "통합 수정방")
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        })
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomId").value(roomId))
+                .andExpect(jsonPath("$.data.name").value("통합 수정방"))
+                .andExpect(jsonPath("$.data.thumbnailUrl").value("https://cdn.example.com/updated-room.png"));
+    }
+
+    @Test
     void thumbnailUploadRejectsInvalidImageFile() throws Exception {
         User host = saveUser("방장", "thumbnail-invalid-host");
         authenticate(host.getId());

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
@@ -15,6 +15,8 @@ import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.repository.UserRepository;
 import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
+import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.AfterEach;
@@ -22,7 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -35,6 +39,8 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -67,6 +73,12 @@ class StudyRoomApiIntegrationTest {
 
     @Autowired
     private ProblemSolveRepository problemSolveRepository;
+
+    @MockBean
+    private FileUploadService fileUploadService;
+
+    @MockBean
+    private S3DeleteProducer s3DeleteProducer;
 
     private Long authenticatedUserId;
 
@@ -144,6 +156,53 @@ class StudyRoomApiIntegrationTest {
                         .content(objectMapper.writeValueAsString(new StudyRoomUpdateRequest(" "))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    @Test
+    void hostCanUpdateThumbnailAndResponsesIncludeThumbnailUrl() throws Exception {
+        User host = saveUser("방장", "thumbnail-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("썸네일방");
+        MockMultipartFile thumbnail = new MockMultipartFile("thumbnail", "thumbnail.png", "image/png", pngBytes());
+        given(fileUploadService.uploadFileToS3(any())).willReturn("https://cdn.example.com/study-room.png");
+
+        mockMvc.perform(multipart("/api/study-room/{roomId}/thumbnail", roomId)
+                        .file(thumbnail)
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        })
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.thumbnailUrl").value("https://cdn.example.com/study-room.png"));
+
+        mockMvc.perform(get("/api/study-room/{roomId}", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.thumbnailUrl").value("https://cdn.example.com/study-room.png"));
+
+        mockMvc.perform(get("/api/study-room")
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[?(@.roomId == " + roomId + ")].thumbnailUrl").value("https://cdn.example.com/study-room.png"));
+    }
+
+    @Test
+    void thumbnailUploadRejectsInvalidImageFile() throws Exception {
+        User host = saveUser("방장", "thumbnail-invalid-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("썸네일 검증방");
+        MockMultipartFile thumbnail = new MockMultipartFile("thumbnail", "thumbnail.png", "image/png", "not-image".getBytes());
+
+        mockMvc.perform(multipart("/api/study-room/{roomId}/thumbnail", roomId)
+                        .file(thumbnail)
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        })
+                        .with(auth()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(2003));
     }
 
     @Test
@@ -409,5 +468,13 @@ class StudyRoomApiIntegrationTest {
                     60
             ));
         }
+    }
+
+    private byte[] pngBytes() {
+        return new byte[]{
+                (byte) 0x89, 0x50, 0x4E, 0x47,
+                0x0D, 0x0A, 0x1A, 0x0A,
+                0x00, 0x00, 0x00, 0x0D
+        };
     }
 }

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
@@ -100,13 +100,50 @@ class StudyRoomApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.memberCount").value(2))
                 .andExpect(jsonPath("$.data.members[?(@.userId == " + host.getId() + ")].todayPracticeCount").value(2))
-                .andExpect(jsonPath("$.data.members[?(@.userId == " + member.getId() + ")].todayPracticeCount").value(3));
+                .andExpect(jsonPath("$.data.members[?(@.userId == " + host.getId() + ")].practicedToday").value(true))
+                .andExpect(jsonPath("$.data.members[?(@.userId == " + member.getId() + ")].todayPracticeCount").value(3))
+                .andExpect(jsonPath("$.data.members[?(@.userId == " + member.getId() + ")].practicedToday").value(true));
 
         mockMvc.perform(get("/api/study-room")
                         .with(auth()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[?(@.roomId == " + roomId + ")].todayPracticeMemberCount").value(2))
                 .andExpect(jsonPath("$.data[?(@.roomId == " + roomId + ")].todayPracticeCount").value(5));
+    }
+
+    @Test
+    void hostCanUpdateRoomNameAndMemberCannotUpdateRoomName() throws Exception {
+        User host = saveUser("방장", "room-update-host");
+        User member = saveUser("멤버", "room-update-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("기존 이름");
+        String inviteCode = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(inviteCode);
+
+        mockMvc.perform(patch("/api/study-room/{roomId}", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomUpdateRequest("멤버 수정"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10003));
+
+        authenticate(host.getId());
+        mockMvc.perform(patch("/api/study-room/{roomId}", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomUpdateRequest("  새 스터디룸  "))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomId").value(roomId))
+                .andExpect(jsonPath("$.data.name").value("새 스터디룸"))
+                .andExpect(jsonPath("$.data.memberCount").value(2));
+
+        mockMvc.perform(patch("/api/study-room/{roomId}", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomUpdateRequest(" "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomApiIntegrationTest.java
@@ -1,0 +1,376 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
+import com.aisip.OnO.backend.problemsolve.entity.ProblemSolve;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeed;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomFeedRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomApiIntegrationTest {
+
+    private static final String EMOJI = "fired_up_sparkle_eyes";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyRoomRepository roomRepository;
+
+    @Autowired
+    private StudyRoomFeedRepository feedRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private ProblemSolveRepository problemSolveRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void roomCreateInviteJoinReadAndTodayPracticeSummaryApiFlow() throws Exception {
+        User host = saveUser("방장", "room-flow-host");
+        User member = saveUser("멤버", "room-flow-member");
+        authenticate(host.getId());
+
+        Long roomId = createRoom("수능 준비방");
+        createPractice(host.getId(), LocalDateTime.now(), 2);
+
+        String inviteCode = issueInviteCode(roomId);
+        authenticate(member.getId());
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(inviteCode))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomId").value(roomId))
+                .andExpect(jsonPath("$.data.memberCount").value(2));
+        createPractice(member.getId(), LocalDateTime.now(), 3);
+
+        mockMvc.perform(get("/api/study-room/{roomId}", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberCount").value(2))
+                .andExpect(jsonPath("$.data.members[?(@.userId == " + host.getId() + ")].todayPracticeCount").value(2))
+                .andExpect(jsonPath("$.data.members[?(@.userId == " + member.getId() + ")].todayPracticeCount").value(3));
+
+        mockMvc.perform(get("/api/study-room")
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[?(@.roomId == " + roomId + ")].todayPracticeMemberCount").value(2))
+                .andExpect(jsonPath("$.data[?(@.roomId == " + roomId + ")].todayPracticeCount").value(5));
+    }
+
+    @Test
+    void nonMemberCannotReadRoomAndMemberCannotKickOtherMember() throws Exception {
+        User host = saveUser("방장", "permission-host");
+        User member = saveUser("멤버", "permission-member");
+        User outsider = saveUser("외부", "permission-outsider");
+        authenticate(host.getId());
+        Long roomId = createRoom("권한 검증방");
+        String inviteCode = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(inviteCode);
+
+        authenticate(outsider.getId());
+        mockMvc.perform(get("/api/study-room/{roomId}", roomId)
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+
+        authenticate(member.getId());
+        mockMvc.perform(delete("/api/study-room/{roomId}/members/{memberId}", roomId, host.getId())
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10003));
+    }
+
+    @Test
+    void feedReactionToggleAndInvalidEmojiAreValidatedByApi() throws Exception {
+        User host = saveUser("방장", "feed-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("피드 반응방");
+        StudyRoom room = roomRepository.findById(roomId).orElseThrow();
+        StudyRoomFeed feed = feedRepository.save(StudyRoomFeed.create(room, host, StudyRoomFeedEventType.SESSION_STARTED, "{}"));
+
+        mockMvc.perform(post("/api/study-room/{roomId}/feed/{feedId}/reactions", roomId, feed.getId())
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.feedId").value(feed.getId()))
+                .andExpect(jsonPath("$.data.reactions[0].emoji").value(EMOJI))
+                .andExpect(jsonPath("$.data.reactions[0].count").value(1))
+                .andExpect(jsonPath("$.data.reactions[0].reactedByMe").value(true));
+
+        mockMvc.perform(post("/api/study-room/{roomId}/feed/{feedId}/reactions", roomId, feed.getId())
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactions").isEmpty());
+
+        mockMvc.perform(post("/api/study-room/{roomId}/feed/{feedId}/reactions", roomId, feed.getId())
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest("not_allowed"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void sharedProblemShareReactionAndDeleteAuthorizationApiFlow() throws Exception {
+        User host = saveUser("방장", "shared-host");
+        User member = saveUser("멤버", "shared-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("공유 문제방");
+        String inviteCode = issueInviteCode(roomId);
+        Problem problem = createProblem(host.getId());
+        authenticate(member.getId());
+        join(inviteCode);
+
+        authenticate(host.getId());
+        Long sharedProblemId = shareProblem(roomId, problem.getId(), "같이 보면 좋은 문제");
+
+        authenticate(member.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/shared-problems/{sharedProblemId}/reactions", roomId, sharedProblemId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sharedProblemId").value(sharedProblemId))
+                .andExpect(jsonPath("$.data.reactions[0].count").value(1))
+                .andExpect(jsonPath("$.data.reactions[0].reactedByMe").value(true));
+
+        mockMvc.perform(delete("/api/study-room/{roomId}/shared-problems/{sharedProblemId}", roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+
+        authenticate(host.getId());
+        mockMvc.perform(delete("/api/study-room/{roomId}/shared-problems/{sharedProblemId}", roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("공유 문제 삭제가 완료되었습니다."));
+    }
+
+    @Test
+    void studySessionStartActiveDuplicateAndEndApiFlow() throws Exception {
+        User host = saveUser("방장", "session-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("세션방");
+
+        Long sessionId = startSession(roomId);
+        mockMvc.perform(get("/api/study-room/{roomId}/sessions/active", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.activeSessions[0].userId").value(host.getId()));
+
+        mockMvc.perform(post("/api/study-room/{roomId}/sessions", roomId)
+                        .with(auth()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value(10011));
+
+        mockMvc.perform(patch("/api/study-room/{roomId}/sessions/{sessionId}/end", roomId, sessionId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(sessionId))
+                .andExpect(jsonPath("$.data.endedAt").exists());
+
+        mockMvc.perform(get("/api/study-room/{roomId}/sessions/active", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.activeSessions").isEmpty());
+    }
+
+    @Test
+    void challengeApiUsesCurrentPeriodPracticeCountsAndKeepsPeriodChallengeInProgress() throws Exception {
+        User host = saveUser("방장", "challenge-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("챌린지방");
+        LocalDateTime startAt = LocalDateTime.now().minusDays(10).truncatedTo(ChronoUnit.SECONDS);
+        LocalDateTime endAt = startAt.plusWeeks(3);
+
+        mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ChallengeCreateRequest(
+                                "이번 주 복습 2회",
+                                "individual",
+                                "practice_count",
+                                "weekly",
+                                2,
+                                startAt,
+                                endAt
+                        ))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.period").value("weekly"));
+
+        createPractice(host.getId(), startAt.plusDays(1), 4);
+        createPractice(host.getId(), startAt.plusWeeks(1).plusHours(1), 2);
+
+        mockMvc.perform(get("/api/study-room/{roomId}/challenges", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].status").value("in_progress"))
+                .andExpect(jsonPath("$.data[0].memberProgress[0].current").value(2))
+                .andExpect(jsonPath("$.data[0].memberProgress[0].cleared").value(true));
+
+        mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ChallengeCreateRequest(
+                                " ",
+                                "individual",
+                                "practice_count",
+                                "weekly",
+                                2,
+                                startAt,
+                                endAt
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                )
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readLong(result, "$.data.roomId");
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+
+    private void join(String inviteCode) throws Exception {
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(inviteCode))))
+                .andExpect(status().isOk());
+    }
+
+    private Long startSession(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/sessions", roomId)
+                        .with(auth()))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readLong(result, "$.data.sessionId");
+    }
+
+    private Long shareProblem(Long roomId, Long problemId, String comment) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/shared-problems", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCreateRequest(problemId, comment))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.problemId").value(problemId))
+                .andReturn();
+        return readLong(result, "$.data.sharedProblemId");
+    }
+
+    private Long readLong(MvcResult result, String path) throws Exception {
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), path);
+        return value.longValue();
+    }
+
+    private Problem createProblem(Long userId) {
+        return problemRepository.save(Problem.from(
+                new ProblemRegisterDto(null, "memo", "reference", null, LocalDateTime.now()),
+                userId
+        ));
+    }
+
+    private void createPractice(Long userId, LocalDateTime practicedAt, int count) {
+        Problem problem = createProblem(userId);
+        for (int i = 0; i < count; i++) {
+            problemSolveRepository.save(ProblemSolve.create(
+                    problem,
+                    userId,
+                    practicedAt.plusSeconds(i),
+                    AnswerStatus.CORRECT,
+                    null,
+                    null,
+                    60
+            ));
+        }
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomChallengeApiIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomChallengeApiIntegrationTest.java
@@ -1,0 +1,183 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
+import com.aisip.OnO.backend.problemsolve.entity.ProblemSolve;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.ChallengeCreateRequest;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.InviteCodeResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomCreateRequest;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomDetailResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomJoinRequest;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomInviteService;
+import com.aisip.OnO.backend.studyroom.service.StudyRoomService;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomChallengeApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private StudyRoomService studyRoomService;
+
+    @Autowired
+    private StudyRoomInviteService inviteService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private ProblemSolveRepository problemSolveRepository;
+
+    private User host;
+    private User member;
+    private User outsider;
+    private Long roomId;
+
+    @BeforeEach
+    void setUp() {
+        host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "challenge-host"));
+        member = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "멤버", "challenge-member"));
+        outsider = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "외부", "challenge-outsider"));
+
+        authenticate(host.getId());
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("챌린지 테스트방"), host.getId());
+        InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
+        inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+        roomId = room.roomId();
+    }
+
+    @Test
+    void memberCanCreateWeeklyChallengeAndProgressCountsOnlyCurrentPeriod() throws Exception {
+        LocalDateTime startAt = LocalDateTime.now().minusDays(10).withNano(0);
+        LocalDateTime currentPeriodStart = startAt.plusWeeks(1);
+        createPractice(member.getId(), startAt.plusDays(2));
+        createPractice(member.getId(), currentPeriodStart.plusDays(1));
+        createPractice(member.getId(), currentPeriodStart.plusDays(2));
+        ChallengeCreateRequest request = new ChallengeCreateRequest(
+                "이번 주 복습 2개",
+                "individual",
+                "practice_count",
+                "weekly",
+                2,
+                startAt,
+                startAt.plusWeeks(3)
+        );
+
+        authenticate(member.getId());
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value("이번 주 복습 2개"))
+                .andExpect(jsonPath("$.data.type").value("individual"))
+                .andExpect(jsonPath("$.data.metric").value("practice_count"))
+                .andExpect(jsonPath("$.data.period").value("weekly"))
+                .andExpect(jsonPath("$.data.status").value("in_progress"))
+                .andReturn();
+
+        List<Map<String, Object>> memberProgress = JsonPath.read(
+                result.getResponse().getContentAsString(),
+                "$.data.memberProgress"
+        );
+        Map<String, Object> targetMemberProgress = memberProgress.stream()
+                .filter(progress -> ((Number) progress.get("userId")).longValue() == member.getId())
+                .findFirst()
+                .orElseThrow();
+        assertThat(targetMemberProgress.get("current")).isEqualTo(2);
+        assertThat(targetMemberProgress.get("cleared")).isEqualTo(true);
+    }
+
+    @Test
+    void nonMemberCannotGetChallenges() throws Exception {
+        authenticate(outsider.getId());
+
+        mockMvc.perform(get("/api/study-room/{roomId}/challenges", roomId))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    @Test
+    void createChallengeRejectsInvalidPeriod() throws Exception {
+        ChallengeCreateRequest request = new ChallengeCreateRequest(
+                "잘못된 기간",
+                "individual",
+                "practice_count",
+                "yearly",
+                1,
+                null,
+                LocalDateTime.now().plusDays(1)
+        );
+
+        authenticate(member.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    private void authenticate(Long userId) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                )
+        );
+    }
+
+    private void createPractice(Long userId, LocalDateTime practicedAt) {
+        Problem problem = problemRepository.save(Problem.from(
+                new ProblemRegisterDto(null, "memo", "reference", null, LocalDateTime.now()),
+                userId
+        ));
+        problemSolveRepository.save(ProblemSolve.create(
+                problem,
+                userId,
+                practicedAt,
+                AnswerStatus.CORRECT,
+                null,
+                null,
+                60
+        ));
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomChallengeApiIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomChallengeApiIntegrationTest.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -147,6 +149,80 @@ class StudyRoomChallengeApiIntegrationTest {
                 LocalDateTime.now().plusDays(1)
         );
 
+        authenticate(member.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    @Test
+    void hostCanDeleteChallengeAndMemberCannot() throws Exception {
+        ChallengeCreateRequest request = new ChallengeCreateRequest(
+                "삭제 테스트", "individual", "practice_count", null,
+                3, null, LocalDateTime.now().plusDays(7)
+        );
+        // 방장으로 챌린지 생성: 세션 간 인증 공유 문제를 피하기 위해 auth() RequestPostProcessor 사용
+        MvcResult createResult = mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                host.getId(), null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER")))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number challengeIdValue = JsonPath.read(createResult.getResponse().getContentAsString(), "$.data.challengeId");
+        Long challengeId = challengeIdValue.longValue();
+
+        // 멤버는 삭제 불가 - HOST_ONLY (10003)
+        mockMvc.perform(delete("/api/study-room/{roomId}/challenges/{challengeId}", roomId, challengeId)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                member.getId(), null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10003));
+
+        // 방장은 삭제 가능
+        mockMvc.perform(delete("/api/study-room/{roomId}/challenges/{challengeId}", roomId, challengeId)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                host.getId(), null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("챌린지 삭제가 완료되었습니다."));
+    }
+
+    @Test
+    void createChallengeRejectsTitleTooLong() throws Exception {
+        ChallengeCreateRequest request = new ChallengeCreateRequest(
+                "a".repeat(41), "individual", "practice_count", null,
+                3, null, LocalDateTime.now().plusDays(7)
+        );
+        authenticate(member.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    @Test
+    void createChallengeRejectsPastEndAt() throws Exception {
+        ChallengeCreateRequest request = new ChallengeCreateRequest(
+                "과거 종료일", "individual", "practice_count", null,
+                3, null, LocalDateTime.now().minusDays(1)
+        );
+        authenticate(member.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    @Test
+    void createChallengeRejectsStartAtAfterEndAt() throws Exception {
+        ChallengeCreateRequest request = new ChallengeCreateRequest(
+                "날짜 역전", "individual", "practice_count", null,
+                3, LocalDateTime.now().plusDays(5), LocalDateTime.now().plusDays(3)
+        );
         authenticate(member.getId());
         mockMvc.perform(post("/api/study-room/{roomId}/challenges", roomId)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomFeedApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomFeedApiTest.java
@@ -1,0 +1,221 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeed;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomFeedRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomFeedApiTest {
+
+    private static final String EMOJI = "fired_up_sparkle_eyes";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyRoomRepository roomRepository;
+
+    @Autowired
+    private StudyRoomFeedRepository feedRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void nonMemberCannotGetFeed() throws Exception {
+        User host = saveUser("방장", "feed-nonmember-host");
+        User outsider = saveUser("외부인", "feed-nonmember-outsider");
+        authenticate(host.getId());
+        Long roomId = createRoom("피드 접근 테스트방");
+
+        // 멤버가 아닌 외부인이 피드 조회 → 403 (10002)
+        authenticate(outsider.getId());
+        mockMvc.perform(get("/api/study-room/{roomId}/feed", roomId).with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    @Test
+    void feedPaginationWithCursor() throws Exception {
+        User host = saveUser("방장", "feed-pagination-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("피드 페이지네이션 테스트방");
+
+        // 피드 5개 직접 저장 (DB에 직접 저장 → 연속 ID 보장)
+        StudyRoom room = roomRepository.findById(roomId).orElseThrow();
+        for (int i = 0; i < 5; i++) {
+            feedRepository.save(StudyRoomFeed.create(room, host, StudyRoomFeedEventType.SESSION_STARTED, "{}"));
+        }
+
+        // 첫 번째 페이지: size=3 → 3개, hasNext=true
+        MvcResult firstResult = mockMvc.perform(get("/api/study-room/{roomId}/feed", roomId)
+                        .param("size", "3")
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andReturn();
+
+        String firstBody = firstResult.getResponse().getContentAsString();
+        List<Object> firstContent = JsonPath.read(firstBody, "$.data.content");
+        assertThat(firstContent).hasSize(3);
+        Number nextCursor = JsonPath.read(firstBody, "$.data.nextCursor");
+
+        // 두 번째 페이지: cursor=nextCursor → 2개, hasNext=false
+        MvcResult secondResult = mockMvc.perform(get("/api/study-room/{roomId}/feed", roomId)
+                        .param("size", "3")
+                        .param("cursor", nextCursor.toString())
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andReturn();
+
+        String secondBody = secondResult.getResponse().getContentAsString();
+        List<Object> secondContent = JsonPath.read(secondBody, "$.data.content");
+        assertThat(secondContent).hasSize(2);
+    }
+
+    @Test
+    void multipleUsersCanReactToSameFeed() throws Exception {
+        User host = saveUser("방장", "feed-react-host");
+        User member = saveUser("멤버", "feed-react-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("피드 반응 테스트방");
+        String code = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(code);
+
+        // 피드 1개 직접 저장
+        StudyRoom room = roomRepository.findById(roomId).orElseThrow();
+        StudyRoomFeed feed = feedRepository.save(
+                StudyRoomFeed.create(room, host, StudyRoomFeedEventType.SESSION_STARTED, "{}"));
+
+        // host가 반응 추가 → count=1
+        authenticate(host.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/feed/{feedId}/reactions", roomId, feed.getId())
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactions[0].count").value(1));
+
+        // member가 동일 이모지로 반응 추가 → count=2, reactedByMe=true (member 기준)
+        authenticate(member.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/feed/{feedId}/reactions", roomId, feed.getId())
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactions[0].count").value(2))
+                .andExpect(jsonPath("$.data.reactions[0].reactedByMe").value(true));
+    }
+
+    @Test
+    void nonMemberCannotToggleFeedReaction() throws Exception {
+        User host = saveUser("방장", "feed-react-perm-host");
+        User outsider = saveUser("외부인", "feed-react-perm-outsider");
+        authenticate(host.getId());
+        Long roomId = createRoom("반응 권한 테스트방");
+
+        // 피드 1개 직접 저장
+        StudyRoom room = roomRepository.findById(roomId).orElseThrow();
+        StudyRoomFeed feed = feedRepository.save(
+                StudyRoomFeed.create(room, host, StudyRoomFeedEventType.SESSION_STARTED, "{}"));
+
+        // 외부인이 반응 시도 → 403 (10002)
+        authenticate(outsider.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/feed/{feedId}/reactions", roomId, feed.getId())
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    // ========== 헬퍼 ==========
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                )
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), "$.data.roomId");
+        return value.longValue();
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId).with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+
+    private void join(String code) throws Exception {
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(code))))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomInviteApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomInviteApiTest.java
@@ -1,0 +1,163 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomInviteApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void inviteCodeIsReusedWhenNotExpired() throws Exception {
+        User host = saveUser("방장", "invite-reuse-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("코드 재사용 테스트방");
+
+        String code1 = issueInviteCode(roomId);
+        String code2 = issueInviteCode(roomId);
+
+        // 아직 만료되지 않았으므로 동일 코드 반환
+        assertThat(code2).isEqualTo(code1);
+    }
+
+    @Test
+    void invalidFormatInviteCodeIsRejected() throws Exception {
+        User user = saveUser("사용자", "invite-invalid-user");
+        authenticate(user.getId());
+
+        // 6자리 숫자가 아닌 코드 "abc" → 10006
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest("abc"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10006));
+
+        // 7자리 숫자 코드 "1234567" → 10006
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest("1234567"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10006));
+
+        // null 코드 → 10006
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10006));
+    }
+
+    @Test
+    void alreadyMemberCannotJoinRoom() throws Exception {
+        User host = saveUser("방장", "invite-already-member-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("중복 참여 테스트방");
+        String code = issueInviteCode(roomId);
+
+        // host가 자신의 방에 초대코드로 재가입 시도 → ALREADY_MEMBER (10008)
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(code))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value(10008));
+    }
+
+    @Test
+    void nonExistentValidFormatCodeIsRejected() throws Exception {
+        User user = saveUser("사용자", "invite-nonexist-user");
+        authenticate(user.getId());
+
+        // 형식은 맞지만 DB에 없는 코드 → INVITE_CODE_INVALID (10006)
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest("000000"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10006));
+    }
+
+    // ========== 헬퍼 ==========
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                )
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), "$.data.roomId");
+        return value.longValue();
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId).with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomMemberManagementApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomMemberManagementApiTest.java
@@ -1,0 +1,265 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomMemberManagementApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ========== 강퇴 권한 ==========
+
+    @Test
+    void hostCanKickMemberAndMemberCannotKick() throws Exception {
+        User host = saveUser("방장", "mgmt-kick-host");
+        User member = saveUser("멤버", "mgmt-kick-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("강퇴 테스트방");
+        String code = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(code);
+
+        // member가 host 강퇴 시도 → 방장만 가능 (10003)
+        mockMvc.perform(delete("/api/study-room/{roomId}/members/{memberId}", roomId, host.getId())
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10003));
+
+        // host가 member 강퇴 → 성공
+        authenticate(host.getId());
+        mockMvc.perform(delete("/api/study-room/{roomId}/members/{memberId}", roomId, member.getId())
+                        .with(auth()))
+                .andExpect(status().isOk());
+
+        // 방 조회 → memberCount=1
+        mockMvc.perform(get("/api/study-room/{roomId}", roomId).with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberCount").value(1));
+    }
+
+    @Test
+    void hostCannotKickSelf() throws Exception {
+        User host = saveUser("방장", "mgmt-selfkick-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("자기 강퇴 테스트방");
+
+        // host가 자신을 강퇴 시도 → host 역할이라 막힘 (10003)
+        mockMvc.perform(delete("/api/study-room/{roomId}/members/{memberId}", roomId, host.getId())
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10003));
+    }
+
+    // ========== 방 삭제 권한 ==========
+
+    @Test
+    void hostCanDeleteRoomAndMemberCannot() throws Exception {
+        // 시나리오 A: 방에 속한 member가 삭제 시도 → 방장만 가능 (10003)
+        User host = saveUser("방장", "mgmt-delete-host");
+        User member = saveUser("멤버", "mgmt-delete-member");
+        authenticate(host.getId());
+        Long roomIdWithMember = createRoom("삭제 권한 테스트방");
+        String code = issueInviteCode(roomIdWithMember);
+        authenticate(member.getId());
+        join(code);
+
+        mockMvc.perform(delete("/api/study-room/{roomId}", roomIdWithMember).with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10003));
+
+        // 시나리오 B: host 단독 방(초대코드 없음) 삭제 → 성공
+        // 초대코드 FK 제약이 없는 방에서 검증
+        User host2 = saveUser("방장2", "mgmt-delete-host2");
+        authenticate(host2.getId());
+        Long roomIdAlone = createRoom("host 단독 삭제 테스트방");
+
+        mockMvc.perform(delete("/api/study-room/{roomId}", roomIdAlone).with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("스터디룸 삭제가 완료되었습니다."));
+    }
+
+    // ========== 탈퇴 ==========
+
+    @Test
+    void memberLeaveRemovesMemberFromRoom() throws Exception {
+        User host = saveUser("방장", "mgmt-leave-host");
+        User member = saveUser("멤버", "mgmt-leave-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("탈퇴 테스트방");
+        String code = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(code);
+
+        // member 탈퇴
+        mockMvc.perform(delete("/api/study-room/{roomId}/leave", roomId).with(auth()))
+                .andExpect(status().isOk());
+
+        // 탈퇴 후 접근 → 멤버가 아님 (10002)
+        mockMvc.perform(get("/api/study-room/{roomId}", roomId).with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    @Test
+    void hostLeaveTransfersHostToNextMember() throws Exception {
+        User host = saveUser("방장", "mgmt-transfer-host");
+        User member = saveUser("멤버", "mgmt-transfer-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("위임 테스트방");
+        String code = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(code);
+
+        // host 탈퇴 → member에게 방장 위임
+        authenticate(host.getId());
+        mockMvc.perform(delete("/api/study-room/{roomId}/leave", roomId).with(auth()))
+                .andExpect(status().isOk());
+
+        // member 기준으로 방 조회 → member가 방장, memberCount=1
+        authenticate(member.getId());
+        mockMvc.perform(get("/api/study-room/{roomId}", roomId).with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hostUserId").value(member.getId()))
+                .andExpect(jsonPath("$.data.memberCount").value(1));
+    }
+
+    @Test
+    void hostLeaveAloneDeletesRoom() throws Exception {
+        User host = saveUser("방장", "mgmt-alone-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("혼자 탈퇴 테스트방");
+
+        // host 혼자 탈퇴 → 방 삭제
+        mockMvc.perform(delete("/api/study-room/{roomId}/leave", roomId).with(auth()))
+                .andExpect(status().isOk());
+
+        // 방 조회 → 404 (10001)
+        mockMvc.perform(get("/api/study-room/{roomId}", roomId).with(auth()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(10001));
+    }
+
+    // ========== 주간 목표 ==========
+
+    @Test
+    void memberCanSetAndClearWeeklyGoalAndNegativeGoalIsRejected() throws Exception {
+        User host = saveUser("방장", "mgmt-goal-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("목표 테스트방");
+
+        // weeklyGoal=20 설정 → 응답에 20 포함
+        mockMvc.perform(put("/api/study-room/{roomId}/members/me/goal", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomGoalUpdateRequest(20))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.weeklyGoal").value(20));
+
+        // weeklyGoal=0 설정 → null로 초기화, HTTP 200
+        mockMvc.perform(put("/api/study-room/{roomId}/members/me/goal", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomGoalUpdateRequest(0))))
+                .andExpect(status().isOk());
+
+        // weeklyGoal=-1 → 유효성 오류 (10016)
+        mockMvc.perform(put("/api/study-room/{roomId}/members/me/goal", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomGoalUpdateRequest(-1))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    // ========== 헬퍼 ==========
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                )
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readLong(result, "$.data.roomId");
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId).with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+
+    private void join(String code) throws Exception {
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(code))))
+                .andExpect(status().isOk());
+    }
+
+    private Long readLong(MvcResult result, String path) throws Exception {
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), path);
+        return value.longValue();
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemApiTest.java
@@ -1,0 +1,243 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomSharedProblemApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private ProblemSolveRepository problemSolveRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void nonMemberCannotGetSharedProblems() throws Exception {
+        User host = saveUser("방장", "shared-nonmember-host");
+        User outsider = saveUser("외부인", "shared-nonmember-outsider");
+        authenticate(host.getId());
+        Long roomId = createRoom("공유 문제 접근 테스트방");
+
+        // 외부인이 공유 문제 목록 조회 → 403 (10002)
+        authenticate(outsider.getId());
+        mockMvc.perform(get("/api/study-room/{roomId}/shared-problems", roomId).with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    @Test
+    void commentTooLongIsRejected() throws Exception {
+        User host = saveUser("방장", "shared-comment-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("댓글 길이 테스트방");
+        Problem problem = createProblem(host.getId());
+
+        // 101자 댓글 → 유효성 오류 (10016)
+        String tooLongComment = "a".repeat(101);
+        mockMvc.perform(post("/api/study-room/{roomId}/shared-problems", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCreateRequest(problem.getId(), tooLongComment))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    @Test
+    void nonSharerMemberCannotDeleteSharedProblem() throws Exception {
+        User host = saveUser("방장", "shared-delete-perm-host");
+        User member = saveUser("멤버", "shared-delete-perm-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("삭제 권한 테스트방");
+        String code = issueInviteCode(roomId);
+        Problem problem = createProblem(host.getId());
+        authenticate(member.getId());
+        join(code);
+
+        // host가 문제 공유
+        authenticate(host.getId());
+        Long sharedProblemId = shareProblem(roomId, problem.getId(), "공유 댓글");
+
+        // member가 host 공유 문제 삭제 시도 → 403 (10002)
+        authenticate(member.getId());
+        mockMvc.perform(delete("/api/study-room/{roomId}/shared-problems/{sharedProblemId}", roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    @Test
+    void sharerCanDeleteOwnSharedProblem() throws Exception {
+        User host = saveUser("방장", "shared-delete-own-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("본인 삭제 테스트방");
+        Problem problem = createProblem(host.getId());
+
+        // host가 공유 후 본인 삭제
+        Long sharedProblemId = shareProblem(roomId, problem.getId(), "내 공유 문제");
+
+        mockMvc.perform(delete("/api/study-room/{roomId}/shared-problems/{sharedProblemId}", roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("공유 문제 삭제가 완료되었습니다."));
+
+        // 삭제 후 목록 조회 → 빈 리스트
+        MvcResult listResult = mockMvc.perform(get("/api/study-room/{roomId}/shared-problems", roomId).with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        List<Object> content = JsonPath.read(listResult.getResponse().getContentAsString(), "$.data.content");
+        assertThat(content).isEmpty();
+    }
+
+    @Test
+    void sharedProblemPaginationWithCursor() throws Exception {
+        User host = saveUser("방장", "shared-pagination-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("공유 문제 페이지네이션 테스트방");
+
+        // 5개 문제 공유
+        for (int i = 0; i < 5; i++) {
+            Problem problem = createProblem(host.getId());
+            shareProblem(roomId, problem.getId(), "댓글 " + i);
+        }
+
+        // 첫 번째 페이지: size=3 → 3개, hasNext=true
+        MvcResult firstResult = mockMvc.perform(get("/api/study-room/{roomId}/shared-problems", roomId)
+                        .param("size", "3")
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andReturn();
+
+        String firstBody = firstResult.getResponse().getContentAsString();
+        List<Object> firstContent = JsonPath.read(firstBody, "$.data.content");
+        assertThat(firstContent).hasSize(3);
+        Number nextCursor = JsonPath.read(firstBody, "$.data.nextCursor");
+
+        // 두 번째 페이지: cursor=nextCursor → 2개, hasNext=false
+        MvcResult secondResult = mockMvc.perform(get("/api/study-room/{roomId}/shared-problems", roomId)
+                        .param("size", "3")
+                        .param("cursor", nextCursor.toString())
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andReturn();
+
+        String secondBody = secondResult.getResponse().getContentAsString();
+        List<Object> secondContent = JsonPath.read(secondBody, "$.data.content");
+        assertThat(secondContent).hasSize(2);
+    }
+
+    // ========== 헬퍼 ==========
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                )
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), "$.data.roomId");
+        return value.longValue();
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId).with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+
+    private void join(String code) throws Exception {
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(code))))
+                .andExpect(status().isOk());
+    }
+
+    private Problem createProblem(Long userId) {
+        return problemRepository.save(Problem.from(
+                new ProblemRegisterDto(null, "memo", "ref", null, LocalDateTime.now()),
+                userId
+        ));
+    }
+
+    private Long shareProblem(Long roomId, Long problemId, String comment) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/shared-problems", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCreateRequest(problemId, comment))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), "$.data.sharedProblemId");
+        return value.longValue();
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemApiTest.java
@@ -3,6 +3,9 @@ package com.aisip.OnO.backend.studyroom.integration;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.practicenote.dto.PracticeNoteRegisterDto;
+import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveRegisterDto;
+import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
 import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
 import com.aisip.OnO.backend.user.entity.User;
@@ -174,6 +177,53 @@ class StudyRoomSharedProblemApiTest {
         String secondBody = secondResult.getResponse().getContentAsString();
         List<Object> secondContent = JsonPath.read(secondBody, "$.data.content");
         assertThat(secondContent).hasSize(2);
+    }
+
+    @Test
+    void sharedProblemDoesNotAllowOtherMemberToUseOriginalProblemAsOwnStudyData() throws Exception {
+        User host = saveUser("방장", "shared-readonly-host");
+        User member = saveUser("멤버", "shared-readonly-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("읽기 전용 정책방");
+        String code = issueInviteCode(roomId);
+        Problem hostProblem = createProblem(host.getId());
+        shareProblem(roomId, hostProblem.getId(), "읽기 전용 공유 문제");
+
+        authenticate(member.getId());
+        join(code);
+
+        mockMvc.perform(get("/api/problems/{problemId}", hostProblem.getId())
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(4002));
+
+        mockMvc.perform(post("/api/problem-solves")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ProblemSolveRegisterDto(
+                                hostProblem.getId(),
+                                LocalDateTime.now(),
+                                AnswerStatus.CORRECT,
+                                "타인 공유 문제 복습 시도",
+                                List.of(),
+                                60
+                        ))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(4002));
+
+        mockMvc.perform(post("/api/practiceNotes")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new PracticeNoteRegisterDto(
+                                null,
+                                "타인 공유 문제 편입 시도",
+                                List.of(hostProblem.getId()),
+                                null
+                        ))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(4002));
+
+        assertThat(problemSolveRepository.countByProblemId(hostProblem.getId())).isZero();
     }
 
     // ========== 헬퍼 ==========

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemApiTest.java
@@ -1,7 +1,10 @@
 package com.aisip.OnO.backend.studyroom.integration;
 
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.dto.ProblemImageDataRegisterDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.entity.ProblemImageData;
+import com.aisip.OnO.backend.problem.entity.ProblemImageType;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
 import com.aisip.OnO.backend.practicenote.dto.PracticeNoteRegisterDto;
 import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveRegisterDto;
@@ -40,6 +43,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 class StudyRoomSharedProblemApiTest {
+
+    private static final String EMOJI = "fired_up_sparkle_eyes";
 
     @Autowired
     private MockMvc mockMvc;
@@ -126,6 +131,13 @@ class StudyRoomSharedProblemApiTest {
 
         // host가 공유 후 본인 삭제
         Long sharedProblemId = shareProblem(roomId, problem.getId(), "내 공유 문제");
+        Long commentId = createComment(roomId, sharedProblemId, "삭제 전 댓글");
+        mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}/reactions",
+                        roomId, sharedProblemId, commentId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk());
 
         mockMvc.perform(delete("/api/study-room/{roomId}/shared-problems/{sharedProblemId}", roomId, sharedProblemId)
                         .with(auth()))
@@ -177,6 +189,33 @@ class StudyRoomSharedProblemApiTest {
         String secondBody = secondResult.getResponse().getContentAsString();
         List<Object> secondContent = JsonPath.read(secondBody, "$.data.content");
         assertThat(secondContent).hasSize(2);
+    }
+
+    @Test
+    void sharedProblemListIncludesDetailFieldsForBoardSheet() throws Exception {
+        User host = saveUser("방장", "shared-detail-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("공유 문제 상세 응답방");
+        Problem problem = createProblem(host.getId(), "", "https://cdn.example.com/problem.png");
+        Long sharedProblemId = shareProblem(roomId, problem.getId(), "풀이 의견을 남겨주세요");
+
+        createComment(roomId, sharedProblemId, "첫 번째 의견");
+        createComment(roomId, sharedProblemId, "두 번째 의견");
+
+        mockMvc.perform(get("/api/study-room/{roomId}/shared-problems", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].sharedProblemId").value(sharedProblemId))
+                .andExpect(jsonPath("$.data.content[0].sharedByUserId").value(host.getId()))
+                .andExpect(jsonPath("$.data.content[0].sharedByName").value("방장"))
+                .andExpect(jsonPath("$.data.content[0].sharedByProfileImageUrl").isEmpty())
+                .andExpect(jsonPath("$.data.content[0].problemId").value(problem.getId()))
+                .andExpect(jsonPath("$.data.content[0].problemImageUrl").value("https://cdn.example.com/problem.png"))
+                .andExpect(jsonPath("$.data.content[0].reference").value("공유 문제"))
+                .andExpect(jsonPath("$.data.content[0].comment").value("풀이 의견을 남겨주세요"))
+                .andExpect(jsonPath("$.data.content[0].commentCount").value(2))
+                .andExpect(jsonPath("$.data.content[0].sharedAt").exists())
+                .andExpect(jsonPath("$.data.content[0].reactions").isEmpty());
     }
 
     @Test
@@ -274,10 +313,32 @@ class StudyRoomSharedProblemApiTest {
     }
 
     private Problem createProblem(Long userId) {
-        return problemRepository.save(Problem.from(
-                new ProblemRegisterDto(null, "memo", "ref", null, LocalDateTime.now()),
+        return createProblem(userId, "ref", null);
+    }
+
+    private Problem createProblem(Long userId, String reference, String problemImageUrl) {
+        Problem problem = Problem.from(
+                new ProblemRegisterDto(null, "memo", reference, null, LocalDateTime.now()),
                 userId
-        ));
+        );
+        if (problemImageUrl != null) {
+            ProblemImageData imageData = ProblemImageData.from(
+                    new ProblemImageDataRegisterDto(null, problemImageUrl, ProblemImageType.PROBLEM_IMAGE));
+            imageData.updateProblem(problem);
+        }
+        return problemRepository.save(problem);
+    }
+
+    private Long createComment(Long roomId, Long sharedProblemId, String content) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest(content))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), "$.data.commentId");
+        return value.longValue();
     }
 
     private Long shareProblem(Long roomId, Long problemId, String comment) throws Exception {

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
@@ -79,7 +79,9 @@ class StudyRoomSharedProblemCommentApiTest {
                 .andExpect(jsonPath("$.data.content").value("수정된 풀이 의견"))
                 .andExpect(jsonPath("$.data.authorId").value(member.getId()))
                 .andExpect(jsonPath("$.data.authorName").value("멤버"))
-                .andExpect(jsonPath("$.data.isMine").value(true));
+                .andExpect(jsonPath("$.data.isEdited").value(true))
+                .andExpect(jsonPath("$.data.isMine").value(true))
+                .andExpect(jsonPath("$.data.canDelete").value(true));
 
         MvcResult result = mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
                         roomId, sharedProblemId)
@@ -89,6 +91,7 @@ class StudyRoomSharedProblemCommentApiTest {
                 .andExpect(jsonPath("$.data.content[0].commentId").value(commentId))
                 .andExpect(jsonPath("$.data.content[0].content").value("수정된 풀이 의견"))
                 .andExpect(jsonPath("$.data.content[0].isMine").value(true))
+                .andExpect(jsonPath("$.data.content[0].canDelete").value(true))
                 .andReturn();
 
         List<Object> comments = JsonPath.read(result.getResponse().getContentAsString(), "$.data.content");
@@ -111,6 +114,13 @@ class StudyRoomSharedProblemCommentApiTest {
 
         authenticate(anotherMember.getId());
         join(inviteCode);
+        mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].isMine").value(false))
+                .andExpect(jsonPath("$.data.content[0].canDelete").value(false));
+
         mockMvc.perform(patch("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}",
                         roomId, sharedProblemId, commentId)
                         .with(auth())
@@ -120,6 +130,13 @@ class StudyRoomSharedProblemCommentApiTest {
                 .andExpect(jsonPath("$.errorCode").value(10019));
 
         authenticate(host.getId());
+        mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].isMine").value(false))
+                .andExpect(jsonPath("$.data.content[0].canDelete").value(true));
+
         mockMvc.perform(delete("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}",
                         roomId, sharedProblemId, commentId)
                         .with(auth()))

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
@@ -37,6 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 class StudyRoomSharedProblemCommentApiTest {
 
+    private static final String EMOJI = "fired_up_sparkle_eyes";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -81,7 +83,8 @@ class StudyRoomSharedProblemCommentApiTest {
                 .andExpect(jsonPath("$.data.authorName").value("멤버"))
                 .andExpect(jsonPath("$.data.isEdited").value(true))
                 .andExpect(jsonPath("$.data.isMine").value(true))
-                .andExpect(jsonPath("$.data.canDelete").value(true));
+                .andExpect(jsonPath("$.data.canDelete").value(true))
+                .andExpect(jsonPath("$.data.reactions").isEmpty());
 
         MvcResult result = mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
                         roomId, sharedProblemId)
@@ -92,6 +95,7 @@ class StudyRoomSharedProblemCommentApiTest {
                 .andExpect(jsonPath("$.data.content[0].content").value("수정된 풀이 의견"))
                 .andExpect(jsonPath("$.data.content[0].isMine").value(true))
                 .andExpect(jsonPath("$.data.content[0].canDelete").value(true))
+                .andExpect(jsonPath("$.data.content[0].reactions").isEmpty())
                 .andReturn();
 
         List<Object> comments = JsonPath.read(result.getResponse().getContentAsString(), "$.data.content");
@@ -128,6 +132,14 @@ class StudyRoomSharedProblemCommentApiTest {
                         .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest("권한 없는 수정"))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.errorCode").value(10019));
+
+        mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}/reactions",
+                        roomId, sharedProblemId, commentId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactions[0].count").value(1));
 
         authenticate(host.getId());
         mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
@@ -179,6 +191,47 @@ class StudyRoomSharedProblemCommentApiTest {
 
         List<Object> comments = JsonPath.read(secondResult.getResponse().getContentAsString(), "$.data.content");
         assertThat(comments).hasSize(2);
+    }
+
+    @Test
+    void memberCanToggleSharedProblemCommentReaction() throws Exception {
+        User host = saveUser("방장", "comment-reaction-host");
+        User member = saveUser("멤버", "comment-reaction-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("댓글 반응방");
+        String inviteCode = issueInviteCode(roomId);
+        Long sharedProblemId = shareProblem(roomId, createProblem(host.getId()).getId(), "공유 문제");
+        Long commentId = createComment(roomId, sharedProblemId, "방장 댓글");
+
+        authenticate(member.getId());
+        join(inviteCode);
+
+        mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}/reactions",
+                        roomId, sharedProblemId, commentId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.commentId").value(commentId))
+                .andExpect(jsonPath("$.data.reactions[0].emoji").value(EMOJI))
+                .andExpect(jsonPath("$.data.reactions[0].count").value(1))
+                .andExpect(jsonPath("$.data.reactions[0].reactedByMe").value(true));
+
+        mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].reactions[0].emoji").value(EMOJI))
+                .andExpect(jsonPath("$.data.content[0].reactions[0].count").value(1))
+                .andExpect(jsonPath("$.data.content[0].reactions[0].reactedByMe").value(true));
+
+        mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}/reactions",
+                        roomId, sharedProblemId, commentId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReactionToggleRequest(EMOJI))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactions").isEmpty());
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
@@ -1,0 +1,268 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomSharedProblemCommentApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void memberCanCreateUpdateAndListSharedProblemComments() throws Exception {
+        User host = saveUser("방장", "comment-flow-host");
+        User member = saveUser("멤버", "comment-flow-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("댓글 테스트방");
+        String inviteCode = issueInviteCode(roomId);
+        Long sharedProblemId = shareProblem(roomId, createProblem(host.getId()).getId(), "공유 문제");
+
+        authenticate(member.getId());
+        join(inviteCode);
+        Long commentId = createComment(roomId, sharedProblemId, "처음 풀이 의견");
+
+        mockMvc.perform(patch("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}",
+                        roomId, sharedProblemId, commentId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest("수정된 풀이 의견"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.commentId").value(commentId))
+                .andExpect(jsonPath("$.data.content").value("수정된 풀이 의견"))
+                .andExpect(jsonPath("$.data.authorId").value(member.getId()))
+                .andExpect(jsonPath("$.data.authorName").value("멤버"))
+                .andExpect(jsonPath("$.data.isMine").value(true));
+
+        MvcResult result = mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .param("size", "10")
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].commentId").value(commentId))
+                .andExpect(jsonPath("$.data.content[0].content").value("수정된 풀이 의견"))
+                .andExpect(jsonPath("$.data.content[0].isMine").value(true))
+                .andReturn();
+
+        List<Object> comments = JsonPath.read(result.getResponse().getContentAsString(), "$.data.content");
+        assertThat(comments).hasSize(1);
+    }
+
+    @Test
+    void onlyAuthorCanUpdateAndHostCanDeleteOtherMemberComment() throws Exception {
+        User host = saveUser("방장", "comment-auth-host");
+        User member = saveUser("멤버", "comment-auth-member");
+        User anotherMember = saveUser("다른멤버", "comment-auth-another");
+        authenticate(host.getId());
+        Long roomId = createRoom("댓글 권한방");
+        String inviteCode = issueInviteCode(roomId);
+        Long sharedProblemId = shareProblem(roomId, createProblem(host.getId()).getId(), "공유 문제");
+
+        authenticate(member.getId());
+        join(inviteCode);
+        Long commentId = createComment(roomId, sharedProblemId, "멤버 댓글");
+
+        authenticate(anotherMember.getId());
+        join(inviteCode);
+        mockMvc.perform(patch("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}",
+                        roomId, sharedProblemId, commentId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest("권한 없는 수정"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+
+        authenticate(host.getId());
+        mockMvc.perform(delete("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}",
+                        roomId, sharedProblemId, commentId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("공유 문제 댓글 삭제가 완료되었습니다."));
+
+        mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments", roomId, sharedProblemId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    void commentPaginationUsesCursor() throws Exception {
+        User host = saveUser("방장", "comment-page-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("댓글 페이지방");
+        Long sharedProblemId = shareProblem(roomId, createProblem(host.getId()).getId(), "공유 문제");
+        for (int i = 0; i < 5; i++) {
+            createComment(roomId, sharedProblemId, "댓글 " + i);
+        }
+
+        MvcResult firstResult = mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .param("size", "3")
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andReturn();
+        Number nextCursor = JsonPath.read(firstResult.getResponse().getContentAsString(), "$.data.nextCursor");
+
+        MvcResult secondResult = mockMvc.perform(get("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .param("size", "3")
+                        .param("cursor", nextCursor.toString())
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andReturn();
+
+        List<Object> comments = JsonPath.read(secondResult.getResponse().getContentAsString(), "$.data.content");
+        assertThat(comments).hasSize(2);
+    }
+
+    @Test
+    void blankOrTooLongCommentIsRejected() throws Exception {
+        User host = saveUser("방장", "comment-invalid-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("댓글 검증방");
+        Long sharedProblemId = shareProblem(roomId, createProblem(host.getId()).getId(), "공유 문제");
+
+        mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments", roomId, sharedProblemId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest(" "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+
+        mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments", roomId, sharedProblemId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest("a".repeat(1001)))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(10016));
+    }
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                )
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readLong(result, "$.data.roomId");
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+
+    private void join(String inviteCode) throws Exception {
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(inviteCode))))
+                .andExpect(status().isOk());
+    }
+
+    private Problem createProblem(Long userId) {
+        return problemRepository.save(Problem.from(
+                new ProblemRegisterDto(null, "memo", "reference", null, LocalDateTime.now()),
+                userId
+        ));
+    }
+
+    private Long shareProblem(Long roomId, Long problemId, String comment) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/shared-problems", roomId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCreateRequest(problemId, comment))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readLong(result, "$.data.sharedProblemId");
+    }
+
+    private Long createComment(Long roomId, Long sharedProblemId, String content) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments",
+                        roomId, sharedProblemId)
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest(content))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readLong(result, "$.data.commentId");
+    }
+
+    private Long readLong(MvcResult result, String path) throws Exception {
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), path);
+        return value.longValue();
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomSharedProblemCommentApiTest.java
@@ -117,7 +117,7 @@ class StudyRoomSharedProblemCommentApiTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest("권한 없는 수정"))))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.errorCode").value(10002));
+                .andExpect(jsonPath("$.errorCode").value(10019));
 
         authenticate(host.getId());
         mockMvc.perform(delete("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments/{commentId}",
@@ -176,14 +176,14 @@ class StudyRoomSharedProblemCommentApiTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest(" "))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(10016));
+                .andExpect(jsonPath("$.errorCode").value(10018));
 
         mockMvc.perform(post("/api/study-rooms/{roomId}/shared-problems/{sharedProblemId}/comments", roomId, sharedProblemId)
                         .with(auth())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest("a".repeat(1001)))))
+                        .content(objectMapper.writeValueAsString(new SharedProblemCommentRequest("a".repeat(301)))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(10016));
+                .andExpect(jsonPath("$.errorCode").value(10018));
     }
 
     private User saveUser(String name, String emailPrefix) {

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomWeeklyReportApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudyRoomWeeklyReportApiTest.java
@@ -1,0 +1,218 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomWeeklyReport;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomWeeklyReportRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudyRoomWeeklyReportApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyRoomRepository roomRepository;
+
+    @Autowired
+    private StudyRoomWeeklyReportRepository reportRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void nonMemberCannotGetWeeklyReports() throws Exception {
+        User host = saveUser("방장", "report-nonmember-host");
+        User outsider = saveUser("외부", "report-nonmember-outsider");
+        authenticate(host.getId());
+        Long roomId = createRoom("리포트 권한 테스트방");
+
+        authenticate(outsider.getId());
+        mockMvc.perform(get("/api/study-room/{roomId}/weekly-reports", roomId)
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    @Test
+    void memberGetsEmptyListWhenNoReportsExist() throws Exception {
+        User host = saveUser("방장", "report-empty-host");
+        authenticate(host.getId());
+        Long roomId = createRoom("빈 리포트방");
+
+        mockMvc.perform(get("/api/study-room/{roomId}/weekly-reports", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    void memberCanGetReportAndIsReadStatusIsCorrect() throws Exception {
+        User host = saveUser("방장", "report-read-host");
+        User member = saveUser("멤버", "report-read-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("리포트 읽음 테스트방");
+        String inviteCode = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(inviteCode);
+
+        StudyRoom room = roomRepository.findById(roomId).orElseThrow();
+        StudyRoomWeeklyReport report = reportRepository.save(StudyRoomWeeklyReport.create(
+                room,
+                LocalDate.now().minusDays(7),
+                LocalDate.now().minusDays(1),
+                "방장", 5,
+                "방장", 3,
+                5, 0,
+                "이번 주도 수고하셨습니다!"
+        ));
+
+        // 읽기 전: isRead=false
+        authenticate(member.getId());
+        mockMvc.perform(get("/api/study-room/{roomId}/weekly-reports", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].isRead").value(false));
+
+        // 읽음 처리: 응답에서 isRead=true
+        mockMvc.perform(patch("/api/study-room/{roomId}/weekly-reports/{reportId}/read", roomId, report.getId())
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isRead").value(true));
+
+        // 다시 조회: isRead=true
+        mockMvc.perform(get("/api/study-room/{roomId}/weekly-reports", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].isRead").value(true));
+    }
+
+    @Test
+    void markReadOnNonExistentReportThrowsNotFound() throws Exception {
+        User host = saveUser("방장", "report-notfound-host");
+        User member = saveUser("멤버", "report-notfound-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("리포트 없음 테스트방");
+        String inviteCode = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(inviteCode);
+
+        mockMvc.perform(patch("/api/study-room/{roomId}/weekly-reports/{reportId}/read", roomId, 9999999L)
+                        .with(auth()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(10014));
+    }
+
+    @Test
+    void nonMemberCannotMarkReportRead() throws Exception {
+        User host = saveUser("방장", "report-forbid-host");
+        User outsider = saveUser("외부", "report-forbid-outsider");
+        authenticate(host.getId());
+        Long roomId = createRoom("리포트 금지 테스트방");
+
+        StudyRoom room = roomRepository.findById(roomId).orElseThrow();
+        StudyRoomWeeklyReport report = reportRepository.save(StudyRoomWeeklyReport.create(
+                room,
+                LocalDate.now().minusDays(7),
+                LocalDate.now().minusDays(1),
+                "방장", 5,
+                "방장", 3,
+                5, 0,
+                "이번 주도 수고하셨습니다!"
+        ));
+
+        authenticate(outsider.getId());
+        mockMvc.perform(patch("/api/study-room/{roomId}/weekly-reports/{reportId}/read", roomId, report.getId())
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    // ========== 헬퍼 ==========
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER")))
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), "$.data.roomId");
+        return value.longValue();
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+
+    private void join(String inviteCode) throws Exception {
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(inviteCode))))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudySessionApiTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/integration/StudySessionApiTest.java
@@ -1,0 +1,138 @@
+package com.aisip.OnO.backend.studyroom.integration;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StudySessionApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long authenticatedUserId;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void nonMemberCannotStartStudySession() throws Exception {
+        User host = saveUser("방장", "session-nonmember-host");
+        User outsider = saveUser("외부", "session-nonmember-outsider");
+        authenticate(host.getId());
+        Long roomId = createRoom("세션 권한 테스트방");
+
+        authenticate(outsider.getId());
+        mockMvc.perform(post("/api/study-room/{roomId}/sessions", roomId)
+                        .with(auth()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(10002));
+    }
+
+    @Test
+    void cannotEndOtherUsersStudySession() throws Exception {
+        User host = saveUser("방장", "session-end-host");
+        User member = saveUser("멤버", "session-end-member");
+        authenticate(host.getId());
+        Long roomId = createRoom("세션 종료 테스트방");
+        String inviteCode = issueInviteCode(roomId);
+        authenticate(member.getId());
+        join(inviteCode);
+
+        // host가 세션 시작
+        authenticate(host.getId());
+        MvcResult startResult = mockMvc.perform(post("/api/study-room/{roomId}/sessions", roomId)
+                        .with(auth()))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number sessionIdValue = JsonPath.read(startResult.getResponse().getContentAsString(), "$.data.sessionId");
+        Long sessionId = sessionIdValue.longValue();
+
+        // member가 host 세션 종료 시도 → SESSION_NOT_FOUND (10012): findByIdAndRoomIdAndUserId 미일치
+        authenticate(member.getId());
+        mockMvc.perform(patch("/api/study-room/{roomId}/sessions/{sessionId}/end", roomId, sessionId)
+                        .with(auth()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(10012));
+    }
+
+    // ========== 헬퍼 ==========
+
+    private User saveUser(String name, String emailPrefix) {
+        return userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", name, emailPrefix));
+    }
+
+    private void authenticate(Long userId) {
+        authenticatedUserId = userId;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER")))
+        );
+    }
+
+    private RequestPostProcessor auth() {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                authenticatedUserId, null, List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        ));
+    }
+
+    private Long createRoom(String name) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomCreateRequest(name))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Number value = JsonPath.read(result.getResponse().getContentAsString(), "$.data.roomId");
+        return value.longValue();
+    }
+
+    private String issueInviteCode(Long roomId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/study-room/{roomId}/invite", roomId)
+                        .with(auth()))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.code");
+    }
+
+    private void join(String inviteCode) throws Exception {
+        mockMvc.perform(post("/api/study-room/join")
+                        .with(auth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new StudyRoomJoinRequest(inviteCode))))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -115,6 +116,232 @@ class StudyRoomChallengeServiceTest {
 
         assertThat(response.status()).isEqualTo("completed");
         assertThat(response.groupCurrent()).isEqualTo(5);
+    }
+
+    @Test
+    void dailyPeriodChallengeAggregatesCurrentDayWindow() {
+        // DAILY 주기: startAt = 3일 전 자정, endAt = 4일 후 자정
+        LocalDateTime startAt = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(3);
+        LocalDateTime endAt = startAt.plusDays(7);
+        User user = user(1L, "멤버");
+        StudyRoomMember member = StudyRoomMember.create(user, StudyRoomMemberRole.HOST);
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.INDIVIDUAL,
+                StudyRoomChallengeMetric.PRACTICE_COUNT,
+                StudyRoomChallengePeriod.DAILY,
+                2,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L)).willReturn(List.of(member));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any())).willReturn(Map.of(user.getId(), 0));
+        // practice_count=1, target=2 → cleared=false
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(user.getId(), new StudyRoomStats(0, 1, 0)));
+
+        List<ChallengeResponse> responses = challengeService.getChallenges(10L, user.getId());
+
+        assertThat(responses).hasSize(1);
+        ChallengeResponse response = responses.get(0);
+        assertThat(response.status()).isEqualTo("in_progress");
+        assertThat(response.memberProgress()).singleElement().satisfies(p -> {
+            assertThat(p.current()).isEqualTo(1);
+            assertThat(p.cleared()).isFalse();
+        });
+
+        // 오늘(day 3) 구간: [startAt+3days, startAt+4days]
+        ArgumentCaptor<LocalDateTime> rangeStart = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> rangeEnd = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(statsService).getStats(anyList(), rangeStart.capture(), rangeEnd.capture(), anyMap());
+        assertThat(rangeStart.getValue()).isEqualTo(startAt.plusDays(3));
+        assertThat(rangeEnd.getValue()).isEqualTo(startAt.plusDays(4));
+    }
+
+    @Test
+    void individualChallengeStaysInProgressWhenNotAllMembersCleared() {
+        LocalDateTime startAt = LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.SECONDS);
+        LocalDateTime endAt = LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.SECONDS);
+        User member1 = user(1L, "첫번째");
+        User member2 = user(2L, "두번째");
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.INDIVIDUAL,
+                StudyRoomChallengeMetric.PRACTICE_COUNT,
+                null,
+                3,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L))
+                .willReturn(List.of(
+                        StudyRoomMember.create(member1, StudyRoomMemberRole.HOST),
+                        StudyRoomMember.create(member2, StudyRoomMemberRole.MEMBER)
+                ));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any()))
+                .willReturn(Map.of(member1.getId(), 0, member2.getId(), 0));
+        // member1: practice_count=2 (미달), member2: practice_count=5 (달성)
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(
+                        member1.getId(), new StudyRoomStats(0, 2, 0),
+                        member2.getId(), new StudyRoomStats(0, 5, 0)
+                ));
+
+        ChallengeResponse response = challengeService.getChallenges(10L, member1.getId()).get(0);
+
+        // 일부 멤버만 달성했으므로 in_progress 유지
+        assertThat(response.status()).isEqualTo("in_progress");
+        assertThat(response.memberProgress()).anySatisfy(p -> {
+            assertThat(p.userId()).isEqualTo(member1.getId());
+            assertThat(p.cleared()).isFalse();
+        });
+        assertThat(response.memberProgress()).anySatisfy(p -> {
+            assertThat(p.userId()).isEqualTo(member2.getId());
+            assertThat(p.cleared()).isTrue();
+        });
+    }
+
+    @Test
+    void expiredEndAtChallengeReturnsExpiredStatus() {
+        LocalDateTime startAt = LocalDateTime.now().minusDays(10).truncatedTo(ChronoUnit.SECONDS);
+        LocalDateTime endAt = LocalDateTime.now().minusDays(2).truncatedTo(ChronoUnit.SECONDS);
+        User user = user(1L, "멤버");
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.INDIVIDUAL,
+                StudyRoomChallengeMetric.PRACTICE_COUNT,
+                null,
+                10,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L))
+                .willReturn(List.of(StudyRoomMember.create(user, StudyRoomMemberRole.HOST)));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any())).willReturn(Map.of(user.getId(), 0));
+        // practice_count=1, target=10 → 미달성이고 endAt도 과거
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(user.getId(), new StudyRoomStats(0, 1, 0)));
+
+        ChallengeResponse response = challengeService.getChallenges(10L, user.getId()).get(0);
+
+        assertThat(response.status()).isEqualTo("expired");
+    }
+
+    @Test
+    void attendanceMetricUsesAttendanceDayCountFromStatsService() {
+        LocalDateTime startAt = LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.SECONDS);
+        LocalDateTime endAt = LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.SECONDS);
+        User user = user(1L, "멤버");
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.INDIVIDUAL,
+                StudyRoomChallengeMetric.ATTENDANCE,
+                null,
+                5,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L))
+                .willReturn(List.of(StudyRoomMember.create(user, StudyRoomMemberRole.HOST)));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any())).willReturn(Map.of(user.getId(), 0));
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(user.getId(), new StudyRoomStats(0, 0, 0)));
+        // attendanceDayCounts → 6 (target=5이므로 cleared=true)
+        given(statsService.attendanceDayCounts(anyList(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(Map.of(user.getId(), 6));
+
+        List<ChallengeResponse> responses = challengeService.getChallenges(10L, user.getId());
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).memberProgress()).singleElement().satisfies(p -> {
+            assertThat(p.current()).isEqualTo(6);
+            assertThat(p.cleared()).isTrue();
+        });
+        verify(statsService).attendanceDayCounts(anyList(), any(LocalDateTime.class), any(LocalDateTime.class));
+    }
+
+    @Test
+    void monthlyPeriodChallengeAggregatesCurrentMonthWindow() {
+        // 2달 전 첫째날 자정부터 시작하는 MONTHLY 주기 챌린지
+        LocalDateTime startAt = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
+        LocalDateTime endAt = startAt.plusMonths(6);
+        User user = user(1L, "멤버");
+        StudyRoomMember member = StudyRoomMember.create(user, StudyRoomMemberRole.HOST);
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.INDIVIDUAL,
+                StudyRoomChallengeMetric.PRACTICE_COUNT,
+                StudyRoomChallengePeriod.MONTHLY,
+                3,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L)).willReturn(List.of(member));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any())).willReturn(Map.of(user.getId(), 0));
+        // practice_count=1, target=3 → 미달성 → status = in_progress
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(user.getId(), new StudyRoomStats(0, 1, 0)));
+
+        List<ChallengeResponse> responses = challengeService.getChallenges(10L, user.getId());
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).status()).isEqualTo("in_progress");
+        assertThat(responses.get(0).memberProgress()).singleElement().satisfies(p -> {
+            assertThat(p.current()).isEqualTo(1);
+            assertThat(p.cleared()).isFalse();
+        });
+
+        // 현재 구간 = [startAt.plusMonths(2), startAt.plusMonths(3)] 임을 검증
+        ArgumentCaptor<LocalDateTime> rangeStart = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> rangeEnd = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(statsService).getStats(anyList(), rangeStart.capture(), rangeEnd.capture(), anyMap());
+        assertThat(rangeStart.getValue()).isEqualTo(startAt.plusMonths(2));
+        assertThat(rangeEnd.getValue()).isEqualTo(startAt.plusMonths(3));
+    }
+
+    @Test
+    void streakMetricUsesAttendanceDayCount() {
+        LocalDateTime startAt = LocalDateTime.now().minusDays(14).truncatedTo(ChronoUnit.SECONDS);
+        LocalDateTime endAt = startAt.plusDays(28);
+        User user = user(7L, "멤버");
+        StudyRoomMember member = StudyRoomMember.create(user, StudyRoomMemberRole.HOST);
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.INDIVIDUAL,
+                StudyRoomChallengeMetric.STREAK,
+                null,
+                5,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L)).willReturn(List.of(member));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any())).willReturn(Map.of(user.getId(), 7));
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(user.getId(), new StudyRoomStats(0, 0, 7)));
+        // attendanceDayCounts = 7, target = 5 → cleared=true
+        given(statsService.attendanceDayCounts(anyList(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(Map.of(user.getId(), 7));
+
+        List<ChallengeResponse> responses = challengeService.getChallenges(10L, user.getId());
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).memberProgress()).singleElement().satisfies(p -> {
+            assertThat(p.current()).isEqualTo(7);
+            assertThat(p.cleared()).isTrue();
+        });
+        verify(statsService).attendanceDayCounts(anyList(), any(LocalDateTime.class), any(LocalDateTime.class));
     }
 
     private StudyRoomChallenge challenge(StudyRoomChallengeType type, StudyRoomChallengeMetric metric,

--- a/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeServiceTest.java
@@ -1,0 +1,136 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.ChallengeResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
+import com.aisip.OnO.backend.studyroom.entity.*;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomChallengeRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@ExtendWith(MockitoExtension.class)
+class StudyRoomChallengeServiceTest {
+
+    @Mock
+    private StudyRoomAccessService accessService;
+
+    @Mock
+    private StudyRoomChallengeRepository challengeRepository;
+
+    @Mock
+    private StudyRoomMemberRepository memberRepository;
+
+    @Mock
+    private StudyRoomStatsService statsService;
+
+    private StudyRoomChallengeService challengeService;
+
+    @BeforeEach
+    void setUp() {
+        challengeService = new StudyRoomChallengeService(accessService, challengeRepository, memberRepository, statsService);
+    }
+
+    @Test
+    void weeklyPeriodChallengeUsesCurrentPeriodRangeAndDoesNotCompleteEarly() {
+        LocalDateTime startAt = LocalDateTime.now().minusDays(10).truncatedTo(ChronoUnit.SECONDS);
+        LocalDateTime endAt = startAt.plusDays(21);
+        User user = user(1L, "멤버");
+        StudyRoomMember member = StudyRoomMember.create(user, StudyRoomMemberRole.HOST);
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.INDIVIDUAL,
+                StudyRoomChallengeMetric.PRACTICE_COUNT,
+                StudyRoomChallengePeriod.WEEKLY,
+                3,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L)).willReturn(List.of(member));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any())).willReturn(Map.of(user.getId(), 0));
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(user.getId(), new StudyRoomStats(0, 3, 0)));
+
+        List<ChallengeResponse> responses = challengeService.getChallenges(10L, user.getId());
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).status()).isEqualTo("in_progress");
+        assertThat(responses.get(0).memberProgress()).singleElement().satisfies(progress -> {
+            assertThat(progress.current()).isEqualTo(3);
+            assertThat(progress.cleared()).isTrue();
+        });
+        ArgumentCaptor<LocalDateTime> rangeStart = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> rangeEnd = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(statsService).getStats(anyList(), rangeStart.capture(), rangeEnd.capture(), anyMap());
+        assertThat(rangeStart.getValue()).isEqualTo(startAt.plusWeeks(1));
+        assertThat(rangeEnd.getValue()).isEqualTo(startAt.plusWeeks(2));
+    }
+
+    @Test
+    void nonPeriodGroupChallengeCompletesWhenGroupCurrentReachesTarget() {
+        LocalDateTime startAt = LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.SECONDS);
+        LocalDateTime endAt = LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.SECONDS);
+        User first = user(1L, "첫번째");
+        User second = user(2L, "두번째");
+        StudyRoomChallenge challenge = challenge(
+                StudyRoomChallengeType.GROUP,
+                StudyRoomChallengeMetric.PRACTICE_COUNT,
+                null,
+                5,
+                startAt,
+                endAt
+        );
+
+        given(memberRepository.findAllWithUserByRoomId(10L))
+                .willReturn(List.of(StudyRoomMember.create(first, StudyRoomMemberRole.HOST),
+                        StudyRoomMember.create(second, StudyRoomMemberRole.MEMBER)));
+        given(challengeRepository.findActiveByRoomId(eq(10L), eq(StudyRoomChallengeStatus.IN_PROGRESS), any(LocalDateTime.class)))
+                .willReturn(List.of(challenge));
+        given(statsService.currentStreaks(anyList(), any(), any())).willReturn(Map.of(first.getId(), 0, second.getId(), 0));
+        given(statsService.getStats(anyList(), any(LocalDateTime.class), any(LocalDateTime.class), anyMap()))
+                .willReturn(Map.of(
+                        first.getId(), new StudyRoomStats(0, 2, 0),
+                        second.getId(), new StudyRoomStats(0, 3, 0)
+                ));
+
+        ChallengeResponse response = challengeService.getChallenges(10L, first.getId()).get(0);
+
+        assertThat(response.status()).isEqualTo("completed");
+        assertThat(response.groupCurrent()).isEqualTo(5);
+    }
+
+    private StudyRoomChallenge challenge(StudyRoomChallengeType type, StudyRoomChallengeMetric metric,
+                                         StudyRoomChallengePeriod period, int targetValue,
+                                         LocalDateTime startAt, LocalDateTime endAt) {
+        StudyRoom room = StudyRoom.create("테스트방", 1L);
+        setField(room, "id", 10L);
+        StudyRoomChallenge challenge = StudyRoomChallenge.create(room, "테스트 챌린지", type, metric, period,
+                targetValue, startAt, endAt);
+        setField(challenge, "id", 100L);
+        return challenge;
+    }
+
+    private User user(Long id, String name) {
+        User user = RandomUserGenerator.createRandomUser("GOOGLE", name, "study-room-service-test");
+        setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedServiceUnitTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedServiceUnitTest.java
@@ -1,0 +1,128 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.emoji.CustomEmojiValidator;
+import com.aisip.OnO.backend.studyroom.entity.*;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomFeedReactionRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomFeedRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@ExtendWith(MockitoExtension.class)
+class StudyRoomFeedServiceUnitTest {
+
+    @Mock
+    private StudyRoomAccessService accessService;
+
+    @Mock
+    private StudyRoomMemberRepository memberRepository;
+
+    @Mock
+    private StudyRoomFeedRepository feedRepository;
+
+    @Mock
+    private StudyRoomFeedReactionRepository reactionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StudyRoomReactionService reactionService;
+
+    @Mock
+    private CustomEmojiValidator customEmojiValidator;
+
+    private StudyRoomFeedService feedService;
+
+    private User user;
+    private StudyRoomMember membership;
+    private StudyRoom room;
+
+    @BeforeEach
+    void setUp() {
+        user = RandomUserGenerator.createRandomUser("GOOGLE", "테스트", "feed-unit-test");
+        setField(user, "id", 1L);
+
+        room = StudyRoom.create("테스트방", 1L);
+        setField(room, "id", 10L);
+
+        membership = StudyRoomMember.create(user, StudyRoomMemberRole.MEMBER);
+        membership.updateRoom(room);
+
+        feedService = new StudyRoomFeedService(
+                accessService, memberRepository, feedRepository,
+                reactionRepository, userRepository, new ObjectMapper(),
+                reactionService, customEmojiValidator
+        );
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(memberRepository.findAllWithRoomByUserId(1L)).willReturn(List.of(membership));
+    }
+
+    @Test
+    void problemRegisteredAccumulatesCountOnSameDayFeed() {
+        // 오늘 이미 count=2인 피드가 존재
+        StudyRoomFeed existingFeed = StudyRoomFeed.create(
+                room, user, StudyRoomFeedEventType.PROBLEM_REGISTERED, "{\"count\":2}");
+
+        given(feedRepository.findTopByRoomIdAndUserIdAndEventTypeAndCreatedAtBetweenOrderByCreatedAtDesc(
+                any(), any(), any(StudyRoomFeedEventType.class), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(Optional.of(existingFeed));
+
+        // count=3 추가 → 기존 count(2) + 신규 count(3) = 5
+        feedService.createFeedsForUserRooms(1L, StudyRoomFeedEventType.PROBLEM_REGISTERED, Map.of("count", 3));
+
+        // 새 피드를 저장해서는 안 됨
+        verify(feedRepository, never()).save(any());
+        // 기존 피드의 count가 5로 업데이트되어야 함
+        assertThat(existingFeed.getMetadataJson()).contains("\"count\":5");
+    }
+
+    @Test
+    void problemRegisteredCreatesNewFeedWhenNoSameDayFeedExists() {
+        // 오늘 동일 유형의 피드가 없음
+        given(feedRepository.findTopByRoomIdAndUserIdAndEventTypeAndCreatedAtBetweenOrderByCreatedAtDesc(
+                any(), any(), any(StudyRoomFeedEventType.class), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(Optional.empty());
+        given(feedRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        feedService.createFeedsForUserRooms(1L, StudyRoomFeedEventType.PROBLEM_REGISTERED, Map.of("count", 1));
+
+        // 새 피드가 저장되어야 함
+        verify(feedRepository).save(any(StudyRoomFeed.class));
+    }
+
+    @Test
+    void nonProblemRegisteredEventAlwaysCreatesNewFeed() {
+        given(feedRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        // SESSION_STARTED는 당일 중복 체크 없이 항상 새 피드 생성
+        feedService.createFeedsForUserRooms(1L, StudyRoomFeedEventType.SESSION_STARTED, Map.of());
+
+        // 새 피드가 저장되어야 함
+        verify(feedRepository).save(any(StudyRoomFeed.class));
+        // 당일 기존 피드 조회 쿼리는 호출되면 안 됨
+        verify(feedRepository, never())
+                .findTopByRoomIdAndUserIdAndEventTypeAndCreatedAtBetweenOrderByCreatedAtDesc(
+                        any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.repository.UserRepository;
 import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.aisip.OnO.backend.util.fileupload.exception.FileUploadErrorCase;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @SpringBootTest
@@ -196,8 +198,8 @@ class StudyRoomServiceIntegrationTest {
     void updateThumbnailUploadsAndStoresThumbnailUrl() {
         User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
         StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
-        MockMultipartFile firstThumbnail = new MockMultipartFile("thumbnail", "first.png", "image/png", "first".getBytes());
-        MockMultipartFile secondThumbnail = new MockMultipartFile("thumbnail", "second.png", "image/png", "second".getBytes());
+        MockMultipartFile firstThumbnail = new MockMultipartFile("thumbnail", "first.png", "image/png", pngBytes());
+        MockMultipartFile secondThumbnail = new MockMultipartFile("thumbnail", "second.png", "image/png", pngBytes());
         given(fileUploadService.uploadFileToS3(firstThumbnail)).willReturn("https://cdn.example.com/first.png");
         given(fileUploadService.uploadFileToS3(secondThumbnail)).willReturn("https://cdn.example.com/second.png");
 
@@ -218,12 +220,38 @@ class StudyRoomServiceIntegrationTest {
         StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
         InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
         inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
-        MockMultipartFile thumbnail = new MockMultipartFile("thumbnail", "first.png", "image/png", "first".getBytes());
+        MockMultipartFile thumbnail = new MockMultipartFile("thumbnail", "first.png", "image/png", pngBytes());
 
         assertThatThrownBy(() -> studyRoomService.updateThumbnail(room.roomId(), member.getId(), thumbnail))
                 .isInstanceOf(ApplicationException.class)
                 .extracting("errorCase")
                 .isEqualTo(StudyRoomErrorCase.STUDY_ROOM_HOST_ONLY);
+    }
+
+    @Test
+    void updateThumbnailRejectsInvalidMimeAndSignature() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        MockMultipartFile thumbnail = new MockMultipartFile("thumbnail", "first.png", "image/png", "not-image".getBytes());
+
+        assertThatThrownBy(() -> studyRoomService.updateThumbnail(room.roomId(), host.getId(), thumbnail))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCase")
+                .isEqualTo(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        verify(fileUploadService, never()).uploadFileToS3(thumbnail);
+    }
+
+    @Test
+    void updateThumbnailRejectsOversizedImage() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        MockMultipartFile thumbnail = new MockMultipartFile("thumbnail", "large.png", "image/png", largePngBytes());
+
+        assertThatThrownBy(() -> studyRoomService.updateThumbnail(room.roomId(), host.getId(), thumbnail))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCase")
+                .isEqualTo(FileUploadErrorCase.FILE_SIZE_EXCEEDED);
+        verify(fileUploadService, never()).uploadFileToS3(thumbnail);
     }
 
     @Test
@@ -279,5 +307,20 @@ class StudyRoomServiceIntegrationTest {
                     60
             ));
         }
+    }
+
+    private byte[] pngBytes() {
+        return new byte[]{
+                (byte) 0x89, 0x50, 0x4E, 0x47,
+                0x0D, 0x0A, 0x1A, 0x0A,
+                0x00, 0x00, 0x00, 0x0D
+        };
+    }
+
+    private byte[] largePngBytes() {
+        byte[] bytes = new byte[(5 * 1024 * 1024) + 1];
+        byte[] header = pngBytes();
+        System.arraycopy(header, 0, bytes, 0, header.length);
+        return bytes;
     }
 }

--- a/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
@@ -1,7 +1,14 @@
 package com.aisip.OnO.backend.studyroom.service;
 
 import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
+import com.aisip.OnO.backend.problem.entity.Problem;
+import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.problemsolve.entity.AnswerStatus;
+import com.aisip.OnO.backend.problemsolve.entity.ProblemSolve;
+import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveRepository;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.InviteCodeResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomListResponse;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomCreateRequest;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomDetailResponse;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomGoalUpdateRequest;
@@ -21,6 +28,9 @@ import com.aisip.OnO.backend.util.RandomUserGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,6 +58,12 @@ class StudyRoomServiceIntegrationTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private ProblemSolveRepository problemSolveRepository;
 
     @Test
     void createRoomCreatesHostMember() {
@@ -99,13 +115,14 @@ class StudyRoomServiceIntegrationTest {
                 StudyRoomFeedEventType.SESSION_STARTED,
                 "{}"
         ));
-        StudyRoomFeedReaction reaction = feedReactionRepository.save(StudyRoomFeedReaction.create(feed, host, "🔥"));
+        StudyRoomFeedReaction reaction = feedReactionRepository.save(StudyRoomFeedReaction.create(feed, host, "fired_up_sparkle_eyes"));
 
         feedReactionRepository.delete(reaction);
         feedReactionRepository.flush();
-        StudyRoomFeedReaction recreated = feedReactionRepository.saveAndFlush(StudyRoomFeedReaction.create(feed, host, "🔥"));
+        StudyRoomFeedReaction recreated = feedReactionRepository.saveAndFlush(StudyRoomFeedReaction.create(feed, host, "fired_up_sparkle_eyes"));
 
         assertThat(recreated.getId()).isNotNull();
+        assertThat(recreated.getEmoji()).isEqualTo("fired_up_sparkle_eyes");
     }
 
     @Test
@@ -118,6 +135,49 @@ class StudyRoomServiceIntegrationTest {
                 .isInstanceOf(ApplicationException.class)
                 .extracting("errorCase")
                 .isEqualTo(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
+    }
+
+    @Test
+    void getMyRoomsIncludesTodayPracticeSummary() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        User member = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "멤버", "member"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
+        inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+        createPractice(host.getId(), 2);
+        createPractice(member.getId(), 3);
+
+        List<StudyRoomListResponse> rooms = studyRoomService.getMyRooms(host.getId());
+
+        StudyRoomListResponse response = rooms.stream()
+                .filter(item -> item.roomId().equals(room.roomId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(response.memberCount()).isEqualTo(2);
+        assertThat(response.todayPracticeMemberCount()).isEqualTo(2);
+        assertThat(response.todayPracticeCount()).isEqualTo(5);
+    }
+
+    @Test
+    void getRoomIncludesMemberTodayPracticeCount() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        User member = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "멤버", "member"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
+        inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+        createPractice(host.getId(), 2);
+        createPractice(member.getId(), 0);
+
+        StudyRoomDetailResponse response = studyRoomService.getRoom(room.roomId(), host.getId());
+
+        assertThat(response.members()).anySatisfy(item -> {
+            assertThat(item.userId()).isEqualTo(host.getId());
+            assertThat(item.todayPracticeCount()).isEqualTo(2);
+        });
+        assertThat(response.members()).anySatisfy(item -> {
+            assertThat(item.userId()).isEqualTo(member.getId());
+            assertThat(item.todayPracticeCount()).isZero();
+        });
     }
 
     @Test
@@ -155,5 +215,23 @@ class StudyRoomServiceIntegrationTest {
                 .isEqualTo(20);
         assertThat(studyRoomService.updateGoal(room.roomId(), host.getId(), new StudyRoomGoalUpdateRequest(0)).weeklyGoal())
                 .isNull();
+    }
+
+    private void createPractice(Long userId, int count) {
+        Problem problem = problemRepository.save(Problem.from(
+                new ProblemRegisterDto(null, "memo", "reference", null, LocalDateTime.now()),
+                userId
+        ));
+        for (int i = 0; i < count; i++) {
+            problemSolveRepository.save(ProblemSolve.create(
+                    problem,
+                    userId,
+                    LocalDateTime.now(),
+                    AnswerStatus.CORRECT,
+                    null,
+                    null,
+                    60
+            ));
+        }
     }
 }

--- a/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
@@ -1,0 +1,159 @@
+package com.aisip.OnO.backend.studyroom.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.InviteCodeResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomCreateRequest;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomDetailResponse;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomGoalUpdateRequest;
+import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.StudyRoomJoinRequest;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeed;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedEventType;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomFeedReaction;
+import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
+import com.aisip.OnO.backend.studyroom.exception.StudyRoomErrorCase;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomFeedReactionRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomFeedRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
+import com.aisip.OnO.backend.user.entity.User;
+import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.RandomUserGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class StudyRoomServiceIntegrationTest {
+
+    @Autowired
+    private StudyRoomService studyRoomService;
+
+    @Autowired
+    private StudyRoomInviteService inviteService;
+
+    @Autowired
+    private StudyRoomMemberRepository memberRepository;
+
+    @Autowired
+    private StudyRoomRepository roomRepository;
+
+    @Autowired
+    private StudyRoomFeedRepository feedRepository;
+
+    @Autowired
+    private StudyRoomFeedReactionRepository feedReactionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void createRoomCreatesHostMember() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+
+        StudyRoomDetailResponse response = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+
+        assertThat(response.name()).isEqualTo("수능 준비방");
+        assertThat(response.hostUserId()).isEqualTo(host.getId());
+        assertThat(response.memberCount()).isEqualTo(1);
+        assertThat(memberRepository.existsByRoomIdAndUserId(response.roomId(), host.getId())).isTrue();
+    }
+
+    @Test
+    void joinWithInviteCodeAddsMember() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        User member = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "멤버", "member"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
+
+        StudyRoomDetailResponse joined = inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+
+        assertThat(joined.memberCount()).isEqualTo(2);
+        assertThat(memberRepository.existsByRoomIdAndUserId(room.roomId(), member.getId())).isTrue();
+    }
+
+    @Test
+    void memberCanRejoinAfterLeavingRoom() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        User member = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "멤버", "member"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
+        inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+
+        studyRoomService.leaveRoom(room.roomId(), member.getId());
+        StudyRoomDetailResponse rejoined = inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+
+        assertThat(rejoined.memberCount()).isEqualTo(2);
+        assertThat(memberRepository.existsByRoomIdAndUserId(room.roomId(), member.getId())).isTrue();
+    }
+
+    @Test
+    void feedReactionCanBeRecreatedAfterDelete() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        StudyRoomFeed feed = feedRepository.save(StudyRoomFeed.create(
+                roomRepository.findById(room.roomId()).orElseThrow(),
+                host,
+                StudyRoomFeedEventType.SESSION_STARTED,
+                "{}"
+        ));
+        StudyRoomFeedReaction reaction = feedReactionRepository.save(StudyRoomFeedReaction.create(feed, host, "🔥"));
+
+        feedReactionRepository.delete(reaction);
+        feedReactionRepository.flush();
+        StudyRoomFeedReaction recreated = feedReactionRepository.saveAndFlush(StudyRoomFeedReaction.create(feed, host, "🔥"));
+
+        assertThat(recreated.getId()).isNotNull();
+    }
+
+    @Test
+    void nonMemberCannotReadRoom() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        User outsider = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "외부", "outsider"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+
+        assertThatThrownBy(() -> studyRoomService.getRoom(room.roomId(), outsider.getId()))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCase")
+                .isEqualTo(StudyRoomErrorCase.STUDY_ROOM_FORBIDDEN);
+    }
+
+    @Test
+    void hostLeaveTransfersHostToNextMember() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        User member = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "멤버", "member"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
+        inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+
+        studyRoomService.leaveRoom(room.roomId(), host.getId());
+
+        assertThat(memberRepository.existsByRoomIdAndUserId(room.roomId(), host.getId())).isFalse();
+        assertThat(memberRepository.findByRoomIdAndUserId(room.roomId(), member.getId()).orElseThrow().getRole())
+                .isEqualTo(StudyRoomMemberRole.HOST);
+        assertThat(roomRepository.findById(room.roomId()).orElseThrow().getHostUserId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    void hostLeaveDeletesRoomWhenNoOtherMemberExists() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+
+        studyRoomService.leaveRoom(room.roomId(), host.getId());
+
+        assertThat(roomRepository.findById(room.roomId())).isEmpty();
+    }
+
+    @Test
+    void updateGoalCanSetAndClearWeeklyGoal() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+
+        assertThat(studyRoomService.updateGoal(room.roomId(), host.getId(), new StudyRoomGoalUpdateRequest(20)).weeklyGoal())
+                .isEqualTo(20);
+        assertThat(studyRoomService.updateGoal(room.roomId(), host.getId(), new StudyRoomGoalUpdateRequest(0)).weeklyGoal())
+                .isNull();
+    }
+}

--- a/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/studyroom/service/StudyRoomServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.studyroom.service;
 
 import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
 import com.aisip.OnO.backend.problem.entity.Problem;
 import com.aisip.OnO.backend.problem.repository.ProblemRepository;
@@ -25,15 +26,20 @@ import com.aisip.OnO.backend.studyroom.repository.StudyRoomMemberRepository;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.repository.UserRepository;
 import com.aisip.OnO.backend.util.RandomUserGenerator;
+import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 class StudyRoomServiceIntegrationTest {
@@ -64,6 +70,12 @@ class StudyRoomServiceIntegrationTest {
 
     @Autowired
     private ProblemSolveRepository problemSolveRepository;
+
+    @MockBean
+    private FileUploadService fileUploadService;
+
+    @MockBean
+    private S3DeleteProducer s3DeleteProducer;
 
     @Test
     void createRoomCreatesHostMember() {
@@ -178,6 +190,40 @@ class StudyRoomServiceIntegrationTest {
             assertThat(item.userId()).isEqualTo(member.getId());
             assertThat(item.todayPracticeCount()).isZero();
         });
+    }
+
+    @Test
+    void updateThumbnailUploadsAndStoresThumbnailUrl() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        MockMultipartFile firstThumbnail = new MockMultipartFile("thumbnail", "first.png", "image/png", "first".getBytes());
+        MockMultipartFile secondThumbnail = new MockMultipartFile("thumbnail", "second.png", "image/png", "second".getBytes());
+        given(fileUploadService.uploadFileToS3(firstThumbnail)).willReturn("https://cdn.example.com/first.png");
+        given(fileUploadService.uploadFileToS3(secondThumbnail)).willReturn("https://cdn.example.com/second.png");
+
+        assertThat(studyRoomService.updateThumbnail(room.roomId(), host.getId(), firstThumbnail).thumbnailUrl())
+                .isEqualTo("https://cdn.example.com/first.png");
+        assertThat(studyRoomService.updateThumbnail(room.roomId(), host.getId(), secondThumbnail).thumbnailUrl())
+                .isEqualTo("https://cdn.example.com/second.png");
+
+        assertThat(roomRepository.findById(room.roomId()).orElseThrow().getThumbnailUrl())
+                .isEqualTo("https://cdn.example.com/second.png");
+        verify(s3DeleteProducer).sendDeleteMessage("https://cdn.example.com/first.png", room.roomId());
+    }
+
+    @Test
+    void nonHostCannotUpdateThumbnail() {
+        User host = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "방장", "host"));
+        User member = userRepository.save(RandomUserGenerator.createRandomUser("GOOGLE", "멤버", "member"));
+        StudyRoomDetailResponse room = studyRoomService.createRoom(new StudyRoomCreateRequest("수능 준비방"), host.getId());
+        InviteCodeResponse invite = inviteService.issueInviteCode(room.roomId(), host.getId());
+        inviteService.join(new StudyRoomJoinRequest(invite.code()), member.getId());
+        MockMultipartFile thumbnail = new MockMultipartFile("thumbnail", "first.png", "image/png", "first".getBytes());
+
+        assertThatThrownBy(() -> studyRoomService.updateThumbnail(room.roomId(), member.getId(), thumbnail))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCase")
+                .isEqualTo(StudyRoomErrorCase.STUDY_ROOM_HOST_ONLY);
     }
 
     @Test

--- a/src/test/java/com/aisip/OnO/backend/user/controller/UserControllerTest.java
+++ b/src/test/java/com/aisip/OnO/backend/user/controller/UserControllerTest.java
@@ -50,6 +50,7 @@ class UserControllerTest {
                 1L,  // userId
                 "testUser",  // name
                 "test@example.com",  // email
+                null,
                 1L,  // level
                 0L,  // point
                 1L,

--- a/src/test/java/com/aisip/OnO/backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/user/service/UserServiceTest.java
@@ -4,12 +4,15 @@ import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.folder.service.FolderService;
 import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
 import com.aisip.OnO.backend.problem.service.ProblemService;
+import com.aisip.OnO.backend.config.rabbitmq.producer.S3DeleteProducer;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentRepository;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentReactionRepository;
 import com.aisip.OnO.backend.user.dto.UserRegisterDto;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.entity.User;
 import com.aisip.OnO.backend.user.exception.UserErrorCase;
 import com.aisip.OnO.backend.user.repository.UserRepository;
+import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import com.aisip.OnO.backend.util.webhook.DiscordWebhookNotificationService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -43,6 +47,12 @@ class UserServiceTest {
     private PracticeNoteService practiceNoteService;
     @Mock
     private StudyRoomSharedProblemCommentRepository sharedProblemCommentRepository;
+    @Mock
+    private StudyRoomSharedProblemCommentReactionRepository sharedProblemCommentReactionRepository;
+    @Mock
+    private FileUploadService fileUploadService;
+    @Mock
+    private S3DeleteProducer s3DeleteProducer;
     @Mock
     private DiscordWebhookNotificationService discordWebhookNotificationService;
 
@@ -250,6 +260,8 @@ class UserServiceTest {
 
         // Then
         assertThat(user.getIdentifier()).startsWith("deleted:" + userId + ":");
+        verify(sharedProblemCommentReactionRepository, times(1)).deleteByCommentAuthorId(userId);
+        verify(sharedProblemCommentReactionRepository, times(1)).deleteByUserId(userId);
         verify(sharedProblemCommentRepository, times(1)).deleteByAuthorId(userId);
         verify(practiceNoteService, times(1)).deleteAllPracticesByUser(userId);
         verify(problemService, times(1)).deleteAllUserProblems(userId);
@@ -257,5 +269,52 @@ class UserServiceTest {
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, times(1)).deleteById(userId);
         verify(userRepository, times(2)).flush();
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드")
+    void updateProfileImage() {
+        // Given
+        Long userId = 1L;
+        User user = User.from(userRegisterDto);
+        MockMultipartFile profileImage = pngFile();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(fileUploadService.uploadFileToS3(any())).thenReturn("https://cdn.example.com/profile.png");
+
+        // When
+        UserResponseDto response = userService.updateProfileImage(userId, profileImage);
+
+        // Then
+        assertThat(response.profileImageUrl()).isEqualTo("https://cdn.example.com/profile.png");
+        assertThat(user.getProfileImageUrl()).isEqualTo("https://cdn.example.com/profile.png");
+        verify(fileUploadService, times(1)).uploadFileToS3(profileImage);
+        verify(s3DeleteProducer, never()).sendDeleteMessage(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제")
+    void deleteProfileImage() {
+        // Given
+        Long userId = 1L;
+        User user = User.from(userRegisterDto);
+        user.updateProfileImageUrl("https://cdn.example.com/old-profile.png");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // When
+        UserResponseDto response = userService.deleteProfileImage(userId);
+
+        // Then
+        assertThat(response.profileImageUrl()).isNull();
+        assertThat(user.getProfileImageUrl()).isNull();
+        verify(s3DeleteProducer, times(1)).sendDeleteMessage("https://cdn.example.com/old-profile.png", userId);
+    }
+
+    private MockMultipartFile pngFile() {
+        byte[] content = new byte[] {
+                (byte) 0x89, 0x50, 0x4E, 0x47,
+                0x0D, 0x0A, 0x1A, 0x0A,
+                0x00, 0x00, 0x00, 0x00
+        };
+        return new MockMultipartFile("profileImage", "profile.png", "image/png", content);
     }
 }

--- a/src/test/java/com/aisip/OnO/backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.folder.service.FolderService;
 import com.aisip.OnO.backend.practicenote.service.PracticeNoteService;
 import com.aisip.OnO.backend.problem.service.ProblemService;
+import com.aisip.OnO.backend.studyroom.repository.StudyRoomSharedProblemCommentRepository;
 import com.aisip.OnO.backend.user.dto.UserRegisterDto;
 import com.aisip.OnO.backend.user.dto.UserResponseDto;
 import com.aisip.OnO.backend.user.entity.User;
@@ -40,6 +41,8 @@ class UserServiceTest {
     private ProblemService problemService;
     @Mock
     private PracticeNoteService practiceNoteService;
+    @Mock
+    private StudyRoomSharedProblemCommentRepository sharedProblemCommentRepository;
     @Mock
     private DiscordWebhookNotificationService discordWebhookNotificationService;
 
@@ -122,8 +125,8 @@ class UserServiceTest {
         assertThat(response.email()).contains("guest");
 
         verify(userRepository, times(1)).save(any(User.class));
-        verify(folderService, times(1)).initializeDefaultFoldersIfAbsent(any(Long.class));
-        verify(practiceNoteService, times(1)).registerDefaultPractice(any(Long.class));
+        verify(folderService, times(1)).initializeDefaultFoldersIfAbsent(any());
+        verify(practiceNoteService, times(1)).registerDefaultPractice(any());
     }
 
     @Test
@@ -145,8 +148,8 @@ class UserServiceTest {
 
         // save()가 반드시 한 번 호출되어야 함
         verify(userRepository, times(1)).save(any(User.class));
-        verify(folderService, times(1)).initializeDefaultFoldersIfAbsent(any(Long.class));
-        verify(practiceNoteService, times(1)).registerDefaultPractice(any(Long.class));
+        verify(folderService, times(1)).initializeDefaultFoldersIfAbsent(any());
+        verify(practiceNoteService, times(1)).registerDefaultPractice(any());
     }
 
     @Test
@@ -247,6 +250,7 @@ class UserServiceTest {
 
         // Then
         assertThat(user.getIdentifier()).startsWith("deleted:" + userId + ":");
+        verify(sharedProblemCommentRepository, times(1)).deleteByAuthorId(userId);
         verify(practiceNoteService, times(1)).deleteAllPracticesByUser(userId);
         verify(problemService, times(1)).deleteAllUserProblems(userId);
         verify(folderService, times(1)).deleteAllUserFolders(userId);


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #219

## 📝 작업 내용

- 스터디룸 도메인, 멤버, 초대 코드, 피드, 학습 세션, 공유 문제, 댓글, 챌린지, 주간 리포트 API를 추가했습니다.
- 학습 기록/문제 등록/풀이 완료 흐름과 스터디룸 활동 피드 및 통계를 연동했습니다.
- 커스텀 이모지 공통 검증, 학습 캘린더 mood, 복습노트 완료 moodEmojiKey 응답/저장을 추가했습니다.
- 스터디룸 썸네일 업로드, 공유 문제 댓글/반응, 중복 공유 방지, 주기형/임의 주기 챌린지 집계, FCM 알림 스케줄링을 보강했습니다.
- Flyway migration V6~V12로 신규 테이블과 컬럼을 추가하고, 스터디룸 API 통합 테스트와 핵심 서비스 테스트를 추가했습니다.

## 👤 사용자 영향

- 사용자는 스터디룸을 생성하고 초대 코드로 참여할 수 있으며, 멤버 활동 피드/통계/챌린지/공유 문제/댓글/주간 리포트를 사용할 수 있습니다.
- 기존 학습 캘린더와 복습노트 응답에 감정 이모지 관련 필드가 추가됩니다.
- 스터디룸 챌린지와 공유 문제 활동에 대해 FCM 알림이 발송될 수 있습니다.

## 🔌 API 호환성

- [ ] 요청/응답 DTO 변경 없음
- [ ] 기존 Flutter 앱 버전과 호환 확인
- [x] breaking change 있음

신규 API와 신규 응답 필드가 추가됩니다. 기존 필드 삭제는 없지만 Flutter 앱에서 신규 스터디룸 계약에 맞춘 연동이 필요합니다.

## 🗄️ DB migration

- [ ] 없음
- [x] 있음: migration 파일과 기존 데이터 호환성 확인

- `V6__add_study_room_schema.sql` ~ `V12__add_challenge_period_days.sql` 추가
- 기존 테이블에는 nullable 컬럼 위주로 추가되어 기존 데이터 보존을 전제로 합니다.

## 🔐 인증/권한

- [ ] 영향 없음
- [x] 사용자별 데이터 소유권 검증 확인
- [x] 관리자/특수 권한 영향 확인

- 스터디룸 멤버 여부, 방장 권한, 공유 문제 접근 권한, 댓글/반응 작성자 권한을 서비스 레벨에서 검증합니다.

## ✅ 검증 결과

- 실패: `./gradlew test`
  - `compileTestJava` 단계에서 실패했습니다.
  - `ChallengeCreateRequest`, `StudyRoomChallenge.create`, `StudyRoomChallengeService` 생성자 시그니처가 변경되었지만 일부 테스트 코드가 아직 새 인자 구조를 반영하지 못했습니다.
  - 대표 실패 파일: `StudyRoomChallengeApiIntegrationTest`, `StudyRoomApiIntegrationTest`, `StudyRoomChallengeServiceTest`

## 🚀 배포 리스크

- 신규 Flyway migration이 다수 포함되어 배포 전 staging DB에서 migration 적용 확인이 필요합니다.
- 스터디룸 통계/피드 조회는 방 상세 진입 시 호출량이 커질 수 있어 운영 데이터 규모에서 쿼리 성능 확인이 필요합니다.
- FCM/Quartz 알림은 중복 발송, 예약 취소, 서버 재시작 후 스케줄 복구 여부를 staging에서 확인해야 합니다.
- 현재 테스트 컴파일 실패 상태이므로 merge 전 테스트 코드 보정 후 전체 테스트 재실행이 필요합니다.

## ↩️ 롤백/대응 방법

- 애플리케이션 배포 문제는 이전 백엔드 버전으로 롤백합니다.
- DB migration 적용 후 롤백은 자동 되돌림이 없으므로, 운영 배포 전 DB 백업과 신규 테이블/nullable 컬럼 기준의 수동 복구 SQL을 준비해야 합니다.
- FCM 알림 문제가 발생하면 알림 스케줄러/발송 경로를 비활성화하거나 관련 feature 사용을 중단한 뒤 재배포합니다.

### 스크린샷 (선택)

- 없음