### PR TITLE
[Feat] 3.6.1 — S3 Presigned URL, 스터디룸 챌린지 알림, 폴더·챌린지 개선 및 다수 버그 수정

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/common/config/JpaBatchConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/common/config/JpaBatchConfig.java
@@ -1,0 +1,21 @@
+package com.aisip.OnO.backend.common.config;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+public class JpaBatchConfig {
+
+    @Bean
+    public HibernatePropertiesCustomizer hibernateBatchCustomizer() {
+        return hibernateProperties -> hibernateProperties.putAll(Map.of(
+                AvailableSettings.STATEMENT_BATCH_SIZE, "50",
+                AvailableSettings.ORDER_INSERTS, "true",
+                AvailableSettings.ORDER_UPDATES, "true"
+        ));
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/common/config/SentryConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/common/config/SentryConfig.java
@@ -1,0 +1,23 @@
+package com.aisip.OnO.backend.common.config;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import io.sentry.SentryOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SentryConfig {
+
+    @Bean
+    public SentryOptions.BeforeSendCallback sentryBeforeSendCallback() {
+        return (event, hint) -> {
+            Throwable throwable = event.getThrowable();
+            if (throwable instanceof ApplicationException appEx) {
+                if (appEx.getErrorCase().getHttpStatusCode() < 500) {
+                    return null;
+                }
+            }
+            return event;
+        };
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/RabbitMQConfig.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/RabbitMQConfig.java
@@ -34,10 +34,14 @@ public class RabbitMQConfig {
     public static final String FCM_NOTIFICATION_QUEUE = "fcm.notification.queue";
     public static final String FCM_NOTIFICATION_DLQ = "fcm.notification.dlq";
 
+    public static final String DISCORD_WEBHOOK_QUEUE = "discord.webhook.queue";
+    public static final String DISCORD_WEBHOOK_DLQ = "discord.webhook.dlq";
+
     // ==================== Routing Key 정의 ====================
     public static final String S3_DELETE_ROUTING_KEY = "s3.delete";
     public static final String GPT_ANALYSIS_ROUTING_KEY = "gpt.analysis";
     public static final String FCM_NOTIFICATION_ROUTING_KEY = "fcm.notification";
+    public static final String DISCORD_WEBHOOK_ROUTING_KEY = "discord.webhook";
 
     /**
      * JSON 메시지 컨버터 (객체를 JSON으로 직렬화/역직렬화)
@@ -201,5 +205,34 @@ public class RabbitMQConfig {
                 .bind(fcmNotificationQueue())
                 .to(notificationExchange())
                 .with(FCM_NOTIFICATION_ROUTING_KEY);
+    }
+
+    // ==================== Discord Webhook Queue ====================
+
+    /**
+     * Discord Webhook Queue
+     * - DLQ 설정 포함
+     * - TTL: 5분 (300,000ms)
+     */
+    @Bean
+    public Queue discordWebhookQueue() {
+        return QueueBuilder.durable(DISCORD_WEBHOOK_QUEUE)
+                .withArgument("x-dead-letter-exchange", "")
+                .withArgument("x-dead-letter-routing-key", DISCORD_WEBHOOK_DLQ)
+                .withArgument("x-message-ttl", 300000)
+                .build();
+    }
+
+    @Bean
+    public Queue discordWebhookDLQ() {
+        return QueueBuilder.durable(DISCORD_WEBHOOK_DLQ).build();
+    }
+
+    @Bean
+    public Binding discordWebhookBinding() {
+        return BindingBuilder
+                .bind(discordWebhookQueue())
+                .to(notificationExchange())
+                .with(DISCORD_WEBHOOK_ROUTING_KEY);
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/DiscordWebhookConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/DiscordWebhookConsumer.java
@@ -1,0 +1,52 @@
+package com.aisip.OnO.backend.config.rabbitmq.consumer;
+
+import com.aisip.OnO.backend.config.rabbitmq.RabbitMQConfig;
+import com.aisip.OnO.backend.config.rabbitmq.message.DiscordWebhookMessage;
+import com.aisip.OnO.backend.util.webhook.DiscordWebhookPayload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class DiscordWebhookConsumer {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${discord.webhook-url}")
+    private String webhookUrl;
+
+    public DiscordWebhookConsumer() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3_000);
+        factory.setReadTimeout(5_000);
+        this.restTemplate = new RestTemplate(factory);
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.DISCORD_WEBHOOK_QUEUE, concurrency = "1-3")
+    public void handleWebhookMessage(DiscordWebhookMessage message) {
+        DiscordWebhookPayload payload = message.getPayload();
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            restTemplate.postForEntity(webhookUrl, new HttpEntity<>(payload, headers), String.class);
+            log.info("Discord webhook 전송 완료: {}", payload.embeds().get(0).title());
+        } catch (Exception e) {
+            log.error("Discord webhook 전송 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("Discord webhook 전송 실패", e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.DISCORD_WEBHOOK_DLQ)
+    public void handleWebhookDLQ(DiscordWebhookMessage message) {
+        DiscordWebhookPayload payload = message.getPayload();
+        String title = payload.embeds().isEmpty() ? "(제목 없음)" : payload.embeds().get(0).title();
+        log.error("Discord webhook DLQ — 최종 전송 실패, 수동 확인 필요. title={}", title);
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
@@ -49,7 +49,8 @@ public class ProblemAnalysisConsumer {
             // 상태는 Service에서 FAILED로 업데이트됨. 재큐잉 없이 종료(ACK)
             return;
         } catch (ApplicationException e) {
-            if (e.getErrorCase() == ProblemErrorCase.PROBLEM_NOT_FOUND) {
+            if (e.getErrorCase() == ProblemErrorCase.PROBLEM_NOT_FOUND
+                    || e.getErrorCase() == ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND) {
                 log.warn("RabbitMQ message skipped - queue: {}, operation: {}, outcome: {}, problemId: {}, messageRetryCount: {}",
                         RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", "resource_not_found",
                         message.getProblemId(), message.getRetryCount());

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
@@ -30,7 +30,7 @@ public class ProblemAnalysisConsumer {
      * - concurrency: 동시 처리 개수 (1-3개, OpenAI Rate Limit 고려)
      * - 예외 발생 시 자동으로 재시도 → 실패하면 DLQ로 이동
      */
-    @RabbitListener(queues = RabbitMQConfig.GPT_ANALYSIS_QUEUE, concurrency = "1-3")
+    @RabbitListener(queues = RabbitMQConfig.GPT_ANALYSIS_QUEUE, concurrency = "1-2")
     public void handleAnalysisMessage(ProblemAnalysisMessage message) {
         log.info("RabbitMQ message received - queue: {}, operation: {}, problemId: {}, messageRetryCount: {}",
                 RabbitMQConfig.GPT_ANALYSIS_QUEUE, "problem_analysis", message.getProblemId(), message.getRetryCount());

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/consumer/ProblemAnalysisConsumer.java
@@ -4,6 +4,7 @@ import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.config.rabbitmq.RabbitMQConfig;
 import com.aisip.OnO.backend.config.rabbitmq.message.ProblemAnalysisMessage;
 import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
+import com.aisip.OnO.backend.problem.service.ProblemAnalysisFailureService;
 import com.aisip.OnO.backend.problem.service.ProblemAnalysisService;
 import com.aisip.OnO.backend.util.ai.NonRetryableAnalysisException;
 import com.aisip.OnO.backend.util.webhook.DiscordWebhookNotificationService;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class ProblemAnalysisConsumer {
 
     private final ProblemAnalysisService analysisService;
+    private final ProblemAnalysisFailureService analysisFailureService;
     private final DiscordWebhookNotificationService discordWebhookNotificationService;
 
     /**
@@ -94,6 +96,14 @@ public class ProblemAnalysisConsumer {
                 message.getProblemId(),
                 message.getRetryCount()
         );
+
+        // DLQ 도달 = 모든 재시도 소진. PROCESSING 고착 방지를 위해 FAILED로 전이
+        try {
+            analysisFailureService.markFailed(message.getProblemId(), "최대 재시도 횟수 초과 또는 큐 만료");
+        } catch (Exception e) {
+            log.error("RabbitMQ DLQ markFailed failed - problemId: {}, error: {}",
+                    message.getProblemId(), e.getMessage());
+        }
 
         try {
             discordWebhookNotificationService.sendErrorNotification(

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/message/DiscordWebhookMessage.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/message/DiscordWebhookMessage.java
@@ -1,0 +1,17 @@
+package com.aisip.OnO.backend.config.rabbitmq.message;
+
+import com.aisip.OnO.backend.util.webhook.DiscordWebhookPayload;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordWebhookMessage implements Serializable {
+
+    private DiscordWebhookPayload payload;
+    private String dedupKey;
+}

--- a/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/DiscordWebhookProducer.java
+++ b/src/main/java/com/aisip/OnO/backend/config/rabbitmq/producer/DiscordWebhookProducer.java
@@ -1,0 +1,30 @@
+package com.aisip.OnO.backend.config.rabbitmq.producer;
+
+import com.aisip.OnO.backend.config.rabbitmq.RabbitMQConfig;
+import com.aisip.OnO.backend.config.rabbitmq.message.DiscordWebhookMessage;
+import com.aisip.OnO.backend.util.webhook.DiscordWebhookPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordWebhookProducer {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void send(DiscordWebhookPayload payload, String dedupKey) {
+        try {
+            rabbitTemplate.convertAndSend(
+                    RabbitMQConfig.NOTIFICATION_EXCHANGE,
+                    RabbitMQConfig.DISCORD_WEBHOOK_ROUTING_KEY,
+                    new DiscordWebhookMessage(payload, dedupKey)
+            );
+            log.debug("Discord webhook 메시지 큐 전송: {}", payload.embeds().get(0).title());
+        } catch (Exception e) {
+            log.error("Discord webhook 큐 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/aisip/OnO/backend/folder/dto/FolderResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/dto/FolderResponseDto.java
@@ -1,13 +1,13 @@
 package com.aisip.OnO.backend.folder.dto;
 
 import com.aisip.OnO.backend.folder.entity.Folder;
-import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record FolderResponseDto (
@@ -29,15 +29,29 @@ public record FolderResponseDto (
     LocalDateTime updateAt
 ) {
     public static FolderResponseDto from(@NotNull Folder folder, List<Long> problemIdList) {
+        return from(folder, problemIdList, Map.of());
+    }
+
+    public static FolderResponseDto from(
+            @NotNull Folder folder,
+            List<Long> problemIdList,
+            Map<Long, Long> problemCountsByFolderId
+    ) {
 
         FolderThumbnailResponseDto parentFolder = folder.getParentFolder() != null
-                ? FolderThumbnailResponseDto.from(folder.getParentFolder())
+                ? FolderThumbnailResponseDto.from(
+                        folder.getParentFolder(),
+                        problemCountsByFolderId.getOrDefault(folder.getParentFolder().getId(), 0L)
+                )
                 : null;
 
         List<FolderThumbnailResponseDto> subFolderList = folder.getSubFolderList() != null
                 ? folder.getSubFolderList()
                 .stream()
-                .map(FolderThumbnailResponseDto::from)
+                .map(subFolder -> FolderThumbnailResponseDto.from(
+                        subFolder,
+                        problemCountsByFolderId.getOrDefault(subFolder.getId(), 0L)
+                ))
                 .toList()
                 : List.of();
 

--- a/src/main/java/com/aisip/OnO/backend/folder/dto/FolderThumbnailResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/dto/FolderThumbnailResponseDto.java
@@ -8,12 +8,18 @@ import org.jetbrains.annotations.NotNull;
 @Builder(access = AccessLevel.PRIVATE)
 public record FolderThumbnailResponseDto(
         Long folderId,
-        String folderName
+        String folderName,
+        Long problemCount
 ) {
-    public static FolderThumbnailResponseDto from(@NotNull Folder folder) {
+    public static FolderThumbnailResponseDto from(@NotNull Folder folder, Long problemCount) {
         return FolderThumbnailResponseDto.builder()
                 .folderId(folder.getId())
                 .folderName(folder.getName())
+                .problemCount(problemCount)
                 .build();
+    }
+
+    public static FolderThumbnailResponseDto from(@NotNull Folder folder) {
+        return from(folder, 0L);
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/folder/repository/FolderRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/repository/FolderRepository.java
@@ -19,4 +19,12 @@ public interface FolderRepository extends JpaRepository<Folder, Long>, FolderRep
     @Modifying
     @Query("delete from Folder f where f.id in :folderIds")
     void deleteAllByIdIn(@Param("folderIds") Collection<Long> folderIds);
+
+    @Query("""
+            SELECT p.folder.id, COUNT(p.id)
+            FROM Problem p
+            WHERE p.folder.id IN :folderIds
+            GROUP BY p.folder.id
+            """)
+    List<Object[]> countProblemsByFolderIds(@Param("folderIds") Collection<Long> folderIds);
 }

--- a/src/main/java/com/aisip/OnO/backend/folder/repository/FolderRepositoryCustom.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/repository/FolderRepositoryCustom.java
@@ -2,7 +2,9 @@ package com.aisip.OnO.backend.folder.repository;
 
 import com.aisip.OnO.backend.folder.entity.Folder;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface FolderRepositoryCustom {
@@ -16,6 +18,8 @@ public interface FolderRepositoryCustom {
     List<Folder> findAllFoldersWithDetailsByUserId(Long userId);
 
     List<Long> findProblemIdsByFolder(Long folderId);
+
+    Map<Long, List<Long>> findProblemIdsByFolderIds(Collection<Long> folderIds);
 
     /**
      * 커서 기반 하위 폴더 조회

--- a/src/main/java/com/aisip/OnO/backend/folder/repository/FolderRepositoryImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/repository/FolderRepositoryImpl.java
@@ -2,11 +2,15 @@ package com.aisip.OnO.backend.folder.repository;
 
 import com.aisip.OnO.backend.folder.entity.Folder;
 import com.aisip.OnO.backend.folder.entity.QFolder;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.aisip.OnO.backend.folder.entity.QFolder.folder;
 import static com.aisip.OnO.backend.problem.entity.QProblem.problem;
@@ -71,6 +75,23 @@ public class FolderRepositoryImpl implements FolderRepositoryCustom {
                 .where(problem.folder.id.eq(folderId))
                 .orderBy(problem.id.asc())
                 .fetch();
+    }
+
+    @Override
+    public Map<Long, List<Long>> findProblemIdsByFolderIds(Collection<Long> folderIds) {
+        if (folderIds == null || folderIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Tuple> rows = queryFactory
+                .select(problem.folder.id, problem.id)
+                .from(problem)
+                .where(problem.folder.id.in(folderIds))
+                .orderBy(problem.folder.id.asc(), problem.id.asc())
+                .fetch();
+        return rows.stream().collect(Collectors.groupingBy(
+                t -> t.get(problem.folder.id),
+                Collectors.mapping(t -> t.get(problem.id), Collectors.toList())
+        ));
     }
 
     @Override

--- a/src/main/java/com/aisip/OnO/backend/folder/service/FolderService.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/service/FolderService.java
@@ -8,7 +8,6 @@ import com.aisip.OnO.backend.folder.dto.FolderThumbnailResponseDto;
 import com.aisip.OnO.backend.folder.entity.Folder;
 import com.aisip.OnO.backend.folder.exception.FolderErrorCase;
 import com.aisip.OnO.backend.folder.repository.FolderRepository;
-import com.aisip.OnO.backend.problem.dto.ProblemResponseDto;
 import com.aisip.OnO.backend.problem.service.ProblemService;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +54,7 @@ public class FolderService {
         log.info("userId : {} find root folder id: {}", userId, rootFolder.getId());
 
         List<Long> problemIdList = folderRepository.findProblemIdsByFolder(rootFolder.getId());
-        return FolderResponseDto.from(rootFolder, problemIdList);
+        return toFolderResponseDto(rootFolder, problemIdList);
     }
 
     @Transactional(readOnly = true)
@@ -64,7 +63,7 @@ public class FolderService {
                 .orElseThrow(() -> new ApplicationException(FolderErrorCase.FOLDER_NOT_FOUND));
 
         List<Long> problemIdList = folderRepository.findProblemIdsByFolder(folder.getId());
-        return FolderResponseDto.from(folder, problemIdList);
+        return toFolderResponseDto(folder, problemIdList);
     }
 
     @Transactional(readOnly = true)
@@ -72,7 +71,7 @@ public class FolderService {
         Folder folder = findFolderWithDetailsOwnedByUser(folderId, userId);
 
         List<Long> problemIdList = folderRepository.findProblemIdsByFolder(folder.getId());
-        return FolderResponseDto.from(folder, problemIdList);
+        return toFolderResponseDto(folder, problemIdList);
     }
 
     @Transactional(readOnly = true)
@@ -94,7 +93,7 @@ public class FolderService {
 
         return folderList.isEmpty()
                 ? List.of()
-                : folderList.stream().map(FolderThumbnailResponseDto::from).collect(Collectors.toList());
+                : toFolderThumbnailDtos(folderList);
     }
 
     public List<FolderResponseDto> findAllUserFolders(Long userId) {
@@ -105,7 +104,7 @@ public class FolderService {
                 ? List.of()
                 : folders.stream().map(folder -> {
                     List<Long> problemIdList = folderRepository.findProblemIdsByFolder(folder.getId());
-                    return FolderResponseDto.from(folder, problemIdList);
+                    return toFolderResponseDto(folder, problemIdList);
                 }).toList();
     }
 
@@ -217,9 +216,7 @@ public class FolderService {
         List<Folder> content = hasNext ? folders.subList(0, size) : folders;
         Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
 
-        List<FolderThumbnailResponseDto> dtoList = content.stream()
-                .map(FolderThumbnailResponseDto::from)
-                .collect(Collectors.toList());
+        List<FolderThumbnailResponseDto> dtoList = toFolderThumbnailDtos(content);
 
         log.info("folderId: {} find subfolders with cursor: {}, size: {}, hasNext: {}", folderId, cursor, size, hasNext);
         return CursorPageResponse.of(dtoList, nextCursor, hasNext, size);
@@ -253,11 +250,50 @@ public class FolderService {
         List<Folder> content = hasNext ? folders.subList(0, size) : folders;
         Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
 
-        List<FolderThumbnailResponseDto> dtoList = content.stream()
-                .map(FolderThumbnailResponseDto::from)
-                .collect(Collectors.toList());
+        List<FolderThumbnailResponseDto> dtoList = toFolderThumbnailDtos(content);
 
         log.info("userId: {} find all folder thumbnails with cursor: {}, size: {}, hasNext: {}", userId, cursor, size, hasNext);
         return CursorPageResponse.of(dtoList, nextCursor, hasNext, size);
+    }
+
+    private FolderResponseDto toFolderResponseDto(Folder folder, List<Long> problemIdList) {
+        Set<Long> thumbnailFolderIds = new HashSet<>();
+        if (folder.getParentFolder() != null) {
+            thumbnailFolderIds.add(folder.getParentFolder().getId());
+        }
+        if (folder.getSubFolderList() != null) {
+            folder.getSubFolderList().stream()
+                    .map(Folder::getId)
+                    .forEach(thumbnailFolderIds::add);
+        }
+
+        Map<Long, Long> problemCountsByFolderId = findProblemCountsByFolderIds(thumbnailFolderIds);
+        return FolderResponseDto.from(folder, problemIdList, problemCountsByFolderId);
+    }
+
+    private List<FolderThumbnailResponseDto> toFolderThumbnailDtos(List<Folder> folders) {
+        List<Long> folderIds = folders.stream()
+                .map(Folder::getId)
+                .toList();
+        Map<Long, Long> problemCountsByFolderId = findProblemCountsByFolderIds(folderIds);
+
+        return folders.stream()
+                .map(folder -> FolderThumbnailResponseDto.from(
+                        folder,
+                        problemCountsByFolderId.getOrDefault(folder.getId(), 0L)
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, Long> findProblemCountsByFolderIds(Collection<Long> folderIds) {
+        if (folderIds == null || folderIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return folderRepository.countProblemsByFolderIds(folderIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
     }
 }

--- a/src/main/java/com/aisip/OnO/backend/folder/service/FolderService.java
+++ b/src/main/java/com/aisip/OnO/backend/folder/service/FolderService.java
@@ -98,14 +98,27 @@ public class FolderService {
 
     public List<FolderResponseDto> findAllUserFolders(Long userId) {
         List<Folder> folders = folderRepository.findAllFoldersWithDetailsByUserId(userId);
+        if (folders.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> folderIds = folders.stream().map(Folder::getId).toList();
+        Map<Long, List<Long>> problemIdsByFolder = folderRepository.findProblemIdsByFolderIds(folderIds);
+
+        Set<Long> thumbnailFolderIds = new HashSet<>();
+        for (Folder f : folders) {
+            if (f.getParentFolder() != null) thumbnailFolderIds.add(f.getParentFolder().getId());
+            if (f.getSubFolderList() != null) f.getSubFolderList().forEach(sf -> thumbnailFolderIds.add(sf.getId()));
+        }
+        Map<Long, Long> problemCounts = findProblemCountsByFolderIds(thumbnailFolderIds);
 
         log.info("userId : {} find All user folders", userId);
-        return folders.isEmpty()
-                ? List.of()
-                : folders.stream().map(folder -> {
-                    List<Long> problemIdList = folderRepository.findProblemIdsByFolder(folder.getId());
-                    return toFolderResponseDto(folder, problemIdList);
-                }).toList();
+        return folders.stream()
+                .map(folder -> FolderResponseDto.from(
+                        folder,
+                        problemIdsByFolder.getOrDefault(folder.getId(), List.of()),
+                        problemCounts))
+                .toList();
     }
 
     private void createDefaultSubFolder(Folder rootFolder, Long userId) {

--- a/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
@@ -2,6 +2,7 @@ package com.aisip.OnO.backend.problem.controller;
 
 import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.common.response.CursorPageResponse;
+import com.aisip.OnO.backend.problem.dto.AddProblemImageUrlsRequest;
 import com.aisip.OnO.backend.problem.dto.ProblemAnalysisResponseDto;
 import com.aisip.OnO.backend.problem.dto.ReviewDueResponseDto;
 import com.aisip.OnO.backend.problem.dto.ProblemDeleteRequestDto;
@@ -163,6 +164,19 @@ public class ProblemController {
         problemService.analysisProblem(problemId, userId);
 
         return CommonResponse.success("이미지 업로드가 시작되었습니다.");
+    }
+
+    // ✅ 문제 이미지 URL 추가 (Presigned URL 방식)
+    @PostMapping("/{problemId}/imageData/urls")
+    public CommonResponse<Void> addProblemImageDataUrls(
+            @PathVariable("problemId") Long problemId,
+            @RequestBody AddProblemImageUrlsRequest request
+    ) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        problemService.addImageDataUrls(problemId, userId, request);
+        problemService.analysisProblem(problemId, userId);
+
+        return CommonResponse.success(null);
     }
 
     // ✅ 문제 이미지 비동기 업로드

--- a/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/controller/ProblemController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -170,7 +171,7 @@ public class ProblemController {
     @PostMapping("/{problemId}/imageData/urls")
     public CommonResponse<Void> addProblemImageDataUrls(
             @PathVariable("problemId") Long problemId,
-            @RequestBody AddProblemImageUrlsRequest request
+            @Validated @RequestBody AddProblemImageUrlsRequest request
     ) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         problemService.addImageDataUrls(problemId, userId, request);

--- a/src/main/java/com/aisip/OnO/backend/problem/dto/AddProblemImageUrlsRequest.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/dto/AddProblemImageUrlsRequest.java
@@ -1,0 +1,8 @@
+package com.aisip.OnO.backend.problem.dto;
+
+import java.util.List;
+
+public record AddProblemImageUrlsRequest(List<ImageUrlItem> imageDataList) {
+
+    public record ImageUrlItem(String imageUrl, String problemImageType) {}
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/dto/AddProblemImageUrlsRequest.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/dto/AddProblemImageUrlsRequest.java
@@ -1,8 +1,10 @@
 package com.aisip.OnO.backend.problem.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.util.List;
 
-public record AddProblemImageUrlsRequest(List<ImageUrlItem> imageDataList) {
+public record AddProblemImageUrlsRequest(@NotNull List<ImageUrlItem> imageDataList) {
 
     public record ImageUrlItem(String imageUrl, String problemImageType) {}
 }

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisDbService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisDbService.java
@@ -1,0 +1,71 @@
+package com.aisip.OnO.backend.problem.service;
+
+import com.aisip.OnO.backend.common.exception.ApplicationException;
+import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
+import com.aisip.OnO.backend.problem.entity.ProblemAnalysis;
+import com.aisip.OnO.backend.problem.entity.ProblemImageData;
+import com.aisip.OnO.backend.problem.entity.ProblemImageType;
+import com.aisip.OnO.backend.problem.exception.ProblemErrorCase;
+import com.aisip.OnO.backend.problem.repository.ProblemAnalysisRepository;
+import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
+import com.aisip.OnO.backend.problem.repository.ProblemRepository;
+import com.aisip.OnO.backend.util.ai.ProblemAnalysisResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * ProblemAnalysisService의 DB 접근 작업을 분리한 별도 빈.
+ * analyzeProblemSync에서 self-invocation 없이 AOP 프록시를 거쳐 호출되어야 @Transactional이 정상 동작함.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProblemAnalysisDbService {
+
+    private final ProblemRepository problemRepository;
+    private final ProblemImageDataRepository problemImageDataRepository;
+    private final ProblemAnalysisRepository analysisRepository;
+
+    @Transactional(readOnly = true)
+    public AnalysisPreparation fetchAnalysisPreparation(Long problemId) {
+        problemRepository.findById(problemId)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
+
+        List<String> imageUrls = problemImageDataRepository.findAllByProblemId(problemId)
+                .stream()
+                .filter(data -> data.getProblemImageType().equals(ProblemImageType.PROBLEM_IMAGE))
+                .map(ProblemImageData::getImageUrl)
+                .toList();
+
+        ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND));
+
+        return new AnalysisPreparation(imageUrls, analysis.getStatus().equals(AnalysisStatus.COMPLETED));
+    }
+
+    @Transactional
+    public void saveAnalysisSuccess(Long problemId, ProblemAnalysisResult result, String keyPointsJson) {
+        ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND));
+        // 다른 스레드가 먼저 완료한 경우 덮어쓰기 방지
+        if (analysis.getStatus().equals(AnalysisStatus.COMPLETED)) {
+            log.info("Analysis already COMPLETED by another thread, skipping save. problemId: {}", problemId);
+            return;
+        }
+        analysis.updateWithSuccess(
+                result.getSubject(),
+                result.getProblemType(),
+                keyPointsJson,
+                result.getSolution(),
+                result.getCommonMistakes(),
+                result.getStudyTips()
+        );
+        analysisRepository.save(analysis);
+    }
+
+    public record AnalysisPreparation(List<String> imageUrls, boolean alreadyCompleted) {}
+}

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -35,6 +36,7 @@ public class ProblemAnalysisService {
     private final ObjectMapper objectMapper;
     private final ProblemImageDataRepository problemImageDataRepository;
     private final ProblemAnalysisFailureService problemAnalysisFailureService;
+    private final ProblemAnalysisDbService problemAnalysisDbService;
 
     /**
      * 기존 분석 결과 삭제
@@ -127,14 +129,16 @@ public class ProblemAnalysisService {
 
     /**
      * 동기적으로 문제 이미지를 분석합니다 (RabbitMQ Consumer에서 호출)
-     * - 트랜잭션을 OpenAI 호출 전후로 분리해 DB 커넥션 장기 점유를 방지
+     * - NOT_SUPPORTED: 이 메서드 자체는 트랜잭션 없이 실행, DB 작업은 problemAnalysisDbService 빈을 통해 각자 독립 트랜잭션으로 처리
+     * - self-invocation 문제를 피하기 위해 Phase 1/3의 DB 작업을 별도 빈에서 처리
      */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void analyzeProblemSync(Long problemId) {
         log.info("Starting sync analysis for problemId: {}", problemId);
 
         try {
             // Phase 1: 짧은 readOnly 트랜잭션으로 필요한 데이터 조회
-            AnalysisPreparation prep = fetchAnalysisPreparation(problemId);
+            ProblemAnalysisDbService.AnalysisPreparation prep = problemAnalysisDbService.fetchAnalysisPreparation(problemId);
             if (prep.alreadyCompleted()) {
                 log.info("Analysis already completed for problemId: {}", problemId);
                 return;
@@ -151,12 +155,13 @@ public class ProblemAnalysisService {
                 log.error("JSON 변환 실패 for problemId: {}", problemId, jsonException);
                 throw new RuntimeException("JSON 변환 실패", jsonException);
             }
-            saveAnalysisSuccess(problemId, result, keyPointsJson);
+            problemAnalysisDbService.saveAnalysisSuccess(problemId, result, keyPointsJson);
             log.info("Analysis completed successfully for problemId: {}", problemId);
 
         } catch (ApplicationException e) {
-            if (e.getErrorCase() == ProblemErrorCase.PROBLEM_NOT_FOUND) {
-                log.warn("Skipping analysis because problem was deleted or missing. problemId: {}", problemId);
+            if (e.getErrorCase() == ProblemErrorCase.PROBLEM_NOT_FOUND
+                    || e.getErrorCase() == ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND) {
+                log.warn("Skipping analysis because problem or analysis was deleted. problemId: {}", problemId);
                 throw e;
             }
             log.error("Application error during sync analysis for problemId: {}", problemId, e);
@@ -172,40 +177,6 @@ public class ProblemAnalysisService {
             throw e;
         }
     }
-
-    @Transactional(readOnly = true)
-    public AnalysisPreparation fetchAnalysisPreparation(Long problemId) {
-        problemRepository.findById(problemId)
-                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
-
-        List<String> imageUrls = problemImageDataRepository.findAllByProblemId(problemId)
-                .stream()
-                .filter(data -> data.getProblemImageType().equals(ProblemImageType.PROBLEM_IMAGE))
-                .map(ProblemImageData::getImageUrl)
-                .toList();
-
-        ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
-                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND));
-
-        return new AnalysisPreparation(imageUrls, analysis.getStatus().equals(AnalysisStatus.COMPLETED));
-    }
-
-    @Transactional
-    public void saveAnalysisSuccess(Long problemId, ProblemAnalysisResult result, String keyPointsJson) {
-        ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
-                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND));
-        analysis.updateWithSuccess(
-                result.getSubject(),
-                result.getProblemType(),
-                keyPointsJson,
-                result.getSolution(),
-                result.getCommonMistakes(),
-                result.getStudyTips()
-        );
-        analysisRepository.save(analysis);
-    }
-
-    public record AnalysisPreparation(List<String> imageUrls, boolean alreadyCompleted) {}
 
     /**
      * 비동기로 문제 이미지를 분석합니다 (기존 @Async 방식, deprecated)

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemAnalysisService.java
@@ -127,38 +127,23 @@ public class ProblemAnalysisService {
 
     /**
      * 동기적으로 문제 이미지를 분석합니다 (RabbitMQ Consumer에서 호출)
-     * - 동시성 문제 해결: 이미 생성된 PROCESSING 엔티티만 조회하여 업데이트
+     * - 트랜잭션을 OpenAI 호출 전후로 분리해 DB 커넥션 장기 점유를 방지
      */
-    @Transactional
     public void analyzeProblemSync(Long problemId) {
         log.info("Starting sync analysis for problemId: {}", problemId);
 
         try {
-            // 1. Problem 조회
-            Problem problem = problemRepository.findById(problemId)
-                    .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
-
-            // 2. 문제 이미지 url 조회
-            List<String> problemImageUrls = problemImageDataRepository.findAllByProblemId(problemId)
-                    .stream()
-                    .filter(data -> data.getProblemImageType().equals(ProblemImageType.PROBLEM_IMAGE))
-                    .map(ProblemImageData::getImageUrl)
-                    .toList();
-
-            // 3. 기존 분석 조회 (동시성 문제 해결: 새로 생성하지 않고 조회만)
-            ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
-                    .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND));
-
-            // 4. 이미 완료된 경우 스킵
-            if (analysis.getStatus().equals(AnalysisStatus.COMPLETED)) {
+            // Phase 1: 짧은 readOnly 트랜잭션으로 필요한 데이터 조회
+            AnalysisPreparation prep = fetchAnalysisPreparation(problemId);
+            if (prep.alreadyCompleted()) {
                 log.info("Analysis already completed for problemId: {}", problemId);
                 return;
             }
 
-            // 5. OpenAI API 호출 (여러 이미지를 하나의 문제로 분석)
-            ProblemAnalysisResult result = openAIClient.analyzeImages(problemImageUrls);
+            // Phase 2: 트랜잭션 없이 OpenAI 호출 (DB 커넥션 미점유)
+            ProblemAnalysisResult result = openAIClient.analyzeImages(prep.imageUrls());
 
-            // 6. keyPoints를 JSON 문자열로 변환
+            // Phase 3: 결과를 짧은 쓰기 트랜잭션으로 저장
             String keyPointsJson;
             try {
                 keyPointsJson = objectMapper.writeValueAsString(result.getKeyPoints());
@@ -166,27 +151,14 @@ public class ProblemAnalysisService {
                 log.error("JSON 변환 실패 for problemId: {}", problemId, jsonException);
                 throw new RuntimeException("JSON 변환 실패", jsonException);
             }
-
-            // 7. 분석 결과 업데이트 (COMPLETED)
-            analysis.updateWithSuccess(
-                    result.getSubject(),
-                    result.getProblemType(),
-                    keyPointsJson,
-                    result.getSolution(),
-                    result.getCommonMistakes(),
-                    result.getStudyTips()
-            );
-
-            analysisRepository.save(analysis);
+            saveAnalysisSuccess(problemId, result, keyPointsJson);
             log.info("Analysis completed successfully for problemId: {}", problemId);
 
         } catch (ApplicationException e) {
-            // 삭제된 문제는 재시도 가치가 없어 상위 Consumer에서 비재시도 처리한다.
             if (e.getErrorCase() == ProblemErrorCase.PROBLEM_NOT_FOUND) {
                 log.warn("Skipping analysis because problem was deleted or missing. problemId: {}", problemId);
                 throw e;
             }
-
             log.error("Application error during sync analysis for problemId: {}", problemId, e);
             handleAnalysisError(problemId, e);
             throw e;
@@ -197,9 +169,43 @@ public class ProblemAnalysisService {
         } catch (Exception e) {
             log.error("Error during sync analysis for problemId: {}", problemId, e);
             handleAnalysisError(problemId, e);
-            throw e; // RabbitMQ 재시도를 위해 예외 다시 던짐
+            throw e;
         }
     }
+
+    @Transactional(readOnly = true)
+    public AnalysisPreparation fetchAnalysisPreparation(Long problemId) {
+        problemRepository.findById(problemId)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_NOT_FOUND));
+
+        List<String> imageUrls = problemImageDataRepository.findAllByProblemId(problemId)
+                .stream()
+                .filter(data -> data.getProblemImageType().equals(ProblemImageType.PROBLEM_IMAGE))
+                .map(ProblemImageData::getImageUrl)
+                .toList();
+
+        ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND));
+
+        return new AnalysisPreparation(imageUrls, analysis.getStatus().equals(AnalysisStatus.COMPLETED));
+    }
+
+    @Transactional
+    public void saveAnalysisSuccess(Long problemId, ProblemAnalysisResult result, String keyPointsJson) {
+        ProblemAnalysis analysis = analysisRepository.findByProblemId(problemId)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCase.PROBLEM_ANALYSIS_NOT_FOUND));
+        analysis.updateWithSuccess(
+                result.getSubject(),
+                result.getProblemType(),
+                keyPointsJson,
+                result.getSolution(),
+                result.getCommonMistakes(),
+                result.getStudyTips()
+        );
+        analysisRepository.save(analysis);
+    }
+
+    public record AnalysisPreparation(List<String> imageUrls, boolean alreadyCompleted) {}
 
     /**
      * 비동기로 문제 이미지를 분석합니다 (기존 @Async 방식, deprecated)

--- a/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/problem/service/ProblemService.java
@@ -11,6 +11,7 @@ import com.aisip.OnO.backend.problem.entity.AnalysisStatus;
 import com.aisip.OnO.backend.problem.entity.ProblemAnalysis;
 import com.aisip.OnO.backend.problem.entity.ProblemImageType;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
+import com.aisip.OnO.backend.problem.dto.AddProblemImageUrlsRequest;
 import com.aisip.OnO.backend.problem.dto.ProblemImageDataRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterDto;
 import com.aisip.OnO.backend.problem.dto.ProblemRegisterV2BatchDto;
@@ -479,6 +480,22 @@ public class ProblemService {
             }
 
             log.info("Uploaded image to S3 for problemId: {}, imageType: {}", problemId, imageType);
+        }
+    }
+
+    @Transactional
+    public void addImageDataUrls(Long problemId, Long userId, AddProblemImageUrlsRequest request) {
+        Problem problem = findProblemEntity(problemId, userId);
+        for (AddProblemImageUrlsRequest.ImageUrlItem item : request.imageDataList()) {
+            fileUploadService.validateS3Url(item.imageUrl());
+            ProblemImageType imageType = ProblemImageType.valueOf(item.problemImageType());
+            ProblemImageData imageData = ProblemImageData.from(
+                    new ProblemImageDataRegisterDto(problemId, item.imageUrl(), imageType));
+            imageData.updateProblem(problem);
+            problemImageDataRepository.save(imageData);
+            if (imageType == ProblemImageType.SOLVE_IMAGE) {
+                missionLogService.registerProblemPracticeMission(userId, problemId);
+            }
         }
     }
 

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/controller/ProblemSolveController.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/controller/ProblemSolveController.java
@@ -5,9 +5,11 @@ import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveRegisterDto;
 import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveResponseDto;
 import com.aisip.OnO.backend.problemsolve.dto.ProblemSolveUpdateDto;
 import com.aisip.OnO.backend.problemsolve.service.ProblemSolveService;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -92,14 +94,14 @@ public class ProblemSolveController {
     @PostMapping("/{problemSolveId}/image-urls")
     public CommonResponse<Void> addProblemSolveImageUrls(
             @PathVariable("problemSolveId") Long problemSolveId,
-            @RequestBody ImageUrlsRequest request) {
+            @Validated @RequestBody ImageUrlsRequest request) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         problemSolveService.addImageUrls(problemSolveId, userId, request.imageUrls());
 
         return CommonResponse.success(null);
     }
 
-    public record ImageUrlsRequest(List<String> imageUrls) {}
+    public record ImageUrlsRequest(@NotNull List<String> imageUrls) {}
 
     // 복습 기록 수정
     @PatchMapping("")

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/controller/ProblemSolveController.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/controller/ProblemSolveController.java
@@ -88,6 +88,19 @@ public class ProblemSolveController {
         return CommonResponse.success("복습 기록 이미지 업로드가 완료되었습니다.");
     }
 
+    // 복습 기록 이미지 URL 추가 (Presigned URL 방식)
+    @PostMapping("/{problemSolveId}/image-urls")
+    public CommonResponse<Void> addProblemSolveImageUrls(
+            @PathVariable("problemSolveId") Long problemSolveId,
+            @RequestBody ImageUrlsRequest request) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        problemSolveService.addImageUrls(problemSolveId, userId, request.imageUrls());
+
+        return CommonResponse.success(null);
+    }
+
+    public record ImageUrlsRequest(List<String> imageUrls) {}
+
     // 복습 기록 수정
     @PatchMapping("")
     public CommonResponse<String> updateProblemSolve(@RequestBody ProblemSolveUpdateDto updateDto) {

--- a/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
+++ b/src/main/java/com/aisip/OnO/backend/problemsolve/service/ProblemSolveService.java
@@ -181,6 +181,24 @@ public class ProblemSolveService {
     }
 
     @Transactional
+    public void addImageUrls(Long problemSolveId, Long userId, List<String> imageUrls) {
+        ProblemSolve problemSolve = problemSolveRepository.findById(problemSolveId)
+                .orElseThrow(() -> new ApplicationException(ProblemSolveErrorCase.PROBLEM_SOLVE_NOT_FOUND));
+        if (!Objects.equals(problemSolve.getUserId(), userId)) {
+            throw new ApplicationException(ProblemSolveErrorCase.PROBLEM_SOLVE_USER_UNMATCHED);
+        }
+        int existingCount = problemSolve.getImages() == null ? 0 : problemSolve.getImages().size();
+        List<ProblemSolveImageData> imageDataList = IntStream.range(0, imageUrls.size())
+                .mapToObj(i -> {
+                    fileUploadService.validateS3Url(imageUrls.get(i));
+                    return ProblemSolveImageData.create(imageUrls.get(i), existingCount + i);
+                })
+                .collect(Collectors.toList());
+        imageDataList.forEach(problemSolve::addImage);
+        problemSolveImageDataRepository.saveAll(imageDataList);
+    }
+
+    @Transactional
     public void updateProblemSolve(ProblemSolveUpdateDto dto, Long userId) {
         ProblemSolve problemSolve = problemSolveRepository.findById(dto.problemSolveId())
                 .orElseThrow(() -> new ApplicationException(ProblemSolveErrorCase.PROBLEM_SOLVE_NOT_FOUND));

--- a/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/controller/StudyRoomController.java
@@ -99,6 +99,12 @@ public class StudyRoomController {
         return CommonResponse.success(studyRoomService.updateThumbnail(roomId, currentUserId(), thumbnail));
     }
 
+    @PatchMapping(value = "/{roomId}/thumbnail-url", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public CommonResponse<StudyRoomThumbnailUpdateResponse> updateThumbnailByUrl(@PathVariable("roomId") Long roomId,
+                                                                                 @RequestBody ThumbnailUrlUpdateRequest request) {
+        return CommonResponse.success(studyRoomService.updateThumbnailByUrl(roomId, currentUserId(), request.thumbnailUrl()));
+    }
+
     private Long currentUserId() {
         return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -82,7 +82,7 @@ public final class StudyRoomDtos {
                                     Integer groupCurrent) {
     }
 
-    public record ChallengeMemberProgressResponse(Long userId, String name, int current, boolean cleared) {
+    public record ChallengeMemberProgressResponse(Long userId, String name, String profileImageUrl, int current, boolean cleared) {
     }
 
     public record SharedProblemResponse(Long sharedProblemId, Long sharedByUserId, String sharedByName,
@@ -105,8 +105,8 @@ public final class StudyRoomDtos {
     }
 
     public record WeeklyReportResponse(Long reportId, LocalDate weekStart, LocalDate weekEnd,
-                                       String topMemberName, Integer topMemberProblemCount,
-                                       String longestStreakName, Integer longestStreakDays,
+                                       String topMemberName, String topMemberProfileImageUrl, Integer topMemberProblemCount,
+                                       String longestStreakName, String longestStreakProfileImageUrl, Integer longestStreakDays,
                                        Integer totalProblems, Integer challengesCompleted,
                                        String cheerMessage, boolean isRead) {
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -36,9 +36,13 @@ public final class StudyRoomDtos {
     public record SharedProblemCommentRequest(String content) {
     }
 
+    public record StudyRoomMemberSummary(Long userId, String profileImageUrl, boolean practicedToday) {
+    }
+
     public record StudyRoomListResponse(Long roomId, String name, Long hostUserId, int memberCount,
                                         String thumbnailUrl, boolean hasUnreadReport,
-                                        int todayPracticeMemberCount, int todayPracticeCount) {
+                                        int todayPracticeMemberCount, int todayPracticeCount,
+                                        List<StudyRoomMemberSummary> members) {
     }
 
     public record StudyRoomDetailResponse(Long roomId, String name, Long hostUserId, String thumbnailUrl,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/dto/StudyRoomDtos.java
@@ -113,4 +113,7 @@ public final class StudyRoomDtos {
 
     public record WeeklyReportReadResponse(Long reportId, boolean isRead) {
     }
+
+    public record ThumbnailUrlUpdateRequest(String thumbnailUrl) {
+    }
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomChallenge.java
@@ -55,6 +55,9 @@ public class StudyRoomChallenge extends BaseEntity {
     @Column(nullable = false, length = 20)
     private StudyRoomChallengeStatus status;
 
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
     public static StudyRoomChallenge create(StudyRoom room, String title, StudyRoomChallengeType type,
                                             StudyRoomChallengeMetric metric, StudyRoomChallengePeriod period,
                                             Integer periodDays, Integer targetValue,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomWeeklyReport.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/entity/StudyRoomWeeklyReport.java
@@ -41,6 +41,12 @@ public class StudyRoomWeeklyReport extends BaseEntity {
     @Column(name = "longest_streak_days", nullable = false)
     private Integer longestStreakDays;
 
+    @Column(name = "top_member_profile_image_url", length = 512)
+    private String topMemberProfileImageUrl;
+
+    @Column(name = "longest_streak_profile_image_url", length = 512)
+    private String longestStreakProfileImageUrl;
+
     @Column(name = "total_problems", nullable = false)
     private Integer totalProblems;
 
@@ -51,16 +57,20 @@ public class StudyRoomWeeklyReport extends BaseEntity {
     private String cheerMessage;
 
     public static StudyRoomWeeklyReport create(StudyRoom room, LocalDate weekStart, LocalDate weekEnd,
-                                               String topMemberName, int topMemberProblemCount,
-                                               String longestStreakName, int longestStreakDays,
+                                               String topMemberName, String topMemberProfileImageUrl,
+                                               int topMemberProblemCount,
+                                               String longestStreakName, String longestStreakProfileImageUrl,
+                                               int longestStreakDays,
                                                int totalProblems, int challengesCompleted, String cheerMessage) {
         return StudyRoomWeeklyReport.builder()
                 .room(room)
                 .weekStart(weekStart)
                 .weekEnd(weekEnd)
                 .topMemberName(topMemberName)
+                .topMemberProfileImageUrl(topMemberProfileImageUrl)
                 .topMemberProblemCount(topMemberProblemCount)
                 .longestStreakName(longestStreakName)
+                .longestStreakProfileImageUrl(longestStreakProfileImageUrl)
                 .longestStreakDays(longestStreakDays)
                 .totalProblems(totalProblems)
                 .challengesCompleted(challengesCompleted)

--- a/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomChallengeRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/repository/StudyRoomChallengeRepository.java
@@ -3,6 +3,7 @@ package com.aisip.OnO.backend.studyroom.repository;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomChallenge;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -38,4 +39,15 @@ public interface StudyRoomChallengeRepository extends JpaRepository<StudyRoomCha
                                                           @Param("status") StudyRoomChallengeStatus status,
                                                           @Param("start") LocalDateTime start,
                                                           @Param("end") LocalDateTime end);
+
+    /**
+     * IN_PROGRESS 상태인 챌린지를 원자적으로 targetStatus로 전이.
+     * 동시 호출 시 단 하나의 스레드만 1을 반환 — FCM 중복 발송 방지에 사용.
+     */
+    @Modifying
+    @Query("update StudyRoomChallenge c set c.status = :targetStatus, c.completedAt = :now " +
+            "where c.id = :id and c.status = 'IN_PROGRESS'")
+    int tryTransitionFromInProgress(@Param("id") Long id,
+                                    @Param("targetStatus") StudyRoomChallengeStatus targetStatus,
+                                    @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -119,9 +119,15 @@ public class StudyRoomChallengeService {
                 : null;
         StudyRoomChallengeStatus status = effectiveStatus(challenge, memberProgress, groupCurrent);
         if (persistStatus && challenge.getStatus() != status) {
-            challenge.updateStatus(status);
             if (status == StudyRoomChallengeStatus.COMPLETED) {
-                notifyChallengeCompleted(challenge, members);
+                // 원자적 UPDATE WHERE status = 'IN_PROGRESS' — 단 하나의 스레드만 1을 반환해 FCM 중복 발송 방지
+                int updated = challengeRepository.tryTransitionFromInProgress(challenge.getId(), status, LocalDateTime.now());
+                if (updated > 0) {
+                    challenge.updateStatus(status);
+                    notifyChallengeCompleted(challenge, members);
+                }
+            } else {
+                challenge.updateStatus(status);
             }
         }
         return new ChallengeResponse(

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -124,7 +126,15 @@ public class StudyRoomChallengeService {
                 int updated = challengeRepository.tryTransitionFromInProgress(challenge.getId(), status, LocalDateTime.now());
                 if (updated > 0) {
                     challenge.updateStatus(status);
-                    notifyChallengeCompleted(challenge, members);
+                    // 트랜잭션 커밋 후 FCM 발송 — 롤백 시 중복 발송 방지
+                    final StudyRoomChallenge committedChallenge = challenge;
+                    final List<StudyRoomMember> committedMembers = members;
+                    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            notifyChallengeCompleted(committedChallenge, committedMembers);
+                        }
+                    });
                 }
             } else {
                 challenge.updateStatus(status);
@@ -254,12 +264,76 @@ public class StudyRoomChallengeService {
         }
 
         Map<Long, List<StudyRoomMember>> membersByRoom = new HashMap<>();
+        Map<StatsKey, CachedStats> statsCache = new HashMap<>();
         for (StudyRoomChallenge challenge : inProgressChallenges) {
             Long roomId = challenge.getRoom().getId();
             membersByRoom.computeIfAbsent(roomId, id -> memberRepository.findAllWithUserByRoomId(id));
-            toResponse(challenge, membersByRoom.get(roomId), true);
+            evaluateCompletionAndNotify(challenge, membersByRoom.get(roomId), statsCache);
         }
     }
+
+    private void evaluateCompletionAndNotify(
+            StudyRoomChallenge challenge,
+            List<StudyRoomMember> members,
+            Map<StatsKey, CachedStats> statsCache) {
+        List<Long> userIds = members.stream().map(m -> m.getUser().getId()).toList();
+        AggregationRange range = resolveAggregationRange(challenge, LocalDateTime.now());
+        LocalDate streakBaseDate = min(LocalDate.now(), challenge.getEndAt().toLocalDate());
+        boolean needsAttendance = isAttendanceMetric(challenge.getMetric());
+
+        StatsKey key = new StatsKey(userIds, streakBaseDate, challenge.getStartAt().toLocalDate(), range.start(), range.end());
+        CachedStats cached = statsCache.computeIfAbsent(key, k -> {
+            Map<Long, Integer> streaks = statsService.currentStreaks(k.userIds(), k.streakBase(), k.challengeStart());
+            Map<Long, StudyRoomStats> stats = statsService.getStats(k.userIds(), k.rangeStart(), k.rangeEnd(), streaks);
+            Map<Long, Integer> attendance = statsService.attendanceDayCounts(k.userIds(), k.rangeStart(), k.rangeEnd());
+            return new CachedStats(streaks, stats, attendance);
+        });
+
+        final CachedStats finalCached = cached;
+        List<ChallengeMemberProgressResponse> memberProgress = challenge.getType() == StudyRoomChallengeType.GROUP
+                ? List.of()
+                : members.stream()
+                .map(member -> {
+                    int current = metricValue(challenge.getMetric(),
+                            finalCached.stats().get(member.getUser().getId()),
+                            needsAttendance ? finalCached.attendanceDays().getOrDefault(member.getUser().getId(), 0) : 0);
+                    return new ChallengeMemberProgressResponse(member.getUser().getId(), member.getUser().getName(),
+                            member.getUser().getProfileImageUrl(), current, current >= challenge.getTargetValue());
+                })
+                .toList();
+        Integer groupCurrent = challenge.getType() == StudyRoomChallengeType.GROUP
+                ? userIds.stream()
+                .mapToInt(uid -> metricValue(challenge.getMetric(), finalCached.stats().get(uid),
+                        needsAttendance ? finalCached.attendanceDays().getOrDefault(uid, 0) : 0))
+                .sum()
+                : null;
+        StudyRoomChallengeStatus status = effectiveStatus(challenge, memberProgress, groupCurrent);
+
+        if (challenge.getStatus() != status) {
+            if (status == StudyRoomChallengeStatus.COMPLETED) {
+                int updated = challengeRepository.tryTransitionFromInProgress(challenge.getId(), status, LocalDateTime.now());
+                if (updated > 0) {
+                    challenge.updateStatus(status);
+                    final StudyRoomChallenge committedChallenge = challenge;
+                    final List<StudyRoomMember> committedMembers = members;
+                    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            notifyChallengeCompleted(committedChallenge, committedMembers);
+                        }
+                    });
+                }
+            } else {
+                challenge.updateStatus(status);
+            }
+        }
+    }
+
+    private record StatsKey(List<Long> userIds, LocalDate streakBase, LocalDate challengeStart,
+                            LocalDateTime rangeStart, LocalDateTime rangeEnd) {}
+
+    private record CachedStats(Map<Long, Integer> streaks, Map<Long, StudyRoomStats> stats,
+                               Map<Long, Integer> attendanceDays) {}
 
     private void notifyChallengeCompleted(StudyRoomChallenge challenge, List<StudyRoomMember> members) {
         NotificationRequestDto dto = new NotificationRequestDto(null,

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -18,9 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.springframework.transaction.annotation.Propagation;
 
 @Slf4j
 @Service
@@ -222,6 +224,34 @@ public class StudyRoomChallengeService {
                 || request.period() != null && request.periodDays() != null
                 || request.periodDays() != null && request.periodDays() < 1) {
             throw new ApplicationException(StudyRoomErrorCase.INVALID_STUDY_ROOM_REQUEST);
+        }
+    }
+
+    /**
+     * 사용자의 학습 활동 이후 해당 사용자가 속한 룸들의 IN_PROGRESS 챌린지 완료 여부를 즉시 확인합니다.
+     * REQUIRES_NEW로 독립 트랜잭션 실행 — 실패해도 피드 생성 트랜잭션에 영향 없음.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void checkAndNotifyChallengeCompletionForUser(Long userId) {
+        List<StudyRoomMember> memberships = memberRepository.findAllWithRoomByUserId(userId);
+        if (memberships.isEmpty()) {
+            return;
+        }
+
+        List<Long> roomIds = memberships.stream()
+                .map(m -> m.getRoom().getId())
+                .toList();
+        List<StudyRoomChallenge> inProgressChallenges =
+                challengeRepository.findAllByRoomIdsAndStatus(roomIds, StudyRoomChallengeStatus.IN_PROGRESS);
+        if (inProgressChallenges.isEmpty()) {
+            return;
+        }
+
+        Map<Long, List<StudyRoomMember>> membersByRoom = new HashMap<>();
+        for (StudyRoomChallenge challenge : inProgressChallenges) {
+            Long roomId = challenge.getRoom().getId();
+            membersByRoom.computeIfAbsent(roomId, id -> memberRepository.findAllWithUserByRoomId(id));
+            toResponse(challenge, membersByRoom.get(roomId), true);
         }
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomChallengeService.java
@@ -108,7 +108,7 @@ public class StudyRoomChallengeService {
                     int current = metricValue(challenge.getMetric(), stats.get(member.getUser().getId()),
                             attendanceDays.getOrDefault(member.getUser().getId(), 0));
                     return new ChallengeMemberProgressResponse(member.getUser().getId(), member.getUser().getName(),
-                            current, current >= challenge.getTargetValue());
+                            member.getUser().getProfileImageUrl(), current, current >= challenge.getTargetValue());
                 })
                 .toList();
         Integer groupCurrent = challenge.getType() == StudyRoomChallengeType.GROUP

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomFeedService.java
@@ -47,6 +47,7 @@ public class StudyRoomFeedService {
     private final ObjectMapper objectMapper;
     private final StudyRoomReactionService reactionService;
     private final CustomEmojiValidator customEmojiValidator;
+    private final StudyRoomChallengeService challengeService;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<FeedItemResponse> getFeed(Long roomId, Long userId, Long cursor, int size) {
@@ -88,6 +89,11 @@ public class StudyRoomFeedService {
             createFeedsForUserRooms(event.userId(), event.eventType(), event.metadata());
         } catch (Exception e) {
             log.error("Failed to create study room feed. userId: {}, eventType: {}", event.userId(), event.eventType(), e);
+        }
+        try {
+            challengeService.checkAndNotifyChallengeCompletionForUser(event.userId());
+        } catch (Exception e) {
+            log.error("Failed to check challenge completion. userId: {}, eventType: {}", event.userId(), event.eventType(), e);
         }
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomMapper.java
@@ -3,13 +3,13 @@ package com.aisip.OnO.backend.studyroom.service;
 import com.aisip.OnO.backend.mission.entity.UserMissionStatus;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
-import com.aisip.OnO.backend.studyroom.dto.StudyRoomTodayPracticeSummary;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
 import com.aisip.OnO.backend.studyroom.repository.StudyRoomWeeklyReportReadRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -19,18 +19,33 @@ public class StudyRoomMapper {
 
     private final StudyRoomWeeklyReportReadRepository reportReadRepository;
 
-    public StudyRoomListResponse toListResponse(StudyRoomMember member, int memberCount,
-                                                StudyRoomTodayPracticeSummary todayPracticeSummary) {
+    public StudyRoomListResponse toListResponse(StudyRoomMember member, List<StudyRoomMember> roomMembers,
+                                                Map<Long, Integer> todayPracticeCountByUserId) {
         StudyRoom room = member.getRoom();
+        int todayPracticeMemberCount = 0;
+        int todayPracticeCount = 0;
+        List<StudyRoomMemberSummary> memberSummaries = new ArrayList<>(roomMembers.size());
+        for (StudyRoomMember m : roomMembers) {
+            int count = todayPracticeCountByUserId.getOrDefault(m.getUser().getId(), 0);
+            boolean practicedToday = count > 0;
+            if (practicedToday) todayPracticeMemberCount++;
+            todayPracticeCount += count;
+            memberSummaries.add(new StudyRoomMemberSummary(
+                    m.getUser().getId(),
+                    m.getUser().getProfileImageUrl(),
+                    practicedToday
+            ));
+        }
         return new StudyRoomListResponse(
                 room.getId(),
                 room.getName(),
                 room.getHostUserId(),
-                memberCount,
+                roomMembers.size(),
                 room.getThumbnailUrl(),
                 reportReadRepository.existsUnreadReport(room.getId(), member.getUser().getId()),
-                todayPracticeSummary.todayPracticeMemberCount(),
-                todayPracticeSummary.todayPracticeCount()
+                todayPracticeMemberCount,
+                todayPracticeCount,
+                memberSummaries
         );
     }
 

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -3,7 +3,6 @@ package com.aisip.OnO.backend.studyroom.service;
 import com.aisip.OnO.backend.common.exception.ApplicationException;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomDtos.*;
 import com.aisip.OnO.backend.studyroom.dto.StudyRoomStats;
-import com.aisip.OnO.backend.studyroom.dto.StudyRoomTodayPracticeSummary;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoom;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomMember;
 import com.aisip.OnO.backend.studyroom.entity.StudyRoomMemberRole;
@@ -52,14 +51,16 @@ public class StudyRoomService {
         if (roomIds.isEmpty()) {
             return List.of();
         }
-        Map<Long, Integer> memberCounts = memberRepository.countMembersByRoomIds(roomIds).stream()
-                .collect(java.util.stream.Collectors.toMap(row -> (Long) row[0], row -> Math.toIntExact((Long) row[1])));
-        Map<Long, StudyRoomTodayPracticeSummary> todayPracticeSummaries = statsService.getTodayPracticeSummariesByRoomIds(roomIds);
+        List<StudyRoomMember> allRoomMembers = memberRepository.findAllWithRoomAndUserByRoomIds(roomIds);
+        Map<Long, List<StudyRoomMember>> membersByRoomId = allRoomMembers.stream()
+                .collect(java.util.stream.Collectors.groupingBy(m -> m.getRoom().getId()));
+        List<Long> allUserIds = allRoomMembers.stream().map(m -> m.getUser().getId()).distinct().toList();
+        Map<Long, Integer> todayPracticeCountByUserId = statsService.getTodayPracticeCounts(allUserIds);
         return memberships.stream()
                 .map(member -> mapper.toListResponse(
                         member,
-                        memberCounts.getOrDefault(member.getRoom().getId(), 0),
-                        todayPracticeSummaries.getOrDefault(member.getRoom().getId(), StudyRoomTodayPracticeSummary.empty())
+                        membersByRoomId.getOrDefault(member.getRoom().getId(), List.of()),
+                        todayPracticeCountByUserId
                 ))
                 .toList();
     }

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomService.java
@@ -200,6 +200,17 @@ public class StudyRoomService {
         return new StudyRoomThumbnailUpdateResponse(thumbnailUrl);
     }
 
+    @Transactional
+    public StudyRoomThumbnailUpdateResponse updateThumbnailByUrl(Long roomId, Long userId, String thumbnailUrl) {
+        accessService.validateHost(roomId, userId);
+        fileUploadService.validateS3Url(thumbnailUrl);
+        StudyRoom room = accessService.getRoomOrThrow(roomId);
+        String previousThumbnailUrl = room.getThumbnailUrl();
+        room.updateThumbnailUrl(thumbnailUrl);
+        deleteThumbnailAsync(previousThumbnailUrl, roomId);
+        return new StudyRoomThumbnailUpdateResponse(thumbnailUrl);
+    }
+
     StudyRoomDetailResponse buildDetail(StudyRoom room) {
         List<StudyRoomMember> members = memberRepository.findAllWithUserByRoomId(room.getId());
         List<Long> userIds = members.stream().map(member -> member.getUser().getId()).toList();

--- a/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomWeeklyReportService.java
+++ b/src/main/java/com/aisip/OnO/backend/studyroom/service/StudyRoomWeeklyReportService.java
@@ -134,8 +134,10 @@ public class StudyRoomWeeklyReportService {
                 weekStart,
                 weekEnd,
                 topProblemMember == null ? null : topProblemMember.getUser().getName(),
+                topProblemMember == null ? null : topProblemMember.getUser().getProfileImageUrl(),
                 topProblems,
                 topStreakMember == null ? null : topStreakMember.getUser().getName(),
+                topStreakMember == null ? null : topStreakMember.getUser().getProfileImageUrl(),
                 longestStreak,
                 totalProblems,
                 challengesCompleted,
@@ -211,8 +213,8 @@ public class StudyRoomWeeklyReportService {
 
     private WeeklyReportResponse toResponse(StudyRoomWeeklyReport report, boolean read) {
         return new WeeklyReportResponse(report.getId(), report.getWeekStart(), report.getWeekEnd(),
-                report.getTopMemberName(), report.getTopMemberProblemCount(),
-                report.getLongestStreakName(), report.getLongestStreakDays(),
+                report.getTopMemberName(), report.getTopMemberProfileImageUrl(), report.getTopMemberProblemCount(),
+                report.getLongestStreakName(), report.getLongestStreakProfileImageUrl(), report.getLongestStreakDays(),
                 report.getTotalProblems(), report.getChallengesCompleted(),
                 report.getCheerMessage(), read);
     }

--- a/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
+++ b/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
@@ -55,6 +55,12 @@ public class UserController {
         return CommonResponse.success(userService.updateProfileImage(userId, profileImage));
     }
 
+    @PatchMapping(value = "/me/profile-image-url", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public CommonResponse<UserResponseDto> updateProfileImageByUrl(@RequestBody ProfileImageUrlRequest request) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return CommonResponse.success(userService.updateProfileImageByUrl(userId, request.profileImageUrl()));
+    }
+
     @DeleteMapping("/me/profile-image")
     public CommonResponse<UserResponseDto> deleteProfileImage() {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -67,4 +73,6 @@ public class UserController {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         userService.deleteUserById(userId);
     }
+
+    public record ProfileImageUrlRequest(String profileImageUrl) {}
 }

--- a/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
+++ b/src/main/java/com/aisip/OnO/backend/user/controller/UserController.java
@@ -25,9 +25,7 @@ public class UserController {
     public CommonResponse<UserResponseDto> getUserInfo() {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         missionLogService.registerLoginMission(userId);
-        userService.touchLastActiveAt(userId);
-
-        return CommonResponse.success(userService.findUser(userId));
+        return CommonResponse.success(userService.touchAndFindUser(userId));
     }
 
     // ✅ 사용자 정보 수정

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -145,6 +145,13 @@ public class UserService {
     }
 
     @Transactional
+    public UserResponseDto touchAndFindUser(Long userId) {
+        User user = findUserEntity(userId);
+        user.touchLastActiveAt();
+        return UserResponseDto.from(user);
+    }
+
+    @Transactional
     public void updateNotificationSettings(Long userId, boolean notificationEnabled) {
         findUserEntity(userId).updateNotificationEnabled(notificationEnabled);
     }

--- a/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
+++ b/src/main/java/com/aisip/OnO/backend/user/service/UserService.java
@@ -172,6 +172,16 @@ public class UserService {
     }
 
     @Transactional
+    public UserResponseDto updateProfileImageByUrl(Long userId, String imageUrl) {
+        fileUploadService.validateS3Url(imageUrl);
+        User user = findUserEntity(userId);
+        String previousProfileImageUrl = user.getProfileImageUrl();
+        user.updateProfileImageUrl(imageUrl);
+        deleteImageAsync(previousProfileImageUrl, userId);
+        return UserResponseDto.from(user);
+    }
+
+    @Transactional
     public UserResponseDto deleteProfileImage(Long userId) {
         User user = findUserEntity(userId);
         String previousProfileImageUrl = user.getProfileImageUrl();

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/controller/FileUploadController.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/controller/FileUploadController.java
@@ -1,5 +1,6 @@
 package com.aisip.OnO.backend.util.fileupload.controller;
 
+import com.aisip.OnO.backend.common.ratelimit.RateLimit;
 import com.aisip.OnO.backend.common.response.CommonResponse;
 import com.aisip.OnO.backend.util.fileupload.dto.PresignedUrlResponse;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
@@ -42,6 +43,7 @@ public class FileUploadController {
     // 앱이 S3에 직접 업로드할 수 있는 Presigned URL 발급
     // count: 발급할 URL 수 (최대 20)
     // contentType: 업로드할 이미지 MIME 타입 (예: image/jpeg)
+    @RateLimit(key = "presigned_url", limitPerDay = 200)
     @GetMapping("/presigned-urls")
     public CommonResponse<List<PresignedUrlResponse>> getPresignedUrls(
             @RequestParam(defaultValue = "1") int count,

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/controller/FileUploadController.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/controller/FileUploadController.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.util.fileupload.controller;
 
 import com.aisip.OnO.backend.common.response.CommonResponse;
+import com.aisip.OnO.backend.util.fileupload.dto.PresignedUrlResponse;
 import com.aisip.OnO.backend.util.fileupload.service.FileUploadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,18 @@ public class FileUploadController {
                 .toList();
 
         return CommonResponse.success(imageUrls);
+    }
+
+    // 앱이 S3에 직접 업로드할 수 있는 Presigned URL 발급
+    // count: 발급할 URL 수 (최대 20)
+    // contentType: 업로드할 이미지 MIME 타입 (예: image/jpeg)
+    @GetMapping("/presigned-urls")
+    public CommonResponse<List<PresignedUrlResponse>> getPresignedUrls(
+            @RequestParam(defaultValue = "1") int count,
+            @RequestParam(defaultValue = "image/jpeg") String contentType
+    ) {
+        int safeCount = Math.min(count, 20);
+        return CommonResponse.success(fileUploadService.generatePresignedUrls(contentType, safeCount));
     }
 
     @DeleteMapping("/image")

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/dto/PresignedUrlResponse.java
@@ -1,0 +1,6 @@
+package com.aisip.OnO.backend.util.fileupload.dto;
+
+public record PresignedUrlResponse(
+        String presignedUrl,
+        String fileUrl
+) {}

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
@@ -7,14 +7,20 @@ import com.aisip.OnO.backend.problem.repository.ProblemImageDataRepository;
 import com.aisip.OnO.backend.problemsolve.entity.ProblemSolveImageData;
 import com.aisip.OnO.backend.problemsolve.exception.ProblemSolveErrorCase;
 import com.aisip.OnO.backend.problemsolve.repository.ProblemSolveImageDataRepository;
+import com.aisip.OnO.backend.util.fileupload.dto.PresignedUrlResponse;
 import com.aisip.OnO.backend.util.fileupload.exception.FileUploadErrorCase;
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
+import java.util.Date;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -58,6 +64,22 @@ public class FileUploadService {
         recordExternalCall("s3", "upload", "success", sample);
         log.info("S3 upload completed - fileSize: {}, contentType: {}", file.getSize(), file.getContentType());
         return fileUrl;
+    }
+
+    public List<PresignedUrlResponse> generatePresignedUrls(String contentType, int count) {
+        Date expiration = new Date(System.currentTimeMillis() + 10 * 60 * 1000L); // 10분
+
+        return IntStream.range(0, count)
+                .mapToObj(i -> {
+                    String fileName = createFileNameForPresigned(contentType);
+                    GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, fileName)
+                            .withMethod(HttpMethod.PUT)
+                            .withContentType(contentType)
+                            .withExpiration(expiration);
+                    String presignedUrl = amazonS3Client.generatePresignedUrl(request).toString();
+                    return new PresignedUrlResponse(presignedUrl, getFileUrl(fileName));
+                })
+                .toList();
     }
 
     public void deleteImageFileFromS3(String imageUrl) {
@@ -108,13 +130,22 @@ public class FileUploadService {
 
     private String createFileName(MultipartFile file) {
         String originalFilename = file.getOriginalFilename();
-        String extension = originalFilename.substring(originalFilename.lastIndexOf(".")); // 확장자 추출
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
 
-        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd")); // 날짜 기반 폴더
-        String randomFileName = UUID.randomUUID().toString(); // 랜덤 UUID
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+        return "image/" + datePath + "/" + UUID.randomUUID() + extension;
+    }
 
-        // 예: image/YYYY/MM/DD/랜덤값.png
-        return "image/" + datePath + "/" + randomFileName + extension;
+    private String createFileNameForPresigned(String contentType) {
+        String extension = switch (contentType) {
+            case "image/png" -> ".png";
+            case "image/gif" -> ".gif";
+            case "image/webp" -> ".webp";
+            case "image/heic", "image/heif" -> ".heic";
+            default -> ".jpg"; // image/jpeg, image/jpg, application/octet-stream 등
+        };
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+        return "image/" + datePath + "/" + UUID.randomUUID() + extension;
     }
 
 

--- a/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/fileupload/service/FileUploadService.java
@@ -66,6 +66,15 @@ public class FileUploadService {
         return fileUrl;
     }
 
+    public void validateS3Url(String url) {
+        if (url == null || url.isBlank()) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+        if (!url.startsWith("https://" + bucket + ".s3.")) {
+            throw new ApplicationException(FileUploadErrorCase.INVALID_IMAGE_FILE);
+        }
+    }
+
     public List<PresignedUrlResponse> generatePresignedUrls(String contentType, int count) {
         Date expiration = new Date(System.currentTimeMillis() + 10 * 60 * 1000L); // 10분
 

--- a/src/main/java/com/aisip/OnO/backend/util/webhook/DiscordWebhookNotificationService.java
+++ b/src/main/java/com/aisip/OnO/backend/util/webhook/DiscordWebhookNotificationService.java
@@ -1,13 +1,9 @@
 package com.aisip.OnO.backend.util.webhook;
 
+import com.aisip.OnO.backend.config.rabbitmq.producer.DiscordWebhookProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -20,12 +16,9 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 public class DiscordWebhookNotificationService {
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final DiscordWebhookProducer discordWebhookProducer;
     private final Map<String, Instant> lastSentAtByDedupKey = new ConcurrentHashMap<>();
     private static final Duration ERROR_NOTIFICATION_DEDUP_WINDOW = Duration.ofMinutes(5);
-
-    @Value("${discord.webhook-url}")
-    private String webhookUrl;
 
     /**
      * 에러 발생 시 Discord로 알림 전송
@@ -51,7 +44,7 @@ public class DiscordWebhookNotificationService {
                 )
         );
 
-        sendToDiscord(new DiscordWebhookPayload(null, List.of(embed)), dedupKey);
+        publishToQueue(new DiscordWebhookPayload(null, List.of(embed)), dedupKey);
     }
 
     /**
@@ -67,7 +60,7 @@ public class DiscordWebhookNotificationService {
                 List.of()
         );
 
-        sendToDiscord(new DiscordWebhookPayload(null, List.of(embed)));
+        publishToQueue(new DiscordWebhookPayload(null, List.of(embed)));
     }
 
     /**
@@ -89,33 +82,21 @@ public class DiscordWebhookNotificationService {
                 fields
         );
 
-        sendToDiscord(new DiscordWebhookPayload(null, List.of(embed)), dedupKey);
+        publishToQueue(new DiscordWebhookPayload(null, List.of(embed)), dedupKey);
     }
 
     /**
-     * Discord Webhook으로 메시지 전송 (내부 메서드)
+     * RabbitMQ를 통해 Discord Webhook 메시지를 비동기 전송합니다.
      */
-    private void sendToDiscord(DiscordWebhookPayload payload) {
-        sendToDiscord(payload, null);
+    private void publishToQueue(DiscordWebhookPayload payload, String dedupKey) {
+        discordWebhookProducer.send(payload, dedupKey);
+        if (dedupKey != null) {
+            lastSentAtByDedupKey.put(dedupKey, Instant.now());
+        }
     }
 
-    private void sendToDiscord(DiscordWebhookPayload payload, String dedupKey) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        try {
-            restTemplate.postForEntity(
-                    webhookUrl,
-                    new HttpEntity<>(payload, headers),
-                    String.class
-            );
-            if (dedupKey != null) {
-                lastSentAtByDedupKey.put(dedupKey, Instant.now());
-            }
-            log.info("Discord webhook 전송 완료: {}", payload.embeds().get(0).title());
-        } catch (Exception e) {
-            log.error("Discord webhook 전송 실패: {}", e.getMessage(), e);
-        }
+    private void publishToQueue(DiscordWebhookPayload payload) {
+        publishToQueue(payload, null);
     }
 
     private boolean shouldSuppress(String dedupKey) {

--- a/src/main/resources/db/migration/V15__add_challenge_completed_at.sql
+++ b/src/main/resources/db/migration/V15__add_challenge_completed_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE study_room_challenge
+    ADD COLUMN completed_at DATETIME NULL COMMENT '챌린지 완료 시각 (최초 완료 시 1회만 기록)';

--- a/src/main/resources/db/migration/V16__add_weekly_report_profile_image_urls.sql
+++ b/src/main/resources/db/migration/V16__add_weekly_report_profile_image_urls.sql
@@ -1,0 +1,3 @@
+ALTER TABLE study_room_weekly_report
+    ADD COLUMN top_member_profile_image_url VARCHAR(512) NULL,
+    ADD COLUMN longest_streak_profile_image_url VARCHAR(512) NULL;

--- a/src/main/resources/db/migration/V17__add_refresh_token_index.sql
+++ b/src/main/resources/db/migration/V17__add_refresh_token_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE refresh_token
+    ADD INDEX idx_refresh_token_token (refresh_token(255));

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -283,7 +283,7 @@
       display: flex;
       align-items: flex-end;
       justify-content: center;
-      gap: 12px;
+      gap: 24px;
     }
     .phone-duo .phone-img { max-width: 188px; }
     .phone-duo .phone-img:last-child {
@@ -367,6 +367,41 @@
       font-size: .83rem; color: var(--t3);
     }
 
+    /* ── STUDY ROOM CARDS ── */
+    .study-cards {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      max-width: 380px;
+    }
+    .study-card {
+      display: flex;
+      align-items: flex-start;
+      gap: 16px;
+      background: var(--bg2);
+      border-radius: 18px;
+      padding: 20px 22px;
+    }
+    .study-card-icon {
+      font-size: 1.75rem;
+      flex-shrink: 0;
+      line-height: 1;
+    }
+    .study-card strong {
+      display: block;
+      font-size: .94rem;
+      font-weight: 700;
+      color: var(--t1);
+      margin-bottom: 4px;
+    }
+    .study-card p {
+      font-size: .84rem;
+      color: var(--t2);
+      line-height: 1.55;
+      word-break: keep-all;
+      margin: 0;
+    }
+
     /* ── RESPONSIVE ── */
     @media (max-width: 860px) {
       .feat-inner {
@@ -378,7 +413,9 @@
       .feat-copy .band-p { max-width: none; }
       .feat-img-wrap .phone-img { max-width: 240px; }
       .phone-duo .phone-img { max-width: 155px; }
+      .phone-duo { gap: 16px; }
       .stat-row { justify-content: center; }
+      .study-cards { max-width: none; }
 
       .achieve-inner {
         grid-template-columns: 1fr;
@@ -620,6 +657,52 @@
       <div class="phone-duo">
         <img src="/images/ScreenShot/UserLevel.png" alt="학습 레벨" class="phone-img" loading="lazy">
         <img src="/images/ScreenShot/LearningCalendar2.png" alt="학습 달력" class="phone-img" loading="lazy">
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ── FEATURE 7 : 스터디룸 ── -->
+<div style="background:var(--bg)">
+  <div class="feat-inner">
+    <div class="feat-copy rv">
+      <span class="band-tag">스터디룸</span>
+      <h3 class="band-h2">함께 공부하면<br>더 잘 됩니다</h3>
+      <p class="band-p">
+        친구들과 스터디룸을 만들고, 챌린지와 피드로 서로의 학습을 응원하세요.
+        혼자보다 훨씬 멀리 갈 수 있습니다.
+      </p>
+    </div>
+    <div class="feat-img-wrap rv d1">
+      <div class="study-cards">
+        <div class="study-card">
+          <span class="study-card-icon">👥</span>
+          <div>
+            <strong>스터디룸 개설</strong>
+            <p>초대 코드로 친구를 불러 함께 공부하는 공간을 만드세요.</p>
+          </div>
+        </div>
+        <div class="study-card">
+          <span class="study-card-icon">🏆</span>
+          <div>
+            <strong>챌린지 설정</strong>
+            <p>문제 등록 수, 복습 횟수 등 목표를 정하고 함께 달성해요.</p>
+          </div>
+        </div>
+        <div class="study-card">
+          <span class="study-card-icon">📰</span>
+          <div>
+            <strong>학습 피드</strong>
+            <p>멤버들의 오답노트·복습 활동을 실시간으로 확인하고 응원해요.</p>
+          </div>
+        </div>
+        <div class="study-card">
+          <span class="study-card-icon">📊</span>
+          <div>
+            <strong>주간 리포트</strong>
+            <p>팀원들의 주간 학습 성과를 한눈에 비교할 수 있어요.</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/java/com/aisip/OnO/backend/folder/integration/FolderApiIntegrationTest.java
+++ b/src/test/java/com/aisip/OnO/backend/folder/integration/FolderApiIntegrationTest.java
@@ -158,8 +158,10 @@ public class FolderApiIntegrationTest {
                 .andExpect(jsonPath("$.data.subFolderList.length()").value(folder.getSubFolderList().size()))
                 .andExpect(jsonPath("$.data.subFolderList[0].folderId").value(folder.getSubFolderList().get(0).getId()))
                 .andExpect(jsonPath("$.data.subFolderList[0].folderName").value(folder.getSubFolderList().get(0).getName()))
+                .andExpect(jsonPath("$.data.subFolderList[0].problemCount").value(folder.getSubFolderList().get(0).getProblemList().size()))
                 .andExpect(jsonPath("$.data.subFolderList[1].folderId").value(folder.getSubFolderList().get(1).getId()))
                 .andExpect(jsonPath("$.data.subFolderList[1].folderName").value(folder.getSubFolderList().get(1).getName()))
+                .andExpect(jsonPath("$.data.subFolderList[1].problemCount").value(folder.getSubFolderList().get(1).getProblemList().size()))
                 .andExpect(jsonPath("$.data.problemIdList.length()").value(folder.getProblemList().size()))
                 .andExpect(jsonPath("$.data.problemIdList[0]").value(folder.getProblemList().get(0).getId()))
                 .andReturn();
@@ -181,11 +183,14 @@ public class FolderApiIntegrationTest {
                 .andExpect(jsonPath("$.data.folderId").value(folder.getId()))
                 .andExpect(jsonPath("$.data.folderName").value(folder.getName()))
                 .andExpect(jsonPath("$.data.parentFolder.folderId").value(folder.getParentFolder().getId()))
+                .andExpect(jsonPath("$.data.parentFolder.problemCount").value(folder.getParentFolder().getProblemList().size()))
                 .andExpect(jsonPath("$.data.subFolderList.length()").value(folder.getSubFolderList().size()))
                 .andExpect(jsonPath("$.data.subFolderList[0].folderId").value(folder.getSubFolderList().get(0).getId()))
                 .andExpect(jsonPath("$.data.subFolderList[0].folderName").value(folder.getSubFolderList().get(0).getName()))
+                .andExpect(jsonPath("$.data.subFolderList[0].problemCount").value(folder.getSubFolderList().get(0).getProblemList().size()))
                 .andExpect(jsonPath("$.data.subFolderList[1].folderId").value(folder.getSubFolderList().get(1).getId()))
                 .andExpect(jsonPath("$.data.subFolderList[1].folderName").value(folder.getSubFolderList().get(1).getName()))
+                .andExpect(jsonPath("$.data.subFolderList[1].problemCount").value(folder.getSubFolderList().get(1).getProblemList().size()))
                 .andExpect(jsonPath("$.data.problemIdList.length()").value(folder.getProblemList().size()))
                 .andExpect(jsonPath("$.data.problemIdList[0]").value(folder.getProblemList().get(0).getId()))
                 .andReturn();
@@ -207,6 +212,7 @@ public class FolderApiIntegrationTest {
                 .andExpect(jsonPath("$.data.folderId").value(folder.getId()))
                 .andExpect(jsonPath("$.data.folderName").value(folder.getName()))
                 .andExpect(jsonPath("$.data.parentFolder.folderId").value(folder.getParentFolder().getId()))
+                .andExpect(jsonPath("$.data.parentFolder.problemCount").value(folder.getParentFolder().getProblemList().size()))
                 .andExpect(jsonPath("$.data.subFolderList.length()").value(0))
                 .andExpect(jsonPath("$.data.problemIdList.length()").value(folder.getProblemList().size()))
                 .andExpect(jsonPath("$.data.problemIdList[0]").value(folder.getProblemList().get(0).getId()))
@@ -233,8 +239,10 @@ public class FolderApiIntegrationTest {
                 .andExpect(jsonPath("$.data.problemIdList.length()").value(rootFolder.getProblemList().size()))
                 .andExpect(jsonPath("$.data.subFolderList[0].folderId").value(rootFolder.getSubFolderList().get(0).getId()))
                 .andExpect(jsonPath("$.data.subFolderList[0].folderName").value(rootFolder.getSubFolderList().get(0).getName()))
+                .andExpect(jsonPath("$.data.subFolderList[0].problemCount").value(rootFolder.getSubFolderList().get(0).getProblemList().size()))
                 .andExpect(jsonPath("$.data.subFolderList[1].folderId").value(rootFolder.getSubFolderList().get(1).getId()))
                 .andExpect(jsonPath("$.data.subFolderList[1].folderName").value(rootFolder.getSubFolderList().get(1).getName()))
+                .andExpect(jsonPath("$.data.subFolderList[1].problemCount").value(rootFolder.getSubFolderList().get(1).getProblemList().size()))
                 .andExpect(jsonPath("$.data.problemIdList[0]").value(rootFolder.getProblemList().get(0).getId()))
                 .andReturn();
 
@@ -276,6 +284,7 @@ public class FolderApiIntegrationTest {
             Folder folder = folderList.get(i);
             assertThat(folder.getId().intValue()).isEqualTo( JsonPath.read(content, "$.data[" + i + "].folderId"));
             assertThat(folder.getName()).isEqualTo(JsonPath.read(content, "$.data[" + i + "].folderName"));
+            assertThat(folder.getProblemList().size()).isEqualTo(JsonPath.read(content, "$.data[" + i + "].problemCount"));
         }
 
         System.out.println("==== 응답 결과 ====");
@@ -306,6 +315,10 @@ public class FolderApiIntegrationTest {
             }
             assertThat(folder.getSubFolderList().size()).isEqualTo(JsonPath.read(content, "$.data[" + i + "].subFolderList.length()"));
             assertThat(folder.getProblemList().size()).isEqualTo(JsonPath.read(content, "$.data[" + i + "].problemIdList.length()"));
+            for (int j = 0; j < folder.getSubFolderList().size(); j++) {
+                assertThat(folder.getSubFolderList().get(j).getProblemList().size())
+                        .isEqualTo(JsonPath.read(content, "$.data[" + i + "].subFolderList[" + j + "].problemCount"));
+            }
         }
 
         System.out.println("==== 응답 결과 ====");

--- a/src/test/java/com/aisip/OnO/backend/folder/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/aisip/OnO/backend/folder/repository/FolderRepositoryTest.java
@@ -24,7 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -247,6 +249,24 @@ class FolderRepositoryTest {
             }
         } else{
             assertThat(0L).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("폴더별 문제 수 집계 테스트")
+    void countProblemsByFolderIdsTest() {
+        List<Long> folderIds = folderList.stream()
+                .map(Folder::getId)
+                .toList();
+
+        Map<Long, Long> problemCountsByFolderId = folderRepository.countProblemsByFolderIds(folderIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        for (Folder folder : folderList) {
+            assertThat(problemCountsByFolderId.get(folder.getId())).isEqualTo(2L);
         }
     }
 }

--- a/src/test/java/com/aisip/OnO/backend/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/aisip/OnO/backend/folder/service/FolderServiceTest.java
@@ -157,7 +157,9 @@ class FolderServiceTest {
         assertThat(folderResponseDto.folderName()).isEqualTo(folderList.get(0).getName());
         assertThat(folderResponseDto.parentFolder()).isNull();
         assertThat(folderResponseDto.subFolderList().get(0).folderId()).isEqualTo(folderList.get(1).getId());
+        assertThat(folderResponseDto.subFolderList().get(0).problemCount()).isEqualTo((long) folderList.get(1).getProblemList().size());
         assertThat(folderResponseDto.subFolderList().get(1).folderId()).isEqualTo(folderList.get(2).getId());
+        assertThat(folderResponseDto.subFolderList().get(1).problemCount()).isEqualTo((long) folderList.get(2).getProblemList().size());
         assertThat(folderResponseDto.problemIdList().get(0)).isEqualTo(problemList.get(0).problemId());
         assertThat(folderResponseDto.problemIdList().get(1)).isEqualTo(problemList.get(1).problemId());
     }
@@ -176,8 +178,11 @@ class FolderServiceTest {
         assertThat(folderResponseDto.folderId()).isEqualTo(folderList.get(1).getId());
         assertThat(folderResponseDto.folderName()).isEqualTo(folderList.get(1).getName());
         assertThat(folderResponseDto.parentFolder().folderId()).isEqualTo(parentFolderId);
+        assertThat(folderResponseDto.parentFolder().problemCount()).isEqualTo((long) folderList.get(0).getProblemList().size());
         assertThat(folderResponseDto.subFolderList().get(0).folderId()).isEqualTo(folderList.get(3).getId());
+        assertThat(folderResponseDto.subFolderList().get(0).problemCount()).isEqualTo((long) folderList.get(3).getProblemList().size());
         assertThat(folderResponseDto.subFolderList().get(1).folderId()).isEqualTo(folderList.get(4).getId());
+        assertThat(folderResponseDto.subFolderList().get(1).problemCount()).isEqualTo((long) folderList.get(4).getProblemList().size());
         assertThat(folderResponseDto.problemIdList().get(0)).isEqualTo(problemList.get(2).problemId());
         assertThat(folderResponseDto.problemIdList().get(1)).isEqualTo(problemList.get(3).problemId());
     }
@@ -222,6 +227,7 @@ class FolderServiceTest {
         for (int i = 0; i < folderThumbnailResponseDtoList.size(); i++) {
             assertThat(folderThumbnailResponseDtoList.get(i).folderId()).isEqualTo(folderList.get(i).getId());
             assertThat(folderThumbnailResponseDtoList.get(i).folderName()).isEqualTo(folderList.get(i).getName());
+            assertThat(folderThumbnailResponseDtoList.get(i).problemCount()).isEqualTo((long) folderList.get(i).getProblemList().size());
         }
     }
 


### PR DESCRIPTION
## ✔️ 연관 이슈
- 없음

## 📝 작업 내용
**[Feat] 신규 기능**
- S3 Presigned URL 발급 API 추가
- Presigned URL 방식 이미지 URL 등록 API 3종 추가 (문제, 풀이, 프로필)
- 스터디룸 챌린지 완료 시 즉시 FCM 알림 기능 추가
- 챌린지·주간 리포트 응답에 프로필 이미지 URL 추가
- StudyRoom 목록 응답에 멤버 프로필 이미지와 오늘 연습 여부 추가
- 폴더 썸네일 응답에 problemCount 필드 추가
- Discord Webhook 전송을 RabbitMQ 비동기 방식으로 전환
- 랜딩 페이지 스크린샷 간격 개선 및 스터디룸 섹션 추가

**[Fix] 버그 수정**
- 챌린지 완료 FCM 중복 발송 레이스 컨디션 수정
- ProblemAnalysisService self-invocation 트랜잭션 분리 수정
- ProblemAnalysis DLQ 처리 시 PROCESSING 고착 방지
- AI 분석 Deadlock 위험 완화 — 트랜잭션 분리 및 동시성 감소
- getUserInfo에서 touchLastActiveAt과 findUser 트랜잭션 통합
- Sentry 4xx ApplicationException 노이즈 필터링 BeforeSendCallback 추가
- 검증된 5개 이슈 일괄 수정

**[Chore/Perf]**
- refresh_token 컬럼 인덱스 추가 (V17)
- 오답노트 여러 장 등록 Hibernate JDBC 배치 설정 추가

## 👤 사용자 영향
- S3 Presigned URL 방식으로 이미지 업로드 흐름 변경 (클라이언트 직접 업로드)
- 스터디룸 챌린지 완료 시 실시간 알림 수신
- 폴더·스터디룸·챌린지 API 응답에 추가 필드 제공

## 🔌 API 호환성
- [ ] 요청/응답 DTO 변경 없음
- [x] 기존 Flutter 앱 버전과 호환 확인
- [x] breaking change 있음
  - 신규 API 3종 추가 (Presigned URL 발급·등록)
  - StudyRoom, Folder, Challenge 응답 DTO에 필드 추가 (additive — 하위 호환)

## 🗄️ DB migration
- [ ] 없음
- [x] 있음: migration 파일과 기존 데이터 호환성 확인
  - V15: challenge_completed_at 컬럼 추가
  - V16: weekly_report 프로필 이미지 URL 컬럼 추가
  - V17: refresh_token 컬럼 인덱스 추가

## 🔐 인증/권한
- [ ] 영향 없음
- [x] 사용자별 데이터 소유권 검증 확인
  - Presigned URL API는 인증된 사용자 대상, userId 기준 소유권 검증
- [ ] 관리자/특수 권한 영향 확인

## ✅ 검증 결과
- FolderApiIntegrationTest, FolderRepositoryTest, FolderServiceTest 테스트 코드 추가·수정 확인

## 🚀 배포 리스크
- S3 Presigned URL 방식 전환으로 Flutter 앱 업데이트 필요 (이미지 업로드 흐름 변경)
- FCM 즉시 알림 추가로 챌린지 완료 시 실발송 발생 — 테스트 환경에서 사전 확인 권장
- V15~V17 마이그레이션 자동 실행 — 스키마 변경이므로 dev 환경 선 검증 필요

## ↩️ 롤백/대응 방법
- 마이그레이션 V15~V17은 컬럼 추가·인덱스 추가만이라 롤백 시 해당 컬럼/인덱스 제거 필요
- FCM 관련 문제 시 StudyRoomChallengeService의 알림 로직 비활성화 가능